### PR TITLE
Feature/add parameter support and Update prerequisite check

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github:  jorgeasaurus # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Submit a new bug
+title: '🪲 Bug report'
+labels: bug
+assignees:  jorgeasaurus
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+### Expected Behavior
+<!--- Tell us what should happen -->
+
+### Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+### Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+### Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+1.
+2.
+3.
+4.
+
+### Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Include as many relevant details about the environment where the bug was discovered. -->
+* Operating System and version as reported by `$PSVersionTable.OS`:
+* PowerShell versions as reported by `$PSVersionTable.PSEdition`:
+
+
+### Detailed Description
+<!--- Provide a detailed description of the issue you are facing -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '🙏 Feature request'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+### Description
+<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+<!--- A clear and concise description of what you want to happen. -->
+
+### Describe any alternatives you've considered
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+<!--- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Pull Request
+
+## Type of Change
+
+- [ ] 📖 Documentation
+- [ ] 🪲 Fix
+- [ ] 🩹 Patch
+- [ ] ⚠️ Security Fix
+- [ ] 🚀 Feature
+- [ ] 💥 Breaking Change
+
+## Issue
+<!-- If this PR resolves an issue, enter the issue number here. -->
+
+## Description
+<!-- Please include a clear description of what your pull request does. Remember to only include one change (or group of tightly related changes) per pull request to make review and testing easier. -->
+
+## Checklist
+
+- [ ] 🕵️ I have reviewed my code for errors and tested it.
+- [ ] 🚩 My pull request does not contain multiple types of changes.
+- [ ] 📄 By submitting this pull request, I confirm that my contribution is made under the terms of the project's associated license.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in IntuneHydrationKit, please follow the process:
+
+1. Go to the **Security** tab in the GitHub repository and click **"Report a vulnerability"** to create a private security advisory.
+   - This ensures all communication remains private from the start.
+2. A repo owner will be notified and can discuss the vulnerability privately with you.
+3. We will evaluate the vulnerability and, if necessary, release a fix or mitigating steps to address it. We will contact you to let you know the outcome, and will credit you in the report.
+
+   Please **do not disclose the vulnerability publicly** until a fix is released!
+
+4. Once we have either a) published a fix, or b) declined to address the vulnerability for
+whatever reason, you are free to publicly disclose it.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Hydration-Summary.md
 *.code-workspace
 Test-ModuleConfigurations.ps1
 settingsDelete.json
+Test-ModuleConfigurationsParams.ps1

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion = '0.1.4'
+    ModuleVersion = '0.1.8'
 
     # ID used to uniquely identify this module
     GUID = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -85,6 +85,15 @@
 
             # Release notes for this module
             ReleaseNotes = @'
+## v0.1.8 - Parameter-Based Invocation
+- Added full parameter support for command-line invocation
+- Settings file is now optional when using parameters
+- Parameters override settings file values when both provided
+- New parameters for all configuration options (tenant, auth, imports, reporting)
+- Added -All switch to enable all import types
+- Backwards compatible with existing settings.json workflow
+- Added Windows Driver Update license pre-check (avoids 403 errors)
+
 ## v0.1.0 - Initial Release
 - OpenIntuneBaseline integration (auto-downloads latest policies)
 - Compliance policy templates (Windows, macOS, iOS, Android, Linux)

--- a/IntuneHydrationKit.psm1
+++ b/IntuneHydrationKit.psm1
@@ -29,6 +29,10 @@ $script:LogPath = $null
 $script:VerboseLogging = $false
 $script:CurrentLogFile = $null
 
+# Module-level state for Graph environment
+$script:GraphEnvironment = $null
+$script:GraphEndpoint = $null
+
 # Import private functions
 $privatePath = Join-Path -Path $script:ModuleRoot -ChildPath 'Private'
 if (Test-Path -Path $privatePath) {

--- a/Invoke-IntuneHydration.ps1
+++ b/Invoke-IntuneHydration.ps1
@@ -7,20 +7,201 @@
 .DESCRIPTION
     Executes the complete hydration workflow including authentication,
     pre-flight checks, and import of all baseline configurations.
+
+    Two mutually exclusive invocation modes:
+    1. Settings File Mode: Use -SettingsPath to load all configuration from a JSON file
+    2. Parameter Mode: Use -Interactive or -ClientId/-ClientSecret with other parameters
+
+    These modes cannot be mixed - choose one or the other.
 .PARAMETER SettingsPath
-    Path to the settings JSON file
+    Path to the settings JSON file. Use this for settings file-based invocation.
+    Cannot be combined with -Interactive, -ClientId, or -ClientSecret.
+.PARAMETER TenantId
+    Azure AD tenant ID (GUID). Required for parameter-based invocation.
+.PARAMETER TenantName
+    Tenant name for display purposes (e.g., contoso.onmicrosoft.com)
+.PARAMETER Interactive
+    Use interactive authentication (browser-based login).
+    Cannot be combined with -SettingsPath.
+.PARAMETER ClientId
+    Application (client) ID for service principal authentication.
+    Cannot be combined with -SettingsPath.
+.PARAMETER ClientSecret
+    Client secret for service principal authentication (SecureString).
+    Cannot be combined with -SettingsPath.
+.PARAMETER Environment
+    Azure cloud environment. Valid values: Global, USGov, USGovDoD, Germany, China
+.PARAMETER Create
+    Enable creation of configurations
+.PARAMETER Delete
+    Enable deletion of kit-created configurations
+.PARAMETER Force
+    Skip confirmation prompt when running in delete mode (available for both settings-file and parameter modes)
+.PARAMETER VerboseOutput
+    Enable verbose logging output
+.PARAMETER OpenIntuneBaseline
+    Process OpenIntuneBaseline policies
+.PARAMETER ComplianceTemplates
+    Process compliance policy templates
+.PARAMETER AppProtection
+    Process app protection policies
+.PARAMETER NotificationTemplates
+    Process notification templates
+.PARAMETER EnrollmentProfiles
+    Process enrollment profiles (Autopilot, ESP)
+.PARAMETER DynamicGroups
+    Process dynamic groups
+.PARAMETER DeviceFilters
+    Process device filters
+.PARAMETER ConditionalAccess
+    Process Conditional Access starter pack policies
+.PARAMETER All
+    Enable all targets
+.PARAMETER BaselineRepoUrl
+    GitHub repository URL for OpenIntuneBaseline
+.PARAMETER BaselineBranch
+    Git branch to use for OpenIntuneBaseline
+.PARAMETER BaselineDownloadPath
+    Local path for OpenIntuneBaseline download
+.PARAMETER ReportOutputPath
+    Output directory for reports
+.PARAMETER ReportFormats
+    Report formats to generate (markdown, json)
 .PARAMETER WhatIf
     Run in dry-run mode without making changes to Intune
 .EXAMPLE
     ./Invoke-IntuneHydration.ps1 -SettingsPath ./settings.json
+
+    Run using settings from a JSON file.
 .EXAMPLE
     ./Invoke-IntuneHydration.ps1 -SettingsPath ./settings.json -WhatIf
+
+    Dry-run using settings file.
+.EXAMPLE
+    ./Invoke-IntuneHydration.ps1 -TenantId "00000000-0000-0000-0000-000000000000" -Interactive -Create -All
+
+    Run with all imports enabled using interactive authentication.
+.EXAMPLE
+    ./Invoke-IntuneHydration.ps1 -TenantId "00000000-0000-0000-0000-000000000000" -ClientId "client-id" -ClientSecret $secret -Create -ComplianceTemplates -DynamicGroups
+
+    Run with service principal authentication and specific imports enabled.
+.EXAMPLE
+./Invoke-IntuneHydration.ps1 -TenantId "00000000-0000-0000-0000-000000000000" -Interactive -Delete -All -WhatIf
+
+    Dry-run delete mode with interactive authentication.
 #>
-[CmdletBinding(SupportsShouldProcess)]
+[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'SettingsFile')]
 param(
-    [Parameter(Mandatory = $true)]
+    # Settings file parameter - exclusive mode
+    [Parameter(ParameterSetName = 'SettingsFile', Mandatory = $true, Position = 0)]
     [ValidateScript({ Test-Path $_ })]
-    [string]$SettingsPath
+    [string]$SettingsPath,
+
+    # Tenant parameters - required for parameter-based modes
+    [Parameter(ParameterSetName = 'Interactive', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'ServicePrincipal', Mandatory = $true)]
+    [ValidatePattern('^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$')]
+    [string]$TenantId,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [string]$TenantName,
+
+    # Authentication parameters - Interactive mode
+    [Parameter(ParameterSetName = 'Interactive', Mandatory = $true)]
+    [switch]$Interactive,
+
+    # Authentication parameters - Service Principal mode
+    [Parameter(ParameterSetName = 'ServicePrincipal', Mandatory = $true)]
+    [string]$ClientId,
+
+    [Parameter(ParameterSetName = 'ServicePrincipal', Mandatory = $true)]
+    [SecureString]$ClientSecret,
+
+    # Environment - available for parameter-based modes only
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [ValidateSet('Global', 'USGov', 'USGovDoD', 'Germany', 'China')]
+    [string]$Environment = 'Global',
+
+    # Options parameters - available for parameter-based modes only
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$Create,
+
+    [Parameter(ParameterSetName = 'SettingsFile')]
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$Delete,
+
+    [Parameter(ParameterSetName = 'SettingsFile')]
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$Force,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$VerboseOutput,
+
+    # Target enable switches - available for parameter-based modes only
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$OpenIntuneBaseline,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$ComplianceTemplates,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$AppProtection,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$NotificationTemplates,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$EnrollmentProfiles,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$DynamicGroups,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$DeviceFilters,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$ConditionalAccess,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [switch]$All,
+
+    # OpenIntuneBaseline parameters - available for parameter-based modes only
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [string]$BaselineRepoUrl = "https://github.com/SkipToTheEndpoint/OpenIntuneBaseline",
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [string]$BaselineBranch = 'main',
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [string]$BaselineDownloadPath,
+
+    # Reporting parameters - available for parameter-based modes only
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [string]$ReportOutputPath,
+
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'ServicePrincipal')]
+    [ValidateSet('markdown', 'json')]
+    [string[]]$ReportFormats
 )
 
 
@@ -34,56 +215,119 @@ $moduleRoot = $PSScriptRoot
 $modulePath = Join-Path -Path $moduleRoot -ChildPath 'IntuneHydrationKit.psd1'
 if (Test-Path -Path $modulePath) {
     Import-Module -Name $modulePath -Force
-}
-else {
+} else {
     throw "Module not found at: $modulePath"
 }
 
 #region Main Execution
 
 try {
-    # Load settings first to apply options
-    $settings = Import-HydrationSettings -Path $SettingsPath
+    # Initialize settings based on parameter set
+    $settings = $null
+
+    if ($PSCmdlet.ParameterSetName -eq 'SettingsFile') {
+        # Settings file mode - load everything from the file
+        $settings = Import-HydrationSettings -Path $SettingsPath
+        Write-Host "Loaded settings from: $SettingsPath" -InformationAction Continue
+        if (-not $settings.options) {
+            $settings['options'] = @{}
+        }
+        # Set force option from parameter, preserving any existing force setting from settings file
+        $settings.options.force = $Force.IsPresent -or ($settings.options.ContainsKey('force') -and $settings.options.force)
+    } else {
+        # Parameter-based mode - build settings from parameters
+        Write-Host "Using parameter-based configuration" -InformationAction Continue
+
+        # Determine which targets are enabled
+        $importsEnabled = @{
+            dynamicGroups         = $All.IsPresent -or $DynamicGroups.IsPresent
+            deviceFilters         = $All.IsPresent -or $DeviceFilters.IsPresent
+            conditionalAccess     = $All.IsPresent -or $ConditionalAccess.IsPresent
+            complianceTemplates   = $All.IsPresent -or $ComplianceTemplates.IsPresent
+            openIntuneBaseline    = $All.IsPresent -or $OpenIntuneBaseline.IsPresent
+            enrollmentProfiles    = $All.IsPresent -or $EnrollmentProfiles.IsPresent
+            appProtection         = $All.IsPresent -or $AppProtection.IsPresent
+            notificationTemplates = $All.IsPresent -or $NotificationTemplates.IsPresent
+        }
+
+        # Validate that at least one target is enabled
+        if (-not ($importsEnabled.Values -contains $true)) {
+            throw "At least one target must be enabled. Use -All or specify a target switch (e.g., -DynamicGroups, -DeviceFilters, etc.)."
+        }
+
+        # Build settings object from parameters
+        $settings = @{
+            tenant             = @{
+                tenantId   = $TenantId
+                tenantName = $TenantName
+            }
+            authentication     = @{
+                mode         = if ($Interactive) { 'interactive' } else { 'clientSecret' }
+                clientId     = $ClientId
+                clientSecret = if ($ClientSecret) { [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($ClientSecret)) } else { $null }
+                environment  = $Environment
+            }
+            options            = @{
+                create  = $Create.IsPresent
+                delete  = $Delete.IsPresent
+                force   = $Force.IsPresent
+                dryRun  = [bool]$WhatIfPreference
+                verbose = $VerboseOutput.IsPresent
+            }
+            imports            = $importsEnabled
+            openIntuneBaseline = @{
+                repoUrl      = $BaselineRepoUrl
+                branch       = $BaselineBranch
+                downloadPath = if ($BaselineDownloadPath) { $BaselineDownloadPath } else { './OpenIntuneBaseline' }
+            }
+            reporting          = @{
+                outputPath = if ($ReportOutputPath) { $ReportOutputPath } else { 'Reports' }
+                formats    = if ($ReportFormats) { $ReportFormats } else { @('markdown') }
+            }
+        }
+    }
 
     # Display current settings
-    Write-Host "Loaded settings from: $SettingsPath" -InformationAction Continue
     Write-Host "Target Tenant: $($settings.tenant.tenantId)" -InformationAction Continue
+    if ($settings.tenant.tenantName) {
+        Write-Host "Tenant Name: $($settings.tenant.tenantName)" -InformationAction Continue
+    }
     Write-Host "Authentication Mode: $($settings.authentication.mode)" -InformationAction Continue
     Write-Host "Options:" -InformationAction Continue
     Write-Host ($settings.options | Out-String) -InformationAction Continue
     Write-Host "Imports Enabled:" -InformationAction Continue
     Write-Host ($settings.imports | Out-String) -InformationAction Continue
 
-    # Apply options from settings file (command-line switches take precedence)
-    # Initialize variables with defaults (these will be set below if $settings.options exists)
-    $createEnabled = $false
-    $RemoveExisting = $false
+    # Apply options from settings
+    $createEnabled = $settings.options.create -eq $true
+    $deleteEnabled = $settings.options.delete -eq $true
+    $forceDelete = $settings.options.force -eq $true
+    $RemoveExisting = $deleteEnabled
 
-    if ($settings.options) {
-        # Validate options - create and delete are mutually exclusive
-        $createEnabled = $settings.options.create -eq $true
-        $deleteEnabled = $settings.options.delete -eq $true
+    # Validate options - create and delete are mutually exclusive
+    if ($createEnabled -and $deleteEnabled) {
+        throw "Only one of 'create' or 'delete' options can be true. Current settings: create=$createEnabled, delete=$deleteEnabled"
+    }
 
-        if ($createEnabled -and $deleteEnabled) {
-            throw "Only one of 'create' or 'delete' options can be true. Current settings: create=$createEnabled, delete=$deleteEnabled"
+    if (-not $createEnabled -and -not $deleteEnabled) {
+        throw "At least one of 'create' or 'delete' options must be true. Current settings: create=$createEnabled, delete=$deleteEnabled"
+    }
+
+    if ($deleteEnabled -and -not $forceDelete -and -not $WhatIfPreference) {
+        if (-not $PSCmdlet.ShouldContinue("Proceed with delete operations?", "Delete mode will remove Intune configurations created by the hydration kit.")) {
+            Write-Warning "Delete operation cancelled by user confirmation."
+            return
         }
+    }
 
-        if (-not $createEnabled -and -not $deleteEnabled) {
-            throw "At least one of 'create' or 'delete' options must be true. Current settings: create=$createEnabled, delete=$deleteEnabled"
-        }
+    # dryRun from settings enables WhatIf if not already set via command line
+    if ($settings.options.dryRun -eq $true -and -not $WhatIfPreference) {
+        $script:WhatIfPreference = $true
+    }
 
-        # dryRun from settings enables WhatIf if not already set via command line
-        if ($settings.options.dryRun -eq $true -and -not $WhatIfPreference) {
-            $script:WhatIfPreference = $true
-        }
-
-        # Set operation mode based on options
-        $RemoveExisting = $settings.options.delete -eq $true
-
-        # verbose from settings enables verbose output
-        if ($settings.options.verbose -eq $true) {
-            $script:VerbosePreference = 'Continue'
-        }
+    # verbose from settings enables verbose output
+    if ($settings.options.verbose -eq $true) {
+        $script:VerbosePreference = 'Continue'
     }
 
     # Initialize logging (after applying verbose setting)
@@ -100,8 +344,7 @@ try {
     if ($RemoveExisting) {
         if (-not $createEnabled) {
             Write-HydrationLog -Message "DELETE-ONLY mode - configurations will be deleted without recreation" -Level Warning
-        }
-        else {
+        } else {
             Write-HydrationLog -Message "Remove existing enabled - matching configurations will be deleted before import" -Level Warning
         }
     }
@@ -124,8 +367,7 @@ try {
     if ($settings.authentication.mode -eq 'clientSecret') {
         $authParams['ClientId'] = $settings.authentication.clientId
         $authParams['ClientSecret'] = $settings.authentication.clientSecret | ConvertTo-SecureString -AsPlainText -Force
-    }
-    else {
+    } else {
         $authParams['Interactive'] = $true
     }
 
@@ -164,24 +406,20 @@ try {
                                 Invoke-MgGraphRequest -Method DELETE -Uri "beta/groups/$($group.id)" -ErrorAction Stop
                                 Write-HydrationLog -Message "  Deleted: $($group.displayName)" -Level Info
                                 $allResults += New-HydrationResult -Type 'DynamicGroup' -Name $group.displayName -Action 'Deleted' -Status 'Success'
-                            }
-                            catch {
+                            } catch {
                                 Write-HydrationLog -Message "Failed to delete group '$($group.displayName)': $_" -Level Warning
                                 $allResults += New-HydrationResult -Type 'DynamicGroup' -Name $group.displayName -Action 'Failed' -Status $_.Exception.Message
                             }
-                        }
-                        else {
+                        } else {
                             $allResults += New-HydrationResult -Type 'DynamicGroup' -Name $group.displayName -Action 'WouldDelete' -Status 'DryRun'
                         }
                     }
                     $listUri = $existingGroups.'@odata.nextLink'
                 } while ($listUri)
-            }
-            catch {
+            } catch {
                 Write-HydrationLog -Message "Failed to list dynamic groups: $_" -Level Warning
             }
-        }
-        else {
+        } else {
             # Normal create mode
             $groupsTemplatePath = Join-Path -Path $moduleRoot -ChildPath 'Templates/DynamicGroups'
 
@@ -206,8 +444,7 @@ try {
                         Write-HydrationLog -Message "  $($groupResult.Action): $($groupDef.displayName)" -Level Info
                     }
                 }
-            }
-            else {
+            } else {
                 Write-HydrationLog -Message "Dynamic Groups template directory not found" -Level Warning
             }
         }
@@ -380,12 +617,12 @@ try {
     if ('json' -in $settings.reporting.formats) {
         $jsonReportPath = Join-Path -Path $reportsPath -ChildPath "Hydration-Summary.json"
         @{
-            Timestamp = $timestamp
-            Tenant = $settings.tenant.tenantId
+            Timestamp   = $timestamp
+            Tenant      = $settings.tenant.tenantId
             Environment = $settings.authentication.environment
-            Mode = if ($WhatIfPreference) { 'DryRun' } else { 'Live' }
-            Summary = $summary
-            Results = $allResults
+            Mode        = if ($WhatIfPreference) { 'DryRun' } else { 'Live' }
+            Summary     = $summary
+            Results     = $allResults
         } | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonReportPath -Encoding utf8
         Write-HydrationLog -Message "JSON report written to: $jsonReportPath" -Level Info
     }
@@ -397,8 +634,7 @@ try {
     Write-Host "---------------- Summary ----------------" -InformationAction Continue
     if ($WhatIfPreference) {
         Write-Host ("Would Create: {0} | Would Update: {1} | Would Delete: {2} | Skipped: {3} | Failed: {4}" -f $summary.WouldCreate, $summary.WouldUpdate, $summary.WouldDelete, $summary.Skipped, $summary.Failed) -InformationAction Continue
-    }
-    else {
+    } else {
         Write-Host ("Created: {0} | Updated: {1} | Deleted: {2} | Skipped: {3} | Failed: {4}" -f $summary.Created, $summary.Updated, $summary.Deleted, $summary.Skipped, $summary.Failed) -InformationAction Continue
     }
     Write-Host "Reports: $reportPath" -InformationAction Continue
@@ -411,18 +647,15 @@ try {
     if ($summary.Failed -gt 0) {
         Write-HydrationLog -Message "Completed with $($summary.Failed) failures" -Level Warning
         exit 1
-    }
-    else {
+    } else {
         if ($WhatIfPreference) {
             Write-HydrationLog -Message "Dry-run completed: $($summary.WouldCreate) would create, $($summary.WouldUpdate) would update, $($summary.WouldDelete) would delete, $($summary.Skipped) skipped" -Level Info
-        }
-        else {
+        } else {
             Write-HydrationLog -Message "Completed successfully: $($summary.Created) created, $($summary.Updated) updated, $($summary.Skipped) skipped" -Level Info
         }
         exit 0
     }
-}
-catch {
+} catch {
     Write-HydrationLog -Message "Fatal error: $_" -Level Error
     Write-Error $_
     exit 1

--- a/Private/Test-WindowsDriverUpdateLicense.ps1
+++ b/Private/Test-WindowsDriverUpdateLicense.ps1
@@ -1,0 +1,91 @@
+function Test-WindowsDriverUpdateLicense {
+    <#
+    .SYNOPSIS
+        Checks if the tenant has a license that supports Windows Driver Update profiles
+    .DESCRIPTION
+        Windows Driver Update profiles require one of the following licenses:
+        - Windows 10/11 Enterprise E3 or E5
+        - Windows 10/11 Education A3 or A5 (Microsoft 365 A3/A5)
+        - Windows Virtual Desktop Access E3 or E5
+        - Microsoft 365 Business Premium
+
+        This function checks the tenant's subscribed SKUs for compatible service plans.
+    .EXAMPLE
+        Test-WindowsDriverUpdateLicense
+        Returns $true if a compatible license is found, $false otherwise
+    .OUTPUTS
+        System.Boolean
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    # Service plan names that enable Windows Driver Update profiles
+    # Reference: https://learn.microsoft.com/en-us/mem/intune/protect/windows-driver-updates-overview
+    $driverUpdateServicePlans = @(
+        # Windows Enterprise E3/E5
+        'WIN10_PRO_ENT_SUB',        # Windows 10/11 Enterprise E3
+        'WIN10_ENT_A3_GOV',         # Windows 10/11 Enterprise E3 (Gov)
+        'WIN10_ENT_A5_GOV',         # Windows 10/11 Enterprise E5 (Gov)
+        'WINE5_GCC_COMPAT',         # Windows E5 GCC
+        # Windows VDA
+        'WIN10_VDA_E3',             # Windows Virtual Desktop Access E3
+        'WIN10_VDA_E5',             # Windows Virtual Desktop Access E5
+        'WINDOWS_STORE',            # Sometimes bundled with VDA
+        # Microsoft 365 E3/E5 (includes Windows Enterprise)
+        'SPE_E3',                   # Microsoft 365 E3
+        'SPE_E5',                   # Microsoft 365 E5
+        'SPE_E3_GOV',               # Microsoft 365 E3 (Gov)
+        'SPE_E5_GOV',               # Microsoft 365 E5 (Gov)
+        'SPE_E3_RPA1',              # Microsoft 365 E3 variant
+        'M365_E3',                  # Microsoft 365 E3 (alternate)
+        'M365_E5',                  # Microsoft 365 E5 (alternate)
+        # Microsoft 365 Education A3/A5
+        'M365EDU_A3_FACULTY',       # Microsoft 365 A3 for Faculty
+        'M365EDU_A3_STUDENT',       # Microsoft 365 A3 for Students
+        'M365EDU_A5_FACULTY',       # Microsoft 365 A5 for Faculty
+        'M365EDU_A5_STUDENT',       # Microsoft 365 A5 for Students
+        'SPE_E3_USGOV_GCCHIGH',     # Microsoft 365 E3 GCC High
+        'SPE_E5_USGOV_GCCHIGH',     # Microsoft 365 E5 GCC High
+        # Microsoft 365 Business Premium
+        'SPB',                      # Microsoft 365 Business Premium
+        'SMB_BUSINESS_PREMIUM',     # Microsoft 365 Business Premium (alternate)
+        'O365_BUSINESS_PREMIUM',    # Microsoft 365 Business Premium (legacy)
+        # Windows 365 Enterprise (includes Windows E3 entitlement)
+        'CPC_E_2C_4GB_64GB',        # Windows 365 Enterprise variants
+        'CPC_E_2C_8GB_128GB',
+        'CPC_E_4C_16GB_128GB',
+        'CPC_E_4C_16GB_256GB',
+        'CPC_E_8C_32GB_128GB',
+        'CPC_E_8C_32GB_256GB',
+        'CPC_E_8C_32GB_512GB',
+        # Intune Suite add-on (may include advanced features)
+        'INTUNE_SUITE'
+    )
+
+    try {
+        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus" -ErrorAction Stop
+
+        foreach ($sku in $subscribedSkus.value) {
+            # Skip disabled SKUs
+            if ($sku.capabilityStatus -ne 'Enabled') {
+                continue
+            }
+
+            foreach ($plan in $sku.servicePlans) {
+                if ($plan.servicePlanName -in $driverUpdateServicePlans -and $plan.provisioningStatus -eq 'Success') {
+                    Write-Verbose "Found Windows Driver Update compatible license: $($plan.servicePlanName) in SKU $($sku.skuPartNumber)"
+                    return $true
+                }
+            }
+        }
+
+        Write-Verbose "No Windows Driver Update compatible license found in tenant"
+        return $false
+    }
+    catch {
+        Write-Warning "Failed to check Windows Driver Update license: $_"
+        # Return $true to allow the attempt (will fail with 403 if truly not licensed)
+        return $true
+    }
+}

--- a/Public/Connect-IntuneHydration.ps1
+++ b/Public/Connect-IntuneHydration.ps1
@@ -54,7 +54,9 @@ function Connect-IntuneHydration {
         "Policy.Read.All",
         "Policy.ReadWrite.ConditionalAccess",
         "Application.Read.All",
-        "Directory.ReadWrite.All"
+        "Directory.ReadWrite.All",
+        "LicenseAssignment.Read.All",
+        "Organization.Read.All"
     )
 
     # Store environment for use by other functions

--- a/Public/Import-HydrationSettings.ps1
+++ b/Public/Import-HydrationSettings.ps1
@@ -2,6 +2,8 @@ function Import-HydrationSettings {
     <#
     .SYNOPSIS
         Imports and validates hydration settings
+    .DESCRIPTION
+        Loads settings from a JSON file.
     .PARAMETER Path
         Path to the settings file
     #>
@@ -16,7 +18,7 @@ function Import-HydrationSettings {
         $content = Get-Content -Path $Path -Raw -Encoding utf8
         $settings = $content | ConvertFrom-Json -AsHashtable
 
-        # Validate required fields
+        # Validate required fields only when loading from file
         if (-not $settings.tenant.tenantId) {
             throw "Missing required field: tenant.tenantId"
         }

--- a/settings.example.json
+++ b/settings.example.json
@@ -14,6 +14,7 @@
         "dryRun": false,
         "create": true,
         "delete": false,
+        "force": false,
         "verbose": true
     },
     "imports": {


### PR DESCRIPTION
# Summary

## Highlights

- New parameter-based invocation (in addition to settings files) using PowerShell-native `-WhatIf`, target switches (`-DynamicGroups`, `-DeviceFilters`, etc.), and `-All` to enable every target at once.
- Settings file invocation remains supported; parameters/settings both honor `-WhatIf`, and delete mode now prompts unless `-Force` is supplied.
- Windows Driver Update license pre-check added with clearer prerequisite error surfacing; Graph scopes expanded (`LicenseAssignment.Read.All`, `Organization.Read.All`).
- Community health files added (PR/issue templates, security policy, funding); README updated for the new switches and preview behavior.

## Notable Behaviors

- Settings file `options.dryRun` still maps to `-WhatIf` but is no longer exposed as a parameter; `force` can be set via settings or `-Force`.
- Settings mode and the new parameter mode are mutually exclusive; parameter mode uses the new target switches like `-DynamicGroups`,`-Create`,`-Delete`,`-All`
