### PR TITLE
v0.6.0: Error handling, Graph API improvements, and 190 new tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-04
+
+### Added
+
+- **Retry-After Header Support**: `Invoke-GraphBatchOperation` now captures `Retry-After` headers from individual 429/503 batch responses and honors the longest delay before retrying, falling back to exponential backoff when the header is absent
+- **Paginated Query Retry Logic**: `Get-GraphPagedResults` now retries on 429/5xx transient errors with Retry-After support and exponential backoff (max 3 retries per page)
+- **`[OutputType()]` Annotations**: Added to 8 private helpers: `Get-FilteredTemplates`, `Get-GraphErrorMessage`, `Get-HydrationTemplates`, `Get-ResultSummary`, `New-HydrationDescription`, `New-HydrationResult`, `Remove-ReadOnlyGraphProperties`, `Test-HydrationKitObject`
+- **Comment-Based Help**: Completed `.DESCRIPTION` and `.EXAMPLE` sections for `Write-HydrationLog`, `Initialize-HydrationLogging`, and `Import-HydrationSettings`
+- **Test Coverage**: Expanded from 458 to 648 tests (+190) with 13 new test files:
+  - 9 private function tests: `Get-GraphErrorMessage`, `Get-HydrationTemplates`, `Get-ObfuscatedTenantId`, `Get-PremiumP2ServicePlans`, `Get-ResultSummary`, `New-HydrationResult`, `Remove-ReadOnlyGraphProperties`, `Test-ConditionalAccessPolicyRequiresP2`, `Test-ConditionalAccessPolicyRequiresPreview`
+  - 4 public function tests: `Import-IntuneBaseline`, `Import-IntuneAppProtectionPolicy`, `Import-IntuneConditionalAccessPolicy`, `Import-IntuneNotificationTemplate`
+  - 429 throttle with Retry-After header test for `Invoke-GraphBatchOperation`
+
+### Changed
+
+- **Error Handling**: Replaced bare `throw` and `Write-Error` with `$PSCmdlet.ThrowTerminatingError()` and `$PSCmdlet.WriteError()` in 9 public functions (`Connect-IntuneHydration`, `Get-OpenIntuneBaseline`, `Import-HydrationSettings`, `Import-IntuneBaseline`, `Import-IntuneConditionalAccessPolicy`, `Import-IntuneEnrollmentProfile`, `Invoke-IntuneHydration`, `New-IntuneDynamicGroup`, `Test-IntunePrerequisites`) — all errors now include structured ErrorRecord objects with error IDs, categories, and target objects
+- **Graph API Performance**: Added `$select` query parameter to 8+ GET requests across `Import-IntuneCompliancePolicy`, `Import-IntuneConditionalAccessPolicy`, `Import-IntuneEnrollmentProfile`, `Test-IntunePrerequisites`, and `Test-WindowsDriverUpdateLicense` to reduce response payload size
+- **Centralized Hydration Marker**: Marker strings (`"Imported by Intune Hydration Kit"` and hyphenated variant) consolidated into `$script:HydrationMarker` and `$script:HydrationMarkerAlt` module-scoped variables in `IntuneHydrationKit.psm1`, used by `Test-HydrationKitObject` and `New-HydrationDescription`
+
 ## [0.5.0] - 2026-03-29
 
 ### Added

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -89,6 +89,19 @@
 
             # Release notes for this module
             ReleaseNotes = @'
+
+Install directly from the PowerShell Gallery:
+
+```powershell
+Install-Module -Name IntuneHydrationKit -Scope CurrentUser
+```
+
+To update to the latest version:
+
+```powershell
+Update-Module -Name IntuneHydrationKit
+```
+
 ## v0.6.0
 
 - **Retry-After Support:** Graph API batch operations and paginated queries now honor `Retry-After` headers on 429/503 responses with exponential backoff fallback

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion     = '0.5.0'
+    ModuleVersion     = '0.6.0'
 
     # ID used to uniquely identify this module
     GUID              = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -89,15 +89,15 @@
 
             # Release notes for this module
             ReleaseNotes = @'
-## v0.5.0
+## v0.6.0
 
-- **[IHD] Prefix:** All imported resources now prefixed with `[IHD] ` for instant identification in Intune portal
-- **Delete Bug Fixes:** Fixed Graph API dictionary deserialization, null response handling, scriptblock scope bugs, and HashSet enumeration issues
-- **Tag-Aware Skips:** Import functions only skip objects with the hydration kit marker, not untagged duplicates
-- **Template-Scoped Deletes:** Delete operations now require both kit tag AND matching template name for safety
-- **Performance:** 61% faster execution (~180s to ~70s) using batch Graph API operations
-- **Bundled Templates:** OpenIntuneBaseline templates now included (no external downloads required)
-- **Batch Operations:** Groups, policies, filters, and apps now use batched API calls (up to 10 per batch)
+- **Retry-After Support:** Graph API batch operations and paginated queries now honor `Retry-After` headers on 429/503 responses with exponential backoff fallback
+- **Error Handling:** Public functions use proper `$PSCmdlet.ThrowTerminatingError()` and `$PSCmdlet.WriteError()` with structured ErrorRecord objects
+- **Graph API Performance:** Added `$select` query parameter to 8+ GET requests to reduce payload size
+- **OutputType Annotations:** Added `[OutputType()]` attributes to 8 private helper functions
+- **Centralized Hydration Marker:** Marker strings consolidated into module-scoped variables for consistency
+- **Test Coverage:** Expanded from 458 to 648 tests with 13 new test files covering private helpers and public import functions
+- **Documentation:** Completed comment-based help for `Write-HydrationLog`, `Initialize-HydrationLogging`, and `Import-HydrationSettings`
 
 '@
         }

--- a/IntuneHydrationKit.psm1
+++ b/IntuneHydrationKit.psm1
@@ -39,6 +39,10 @@ $script:MaxBatchSize = 10  # Graph API batch limit (max 20, using 10 for safety)
 # Prefix prepended to every imported resource's displayName/name for easy identification
 $script:ImportPrefix = '[IHD] '
 
+# Hydration kit marker embedded in descriptions/notes to identify objects created by this kit
+$script:HydrationMarker = 'Imported by Intune Hydration Kit'
+$script:HydrationMarkerAlt = 'Imported by Intune-Hydration-Kit'
+
 # Import private functions
 $privatePath = Join-Path -Path $script:ModuleRoot -ChildPath 'Private'
 if (Test-Path -Path $privatePath) {

--- a/Private/Get-FilteredTemplates.ps1
+++ b/Private/Get-FilteredTemplates.ps1
@@ -22,6 +22,7 @@ function Get-FilteredTemplates {
         The type of resource being loaded (for logging purposes)
     #>
     [CmdletBinding()]
+    [OutputType([System.IO.FileInfo[]])]
     param(
         [string]$Path,
 

--- a/Private/Get-GraphErrorMessage.ps1
+++ b/Private/Get-GraphErrorMessage.ps1
@@ -6,6 +6,7 @@ function Get-GraphErrorMessage {
         Internal helper function for parsing Graph API error details into a clean, readable format
     #>
     [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.ErrorRecord]$ErrorRecord

--- a/Private/Get-GraphPagedResults.ps1
+++ b/Private/Get-GraphPagedResults.ps1
@@ -21,6 +21,7 @@ function Get-GraphPagedResults {
         Get-GraphPagedResults -Uri "beta/groups" -ProcessItems { param($items) $items | ForEach-Object { ... } }
     #>
     [CmdletBinding()]
+    [OutputType([object[]])]
     param(
         [Parameter(Mandatory)]
         [string]$Uri,
@@ -34,6 +35,8 @@ function Get-GraphPagedResults {
 
     $results = [System.Collections.Generic.List[object]]::new()
     $listUri = $Uri
+    $maxRetries = 3
+    $baseRetryDelay = 2
 
     do {
         $params = @{
@@ -44,19 +47,44 @@ function Get-GraphPagedResults {
         if ($Headers) { $params['Headers'] = $Headers }
 
         $response = $null
-        try {
-            $response = Invoke-MgGraphRequest @params
-        } catch {
-            # Invoke-MgGraphRequest deserializes JSON into a Dictionary which throws
-            # on duplicate keys. Fall back to raw HTTP response + ConvertFrom-Json
-            # (returns PSCustomObject where last-key-wins, no error).
-            if ($_.Exception.Message -like '*Item has already been added*' -or
-                ($_.Exception.InnerException -and $_.Exception.InnerException.Message -like '*Item has already been added*')) {
-                Write-Verbose "Dictionary deserialization failed for '$listUri', retrying with raw HTTP response"
-                $httpResponse = Invoke-MgGraphRequest @params -OutputType HttpResponseMessage
-                $jsonContent = $httpResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-                $response = $jsonContent | ConvertFrom-Json
-            } else {
+        $retryCount = 0
+
+        while ($true) {
+            try {
+                $response = Invoke-MgGraphRequest @params
+                break
+            } catch {
+                # Invoke-MgGraphRequest deserializes JSON into a Dictionary which throws
+                # on duplicate keys. Fall back to raw HTTP response + ConvertFrom-Json
+                # (returns PSCustomObject where last-key-wins, no error).
+                if ($_.Exception.Message -like '*Item has already been added*' -or
+                    ($_.Exception.InnerException -and $_.Exception.InnerException.Message -like '*Item has already been added*')) {
+                    Write-Verbose "Dictionary deserialization failed for '$listUri', retrying with raw HTTP response"
+                    $httpResponse = Invoke-MgGraphRequest @params -OutputType HttpResponseMessage
+                    $jsonContent = $httpResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+                    $response = $jsonContent | ConvertFrom-Json
+                    break
+                }
+
+                # Handle transient errors (429 throttling, 5xx server errors) with retry
+                $httpStatus = $null
+                if ($_.Exception.Response.StatusCode) {
+                    $httpStatus = [int]$_.Exception.Response.StatusCode
+                }
+                $isRetryable = $httpStatus -in @(429, 503) -or ($httpStatus -ge 500 -and $httpStatus -lt 600)
+
+                if ($isRetryable -and $retryCount -lt $maxRetries) {
+                    $retryAfter = 0
+                    if ($_.Exception.Response.Headers -and $_.Exception.Response.Headers['Retry-After']) {
+                        [int]::TryParse([string]$_.Exception.Response.Headers['Retry-After'], [ref]$retryAfter) | Out-Null
+                    }
+                    $delay = if ($retryAfter -gt 0) { $retryAfter } else { $baseRetryDelay * [Math]::Pow(2, $retryCount) }
+                    Write-Verbose "Transient error (HTTP $httpStatus) fetching '$listUri' - retrying after ${delay}s (attempt $($retryCount + 1) of $maxRetries)"
+                    Start-Sleep -Seconds $delay
+                    $retryCount++
+                    continue
+                }
+
                 throw
             }
         }

--- a/Private/Get-HydrationTemplates.ps1
+++ b/Private/Get-HydrationTemplates.ps1
@@ -12,6 +12,7 @@ function Get-HydrationTemplates {
         The type of resource being loaded (for logging purposes)
     #>
     [CmdletBinding()]
+    [OutputType([System.IO.FileInfo[]])]
     param(
         [Parameter(Mandatory)]
         [string]$Path,

--- a/Private/Get-ResultSummary.ps1
+++ b/Private/Get-ResultSummary.ps1
@@ -6,6 +6,7 @@ function Get-ResultSummary {
         Internal helper function for aggregating result counts by action type
     #>
     [CmdletBinding()]
+    [OutputType([hashtable])]
     param(
         [Parameter(Mandatory = $false)]
         [array]$Results = @()

--- a/Private/Invoke-GraphBatchOperation.ps1
+++ b/Private/Invoke-GraphBatchOperation.ps1
@@ -71,8 +71,20 @@ function Invoke-GraphBatchOperation {
 
         while ($pendingItems.Count -gt 0 -and $retryCount -le $MaxRetries) {
             if ($retryCount -gt 0) {
-                $delay = $RetryDelaySeconds * [Math]::Pow(2, $retryCount - 1)
-                Write-Verbose "Retrying $($pendingItems.Count) failed $($Operation.ToLower())(s) after ${delay}s delay (attempt $retryCount of $MaxRetries)..."
+                # Honor Retry-After from previous throttled responses; fall back to exponential backoff
+                $maxRetryAfter = 0
+                foreach ($item in $pendingItems) {
+                    if ($item.RetryAfter) {
+                        $parsedRetryAfter = 0
+                        if ([int]::TryParse([string]$item.RetryAfter, [ref]$parsedRetryAfter) -and $parsedRetryAfter -gt $maxRetryAfter) {
+                            $maxRetryAfter = $parsedRetryAfter
+                        }
+                        $item.Remove('RetryAfter')
+                    }
+                }
+                $delay = if ($maxRetryAfter -gt 0) { $maxRetryAfter } else { $RetryDelaySeconds * [Math]::Pow(2, $retryCount - 1) }
+                $delaySource = if ($maxRetryAfter -gt 0) { 'Retry-After header' } else { 'exponential backoff' }
+                Write-Verbose "Retrying $($pendingItems.Count) failed $($Operation.ToLower())(s) after ${delay}s delay ($delaySource, attempt $retryCount of $MaxRetries)..."
                 Start-Sleep -Seconds $delay
             }
 
@@ -228,6 +240,7 @@ function Invoke-GraphBatchOperation {
                         $results += New-HydrationResult @resultParams -Action 'Skipped' -Status 'Already deleted'
                     } elseif (($resp.status -in @(429, 503) -or $resp.status -ge 500) -and $retryCount -lt $MaxRetries) {
                         Write-Verbose "Retryable error ($($resp.status)) for '$($item.Name)' - will retry"
+                        if ($resp.headers -and $resp.headers.'Retry-After') { $item.RetryAfter = $resp.headers.'Retry-After' }
                         $itemsToRetry += $item
                     } else {
                         $errorMessage = if ($resp.body.error.message) { $resp.body.error.message } else { "HTTP $($resp.status)" }
@@ -245,6 +258,7 @@ function Invoke-GraphBatchOperation {
                         $results += New-HydrationResult @resultParams -Action 'Skipped' -Status 'Already exists (race condition)'
                     } elseif (($resp.status -in @(429, 503) -or $resp.status -ge 500) -and $retryCount -lt $MaxRetries) {
                         Write-Verbose "Retryable error ($($resp.status)) for '$($item.Name)' - will retry"
+                        if ($resp.headers -and $resp.headers.'Retry-After') { $item.RetryAfter = $resp.headers.'Retry-After' }
                         $itemsToRetry += $item
                     } else {
                         $errorMessage = if ($resp.body.error.message) { $resp.body.error.message } else { "HTTP $($resp.status)" }

--- a/Private/New-HydrationDescription.ps1
+++ b/Private/New-HydrationDescription.ps1
@@ -22,6 +22,7 @@ function New-HydrationDescription {
         # Returns: "My profile Imported by Intune Hydration Kit"
     #>
     [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter()]
         [string]$ExistingText,
@@ -30,7 +31,7 @@ function New-HydrationDescription {
         [string]$Separator = ' - '
     )
 
-    $tag = 'Imported by Intune Hydration Kit'
+    $tag = if ($script:HydrationMarker) { $script:HydrationMarker } else { 'Imported by Intune Hydration Kit' }
     if (-not [string]::IsNullOrWhiteSpace($ExistingText)) {
         return "$ExistingText$Separator$tag"
     }

--- a/Private/New-HydrationResult.ps1
+++ b/Private/New-HydrationResult.ps1
@@ -6,6 +6,7 @@ function New-HydrationResult {
         Internal helper function for creating consistent result objects across all hydration operations
     #>
     [CmdletBinding()]
+    [OutputType([PSCustomObject])]
     param(
         [Parameter()]
         [string]$Name,

--- a/Private/Test-HydrationKitObject.ps1
+++ b/Private/Test-HydrationKitObject.ps1
@@ -46,11 +46,9 @@ function Test-HydrationKitObject {
         [string]$ObjectName
     )
 
-    # The marker that identifies objects created by this kit
-    $hydrationMarker = "Imported by Intune-Hydration-Kit"
-
-    # Also check for alternate format (space vs hyphen variations)
-    $alternateMarker = "Imported by Intune Hydration Kit"
+    # The marker that identifies objects created by this kit (centralized in psm1)
+    $hydrationMarker = if ($script:HydrationMarkerAlt) { $script:HydrationMarkerAlt } else { "Imported by Intune-Hydration-Kit" }
+    $alternateMarker = if ($script:HydrationMarker) { $script:HydrationMarker } else { "Imported by Intune Hydration Kit" }
 
     $fieldsToCheck = @($Description, $Notes)
     $isHydrationKit = $false

--- a/Private/Test-WindowsDriverUpdateLicense.ps1
+++ b/Private/Test-WindowsDriverUpdateLicense.ps1
@@ -66,7 +66,7 @@ function Test-WindowsDriverUpdateLicense {
     )
 
     try {
-        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus" -ErrorAction Stop
+        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus?`$select=id,skuPartNumber,capabilityStatus,servicePlans" -ErrorAction Stop
 
         foreach ($sku in $subscribedSkus.value) {
             # Skip disabled SKUs

--- a/Public/Connect-IntuneHydration.ps1
+++ b/Public/Connect-IntuneHydration.ps1
@@ -95,7 +95,12 @@ function Connect-IntuneHydration {
 
         Write-Host "Successfully connected to tenant: $(Get-ObfuscatedTenantId -TenantId $TenantId) ($Environment)"
     } catch {
-        Write-Error "Failed to connect to Microsoft Graph: $_"
-        throw
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Failed to connect to Microsoft Graph: $($_.Exception.Message)", $_.Exception),
+            'GraphConnectionFailed',
+            [System.Management.Automation.ErrorCategory]::ConnectionError,
+            $TenantId
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 }

--- a/Public/Get-OpenIntuneBaseline.ps1
+++ b/Public/Get-OpenIntuneBaseline.ps1
@@ -62,7 +62,12 @@ function Get-OpenIntuneBaseline {
 
         return $DestinationPath
     } catch {
-        Write-Error "Failed to download OpenIntuneBaseline: $_"
-        throw
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Failed to download OpenIntuneBaseline: $($_.Exception.Message)", $_.Exception),
+            'BaselineDownloadFailed',
+            [System.Management.Automation.ErrorCategory]::ConnectionError,
+            $null
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 }

--- a/Public/Import-HydrationSettings.ps1
+++ b/Public/Import-HydrationSettings.ps1
@@ -6,6 +6,11 @@ function Import-HydrationSettings {
         Loads settings from a JSON file.
     .PARAMETER Path
         Path to the settings file
+    .EXAMPLE
+        Import-HydrationSettings -Path './settings.json'
+    .EXAMPLE
+        $settings = Import-HydrationSettings -Path './settings.json'
+        $settings.tenant.tenantId  # Access tenant ID from loaded settings
     #>
     [CmdletBinding()]
     param(

--- a/Public/Import-HydrationSettings.ps1
+++ b/Public/Import-HydrationSettings.ps1
@@ -25,13 +25,27 @@ function Import-HydrationSettings {
 
         # Validate required fields only when loading from file
         if (-not $settings.tenant.tenantId) {
-            throw "Missing required field: tenant.tenantId"
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("Missing required field: tenant.tenantId"),
+                'MissingTenantId',
+                [System.Management.Automation.ErrorCategory]::InvalidData,
+                $Path
+            )
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
 
         Write-HydrationLog -Message "Settings loaded from: $Path" -Level Info
         return $settings
+    } catch [System.Management.Automation.PipelineStoppedException] {
+        throw
     } catch {
         Write-HydrationLog -Message "Failed to load settings: $_" -Level Error
-        throw
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Failed to load settings from '$Path': $($_.Exception.Message)", $_.Exception),
+            'SettingsLoadFailed',
+            [System.Management.Automation.ErrorCategory]::ReadError,
+            $Path
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 }

--- a/Public/Import-IntuneBaseline.ps1
+++ b/Public/Import-IntuneBaseline.ps1
@@ -54,7 +54,13 @@ function Import-IntuneBaseline {
     }
 
     if (-not $TenantId) {
-        throw "TenantId is required. Either connect using Connect-IntuneHydration or specify -TenantId parameter."
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("TenantId is required. Either connect using Connect-IntuneHydration or specify -TenantId parameter."),
+            'MissingTenantId',
+            [System.Management.Automation.ErrorCategory]::InvalidArgument,
+            $null
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 
     # Resolve BaselinePath to bundled templates if not provided
@@ -75,13 +81,25 @@ function Import-IntuneBaseline {
                 $moduleRoot = Split-Path -Parent (Split-Path -Parent $scriptPath)
                 $BaselinePath = Join-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'Templates') -ChildPath 'OpenIntuneBaseline'
             } elseif (-not $RemoveExisting) {
-                throw "Cannot determine OpenIntuneBaseline path. Please specify -BaselinePath parameter."
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new("Cannot determine OpenIntuneBaseline path. Please specify -BaselinePath parameter."),
+                    'BaselinePathNotFound',
+                    [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                    $null
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
         }
     }
 
     if (-not $RemoveExisting -and (-not $BaselinePath -or -not (Test-Path -Path $BaselinePath))) {
-        throw "OpenIntuneBaseline templates not found at: $BaselinePath"
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("OpenIntuneBaseline templates not found at: $BaselinePath"),
+            'BaselineTemplatesNotFound',
+            [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+            $BaselinePath
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 
     # OpenIntuneBaseline uses OS-based folder structure:

--- a/Public/Import-IntuneCompliancePolicy.ps1
+++ b/Public/Import-IntuneCompliancePolicy.ps1
@@ -177,7 +177,12 @@ function Import-IntuneCompliancePolicy {
             if ($alreadyExists) {
                 $matchedName = $lookupNames | Where-Object { $existingPolicies.ContainsKey($_) -and $existingPolicies[$_].IsTagged } | Select-Object -First 1
                 $matchedPolicy = $existingPolicies[$matchedName]
-                $verifyUri = "beta/$($matchedPolicy.Endpoint)/$($matchedPolicy.Id)"
+                $verifyEndpoint = if ($matchedPolicy.Endpoint -match '^beta/') {
+                    $matchedPolicy.Endpoint
+                } else {
+                    "beta/$($matchedPolicy.Endpoint)"
+                }
+                $verifyUri = "$verifyEndpoint/$($matchedPolicy.Id)"
                 try {
                     $null = Invoke-MgGraphRequest -Method GET -Uri $verifyUri -ErrorAction Stop
                 } catch {

--- a/Public/Import-IntuneCompliancePolicy.ps1
+++ b/Public/Import-IntuneCompliancePolicy.ps1
@@ -46,12 +46,13 @@ function Import-IntuneCompliancePolicy {
     # Prefetch existing compliance policies (paged) from both classic and linux endpoints
     # Store full policy objects so we can check descriptions later
     $existingPolicies = @{}
+    # Each endpoint has different property names — use endpoint-specific $select
     $endpointsToList = @(
-        "beta/deviceManagement/deviceCompliancePolicies",
-        "beta/deviceManagement/compliancePolicies"
+        @{ Uri = "beta/deviceManagement/deviceCompliancePolicies"; Select = "id,displayName,description" },
+        @{ Uri = "beta/deviceManagement/compliancePolicies"; Select = "id,name,description" }
     )
-    foreach ($listUriStart in $endpointsToList) {
-        $listUri = "$listUriStart`?`$select=id,displayName,name,description"
+    foreach ($ep in $endpointsToList) {
+        $listUri = "$($ep.Uri)`?`$select=$($ep.Select)"
         try {
             do {
                 $existingResponse = Invoke-MgGraphRequest -Method GET -Uri $listUri -ErrorAction Stop
@@ -63,14 +64,14 @@ function Import-IntuneCompliancePolicy {
                             $existingPolicies[$policyName] = @{
                                 Id          = $policy.id
                                 Description = $policy.description
-                                Endpoint    = $listUriStart
+                                Endpoint    = $ep.Uri
                                 IsTagged    = $isTagged
                             }
                         } elseif ($isTagged -and -not $existingPolicies[$policyName].IsTagged) {
                             $existingPolicies[$policyName] = @{
                                 Id          = $policy.id
                                 Description = $policy.description
-                                Endpoint    = $listUriStart
+                                Endpoint    = $ep.Uri
                                 IsTagged    = $true
                             }
                         }

--- a/Public/Import-IntuneCompliancePolicy.ps1
+++ b/Public/Import-IntuneCompliancePolicy.ps1
@@ -80,6 +80,7 @@ function Import-IntuneCompliancePolicy {
                 $listUri = $existingResponse.'@odata.nextLink'
             } while ($listUri)
         } catch {
+            Write-Warning "Failed to list compliance policies from $($ep.Uri): $_"
             continue
         }
     }
@@ -169,6 +170,21 @@ function Import-IntuneCompliancePolicy {
                 if ($existingPolicies.ContainsKey($ln) -and $existingPolicies[$ln].IsTagged) {
                     $alreadyExists = $true
                     break
+                }
+            }
+
+            # Verify via targeted GET to guard against stale prefetch data after deletes
+            if ($alreadyExists) {
+                $matchedName = $lookupNames | Where-Object { $existingPolicies.ContainsKey($_) -and $existingPolicies[$_].IsTagged } | Select-Object -First 1
+                $matchedPolicy = $existingPolicies[$matchedName]
+                $verifyUri = "beta/$($matchedPolicy.Endpoint)/$($matchedPolicy.Id)"
+                try {
+                    $null = Invoke-MgGraphRequest -Method GET -Uri $verifyUri -ErrorAction Stop
+                } catch {
+                    if ($_.Exception.Message -match '404|NotFound') {
+                        Write-Verbose "Policy '$matchedName' returned 404 on verify — stale data, will create"
+                        $alreadyExists = $false
+                    }
                 }
             }
 

--- a/Public/Import-IntuneCompliancePolicy.ps1
+++ b/Public/Import-IntuneCompliancePolicy.ps1
@@ -51,7 +51,7 @@ function Import-IntuneCompliancePolicy {
         "beta/deviceManagement/compliancePolicies"
     )
     foreach ($listUriStart in $endpointsToList) {
-        $listUri = $listUriStart
+        $listUri = "$listUriStart`?`$select=id,displayName,name,description"
         try {
             do {
                 $existingResponse = Invoke-MgGraphRequest -Method GET -Uri $listUri -ErrorAction Stop
@@ -253,7 +253,7 @@ function Import-IntuneCompliancePolicy {
 
             # Step 1: Check if compliance script already exists or create it
             $scriptId = $null
-            $existingScripts = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceComplianceScripts" -ErrorAction Stop
+            $existingScripts = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceComplianceScripts?`$select=id,displayName" -ErrorAction Stop
             $existingScript = $existingScripts.value | Where-Object { $_.displayName -eq $scriptDisplayName }
 
             if ($existingScript) {

--- a/Public/Import-IntuneConditionalAccessPolicy.ps1
+++ b/Public/Import-IntuneConditionalAccessPolicy.ps1
@@ -32,7 +32,13 @@ function Import-IntuneConditionalAccessPolicy {
     }
 
     if (-not (Test-Path -Path $TemplatePath)) {
-        throw "Conditional Access template directory not found: $TemplatePath"
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Conditional Access template directory not found: $TemplatePath"),
+            'CATemplateNotFound',
+            [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+            $TemplatePath
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 
     # Get all CA policy templates (non-recursive for CA policies)

--- a/Public/Import-IntuneConditionalAccessPolicy.ps1
+++ b/Public/Import-IntuneConditionalAccessPolicy.ps1
@@ -48,7 +48,7 @@ function Import-IntuneConditionalAccessPolicy {
 
     $hasPremiumP2 = $false
     try {
-        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus" -ErrorAction Stop
+        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus?`$select=id,capabilityStatus,servicePlans" -ErrorAction Stop
         foreach ($sku in $subscribedSkus.value) {
             if ($sku.capabilityStatus -ne 'Enabled') { continue }
             foreach ($plan in $sku.servicePlans) {

--- a/Public/Import-IntuneEnrollmentProfile.ps1
+++ b/Public/Import-IntuneEnrollmentProfile.ps1
@@ -94,7 +94,7 @@ function Import-IntuneEnrollmentProfile {
 
         # Delete matching ESP profiles
         try {
-            $existingESP = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceEnrollmentConfigurations?`$select=id,displayName,description,@odata.type" -ErrorAction Stop
+            $existingESP = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceEnrollmentConfigurations?`$select=id,displayName,description" -ErrorAction Stop
             $espProfiles = $existingESP.value | Where-Object {
                 $_.'@odata.type' -eq '#microsoft.graph.windows10EnrollmentCompletionPageConfiguration'
             }

--- a/Public/Import-IntuneEnrollmentProfile.ps1
+++ b/Public/Import-IntuneEnrollmentProfile.ps1
@@ -236,6 +236,18 @@ function Import-IntuneEnrollmentProfile {
                     }
 
                     if ($taggedMatch) {
+                        # Verify the profile still exists (handles eventual consistency after deletes)
+                        $verified = $false
+                        try {
+                            $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/windowsAutopilotDeploymentProfiles/$existingProfileId" -ErrorAction Stop
+                            $verified = $true
+                        } catch {
+                            Write-Verbose "Autopilot profile '$profileName' (ID: $existingProfileId) no longer exists - proceeding to create"
+                            $taggedMatch = $false
+                        }
+                    }
+
+                    if ($taggedMatch) {
                         Write-HydrationLog -Message "  Skipped: $profileName" -Level Info
                         $results += New-HydrationResult -Name $profileName -Type 'AutopilotDeploymentProfile' -Id $existingProfileId -Action 'Skipped' -Status 'Already exists'
                     } elseif ($PSCmdlet.ShouldProcess($profileName, "Create Autopilot deployment profile")) {
@@ -348,6 +360,18 @@ function Import-IntuneEnrollmentProfile {
                         }
                         if (-not $taggedMatch) {
                             $espId = $espCandidates[0].id
+                        }
+                    }
+
+                    if ($taggedMatch) {
+                        # Verify the ESP still exists (handles eventual consistency after deletes)
+                        $verified = $false
+                        try {
+                            $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceEnrollmentConfigurations/$espId" -ErrorAction Stop
+                            $verified = $true
+                        } catch {
+                            Write-Verbose "ESP '$profileName' (ID: $espId) no longer exists - proceeding to create"
+                            $taggedMatch = $false
                         }
                     }
 
@@ -470,6 +494,18 @@ function Import-IntuneEnrollmentProfile {
                                 break
                             }
                             if (-not $existingPolicyId) { $existingPolicyId = $pol.id }
+                        }
+                    }
+
+                    if ($taggedMatch) {
+                        # Verify the policy still exists (handles eventual consistency after deletes)
+                        $verified = $false
+                        try {
+                            $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/configurationPolicies/$existingPolicyId" -ErrorAction Stop
+                            $verified = $true
+                        } catch {
+                            Write-Verbose "Device preparation policy '$profileName' (ID: $existingPolicyId) no longer exists - proceeding to create"
+                            $taggedMatch = $false
                         }
                     }
 

--- a/Public/Import-IntuneEnrollmentProfile.ps1
+++ b/Public/Import-IntuneEnrollmentProfile.ps1
@@ -40,7 +40,13 @@ function Import-IntuneEnrollmentProfile {
     }
 
     if (-not (Test-Path -Path $TemplatePath)) {
-        throw "Enrollment template directory not found: $TemplatePath"
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Enrollment template directory not found: $TemplatePath"),
+            'EnrollmentTemplateNotFound',
+            [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+            $TemplatePath
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 
     $results = @()
@@ -176,7 +182,13 @@ function Import-IntuneEnrollmentProfile {
             $template = Get-Content -Path $templateFile.FullName -Raw -ErrorAction Stop |
                 ConvertFrom-Json -ErrorAction Stop
         } catch {
-            Write-Error "Failed to load or parse enrollment template file '$($templateFile.FullName)': $_"
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("Failed to load or parse enrollment template file '$($templateFile.FullName)': $($_.Exception.Message)", $_.Exception),
+                'TemplateParseError',
+                [System.Management.Automation.ErrorCategory]::ParserError,
+                $templateFile.FullName
+            )
+            $PSCmdlet.WriteError($errorRecord)
             Write-HydrationLog -Message "  Failed: $($templateFile.Name) - $($_.Exception.Message)" -Level Error
             $results += New-HydrationResult -Name $templateFile.Name -Type 'EnrollmentTemplate' -Action 'Failed' -Status $_.Exception.Message
             continue

--- a/Public/Import-IntuneEnrollmentProfile.ps1
+++ b/Public/Import-IntuneEnrollmentProfile.ps1
@@ -242,8 +242,20 @@ function Import-IntuneEnrollmentProfile {
                             $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/windowsAutopilotDeploymentProfiles/$existingProfileId" -ErrorAction Stop
                             $verified = $true
                         } catch {
-                            Write-Verbose "Autopilot profile '$profileName' (ID: $existingProfileId) no longer exists - proceeding to create"
-                            $taggedMatch = $false
+                            $statusCode = $null
+                            if ($_.Exception.PSObject.Properties['ResponseStatusCode']) {
+                                $statusCode = [int]$_.Exception.ResponseStatusCode
+                            } elseif ($_.Exception.PSObject.Properties['StatusCode']) {
+                                $statusCode = [int]$_.Exception.StatusCode
+                            } elseif ($_.Exception.PSObject.Properties['Response'] -and $null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+                                $statusCode = [int]$_.Exception.Response.StatusCode
+                            }
+                            if ($statusCode -eq 404) {
+                                Write-Verbose "Autopilot profile '$profileName' (ID: $existingProfileId) no longer exists - proceeding to create"
+                                $taggedMatch = $false
+                            } else {
+                                throw
+                            }
                         }
                     }
 
@@ -370,8 +382,20 @@ function Import-IntuneEnrollmentProfile {
                             $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceEnrollmentConfigurations/$espId" -ErrorAction Stop
                             $verified = $true
                         } catch {
-                            Write-Verbose "ESP '$profileName' (ID: $espId) no longer exists - proceeding to create"
-                            $taggedMatch = $false
+                            $statusCode = $null
+                            if ($_.Exception.PSObject.Properties['ResponseStatusCode']) {
+                                $statusCode = [int]$_.Exception.ResponseStatusCode
+                            } elseif ($_.Exception.PSObject.Properties['StatusCode']) {
+                                $statusCode = [int]$_.Exception.StatusCode
+                            } elseif ($_.Exception.PSObject.Properties['Response'] -and $null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+                                $statusCode = [int]$_.Exception.Response.StatusCode
+                            }
+                            if ($statusCode -eq 404) {
+                                Write-Verbose "ESP '$profileName' (ID: $espId) no longer exists - proceeding to create"
+                                $taggedMatch = $false
+                            } else {
+                                throw
+                            }
                         }
                     }
 
@@ -504,8 +528,20 @@ function Import-IntuneEnrollmentProfile {
                             $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/configurationPolicies/$existingPolicyId" -ErrorAction Stop
                             $verified = $true
                         } catch {
-                            Write-Verbose "Device preparation policy '$profileName' (ID: $existingPolicyId) no longer exists - proceeding to create"
-                            $taggedMatch = $false
+                            $statusCode = $null
+                            if ($_.Exception.PSObject.Properties['ResponseStatusCode']) {
+                                $statusCode = [int]$_.Exception.ResponseStatusCode
+                            } elseif ($_.Exception.PSObject.Properties['StatusCode']) {
+                                $statusCode = [int]$_.Exception.StatusCode
+                            } elseif ($_.Exception.PSObject.Properties['Response'] -and $null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+                                $statusCode = [int]$_.Exception.Response.StatusCode
+                            }
+                            if ($statusCode -eq 404) {
+                                Write-Verbose "Device preparation policy '$profileName' (ID: $existingPolicyId) no longer exists - proceeding to create"
+                                $taggedMatch = $false
+                            } else {
+                                throw
+                            }
                         }
                     }
 

--- a/Public/Import-IntuneEnrollmentProfile.ps1
+++ b/Public/Import-IntuneEnrollmentProfile.ps1
@@ -53,7 +53,7 @@ function Import-IntuneEnrollmentProfile {
 
         # Delete matching Autopilot profiles
         try {
-            $existingAutopilot = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/windowsAutopilotDeploymentProfiles" -ErrorAction Stop
+            $existingAutopilot = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/windowsAutopilotDeploymentProfiles?`$select=id,displayName,description" -ErrorAction Stop
             foreach ($enrollmentProfile in $existingAutopilot.value) {
                 if (-not (Test-HydrationKitObject -Description $enrollmentProfile.description -ObjectName $enrollmentProfile.displayName)) {
                     Write-Verbose "Skipping '$($enrollmentProfile.displayName)' - not created by Intune Hydration Kit"
@@ -88,7 +88,7 @@ function Import-IntuneEnrollmentProfile {
 
         # Delete matching ESP profiles
         try {
-            $existingESP = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceEnrollmentConfigurations" -ErrorAction Stop
+            $existingESP = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/deviceEnrollmentConfigurations?`$select=id,displayName,description,@odata.type" -ErrorAction Stop
             $espProfiles = $existingESP.value | Where-Object {
                 $_.'@odata.type' -eq '#microsoft.graph.windows10EnrollmentCompletionPageConfiguration'
             }

--- a/Public/Import-IntuneNotificationTemplate.ps1
+++ b/Public/Import-IntuneNotificationTemplate.ps1
@@ -121,7 +121,19 @@ function Import-IntuneNotificationTemplate {
                     $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/notificationMessageTemplates/$existId" -ErrorAction Stop
                     $verified = $true
                 } catch {
-                    Write-Verbose "Template '$displayName' (ID: $existId) no longer exists - proceeding to create"
+                    $statusCode = $null
+                    if ($_.Exception.PSObject.Properties['ResponseStatusCode']) {
+                        $statusCode = [int]$_.Exception.ResponseStatusCode
+                    } elseif ($_.Exception.PSObject.Properties['StatusCode']) {
+                        $statusCode = [int]$_.Exception.StatusCode
+                    } elseif ($_.Exception.PSObject.Properties['Response'] -and $null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+                        $statusCode = [int]$_.Exception.Response.StatusCode
+                    }
+                    if ($statusCode -eq 404) {
+                        Write-Verbose "Template '$displayName' (ID: $existId) no longer exists - proceeding to create"
+                    } else {
+                        throw
+                    }
                 }
                 if ($verified) {
                     Write-HydrationLog -Message "  Skipped: $displayName" -Level Info
@@ -138,7 +150,19 @@ function Import-IntuneNotificationTemplate {
                     $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/notificationMessageTemplates/$existId" -ErrorAction Stop
                     $verified = $true
                 } catch {
-                    Write-Verbose "Legacy template '$($template.displayName)' (ID: $existId) no longer exists - proceeding to create"
+                    $statusCode = $null
+                    if ($_.Exception.PSObject.Properties['ResponseStatusCode']) {
+                        $statusCode = [int]$_.Exception.ResponseStatusCode
+                    } elseif ($_.Exception.PSObject.Properties['StatusCode']) {
+                        $statusCode = [int]$_.Exception.StatusCode
+                    } elseif ($_.Exception.PSObject.Properties['Response'] -and $null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+                        $statusCode = [int]$_.Exception.Response.StatusCode
+                    }
+                    if ($statusCode -eq 404) {
+                        Write-Verbose "Legacy template '$($template.displayName)' (ID: $existId) no longer exists - proceeding to create"
+                    } else {
+                        throw
+                    }
                 }
                 if ($verified) {
                     Write-HydrationLog -Message "  Skipped: $displayName (legacy match: '$($template.displayName)')" -Level Info

--- a/Public/Import-IntuneNotificationTemplate.ps1
+++ b/Public/Import-IntuneNotificationTemplate.ps1
@@ -39,7 +39,7 @@ function Import-IntuneNotificationTemplate {
     # Prefetch existing templates for duplicate detection
     $existingTemplates = @{}
     try {
-        Get-GraphPagedResults -Uri "beta/deviceManagement/notificationMessageTemplates" -ProcessItems {
+        Get-GraphPagedResults -Uri "beta/deviceManagement/notificationMessageTemplates?`$select=id,displayName" -ProcessItems {
             param($items)
             foreach ($tmpl in $items) {
                 if ($tmpl.displayName -and -not $existingTemplates.ContainsKey($tmpl.displayName)) {
@@ -112,16 +112,39 @@ function Import-IntuneNotificationTemplate {
             }
 
             if ($existingTemplates.ContainsKey($displayName)) {
-                Write-HydrationLog -Message "  Skipped: $displayName" -Level Info
-                $results += New-HydrationResult -Name $displayName -Path $templateFile.FullName -Type 'NotificationTemplate' -Action 'Skipped' -Status 'Already exists'
-                continue
+                # Notification templates lack a description field for hydration markers,
+                # so verify the template still exists via targeted GET (handles eventual
+                # consistency after recent deletes returning stale list data)
+                $existId = $existingTemplates[$displayName].Id
+                $verified = $false
+                try {
+                    $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/notificationMessageTemplates/$existId" -ErrorAction Stop
+                    $verified = $true
+                } catch {
+                    Write-Verbose "Template '$displayName' (ID: $existId) no longer exists - proceeding to create"
+                }
+                if ($verified) {
+                    Write-HydrationLog -Message "  Skipped: $displayName" -Level Info
+                    $results += New-HydrationResult -Name $displayName -Path $templateFile.FullName -Type 'NotificationTemplate' -Action 'Skipped' -Status 'Already exists'
+                    continue
+                }
             }
 
             # Check for legacy unprefixed template to prevent duplicates on upgrade
             if ($existingTemplates.ContainsKey($template.displayName)) {
-                Write-HydrationLog -Message "  Skipped: $displayName (legacy match: '$($template.displayName)')" -Level Info
-                $results += New-HydrationResult -Name $displayName -Path $templateFile.FullName -Type 'NotificationTemplate' -Action 'Skipped' -Status 'Already exists (legacy name)'
-                continue
+                $existId = $existingTemplates[$template.displayName].Id
+                $verified = $false
+                try {
+                    $null = Invoke-MgGraphRequest -Method GET -Uri "beta/deviceManagement/notificationMessageTemplates/$existId" -ErrorAction Stop
+                    $verified = $true
+                } catch {
+                    Write-Verbose "Legacy template '$($template.displayName)' (ID: $existId) no longer exists - proceeding to create"
+                }
+                if ($verified) {
+                    Write-HydrationLog -Message "  Skipped: $displayName (legacy match: '$($template.displayName)')" -Level Info
+                    $results += New-HydrationResult -Name $displayName -Path $templateFile.FullName -Type 'NotificationTemplate' -Action 'Skipped' -Status 'Already exists (legacy name)'
+                    continue
+                }
             }
 
             # Split template into main body and localized messages

--- a/Public/Initialize-HydrationLogging.ps1
+++ b/Public/Initialize-HydrationLogging.ps1
@@ -2,6 +2,9 @@ function Initialize-HydrationLogging {
     <#
     .SYNOPSIS
         Initializes logging for the hydration session
+    .DESCRIPTION
+        Sets up the logging infrastructure for a hydration run, creating the log directory
+        and session log file. Configures both console and file logging with timestamps.
     .PARAMETER LogPath
         Path to write log files. Defaults to OS temp directory under IntuneHydrationKit/Logs
     .PARAMETER EnableVerbose

--- a/Public/Invoke-IntuneHydration.ps1
+++ b/Public/Invoke-IntuneHydration.ps1
@@ -278,7 +278,13 @@ function Invoke-IntuneHydration {
 
             # Validate that at least one target is enabled
             if (-not ($importsEnabled.Values -contains $true)) {
-                throw "At least one target must be enabled. Use -All or specify a target switch (e.g., -DynamicGroups, -DeviceFilters, etc.)."
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new("At least one target must be enabled. Use -All or specify a target switch (e.g., -DynamicGroups, -DeviceFilters, etc.)."),
+                    'NoTargetsEnabled',
+                    [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                    $null
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
 
             # Build settings object from parameters
@@ -389,11 +395,23 @@ function Invoke-IntuneHydration {
 
         # Validate options - create and delete are mutually exclusive
         if ($createEnabled -and $deleteEnabled) {
-            throw "Only one of 'create' or 'delete' options can be true. Current settings: create=$createEnabled, delete=$deleteEnabled"
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("Only one of 'create' or 'delete' options can be true. Current settings: create=$createEnabled, delete=$deleteEnabled"),
+                'MutuallyExclusiveOptions',
+                [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                $null
+            )
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
 
         if (-not $createEnabled -and -not $deleteEnabled) {
-            throw "At least one of 'create' or 'delete' options must be true. Current settings: create=$createEnabled, delete=$deleteEnabled"
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("At least one of 'create' or 'delete' options must be true. Current settings: create=$createEnabled, delete=$deleteEnabled"),
+                'NoOperationSelected',
+                [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                $null
+            )
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
 
         if ($deleteEnabled -and -not $forceDelete -and -not $WhatIfPreference) {

--- a/Public/New-IntuneDynamicGroup.ps1
+++ b/Public/New-IntuneDynamicGroup.ps1
@@ -86,7 +86,13 @@ function New-IntuneDynamicGroup {
             return New-HydrationResult -Name $DisplayName -Type 'DynamicGroup' -Action 'WouldCreate' -Status 'DryRun'
         }
     } catch {
-        Write-Error "Failed to create group '$DisplayName': $_"
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Failed to create group '$DisplayName': $($_.Exception.Message)", $_.Exception),
+            'GroupCreationFailed',
+            [System.Management.Automation.ErrorCategory]::WriteError,
+            $DisplayName
+        )
+        $PSCmdlet.WriteError($errorRecord)
         return New-HydrationResult -Name $DisplayName -Type 'DynamicGroup' -Action 'Failed' -Status $_.Exception.Message
     }
 }

--- a/Public/Test-IntunePrerequisites.ps1
+++ b/Public/Test-IntunePrerequisites.ps1
@@ -36,14 +36,13 @@ function Test-IntunePrerequisites {
 
     try {
         # Check organization info and licenses
-        $org = Invoke-MgGraphRequest -Method GET -Uri "beta/organization" -ErrorAction Stop
+        $org = Invoke-MgGraphRequest -Method GET -Uri "beta/organization?`$select=id,displayName" -ErrorAction Stop
         $orgDetails = $org.value[0]
 
         Write-Host "Connected to: $($orgDetails.displayName)"
 
         # Check for Intune service plan
-        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus" -ErrorAction Stop
-
+        $subscribedSkus = Invoke-MgGraphRequest -Method GET -Uri "beta/subscribedSkus?`$select=id,skuPartNumber,capabilityStatus,servicePlans" -ErrorAction Stop
         $intuneServicePlans = @(
             'INTUNE_A',           # Intune Plan 1
             'INTUNE_EDU',         # Intune for Education

--- a/Public/Test-IntunePrerequisites.ps1
+++ b/Public/Test-IntunePrerequisites.ps1
@@ -124,7 +124,13 @@ function Test-IntunePrerequisites {
 
             # Surface specific issues in the exception message so callers/tests can pattern match
             $issueMessage = $issues -join ' | '
-            throw "Prerequisite checks failed: $issueMessage"
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("Prerequisite checks failed: $issueMessage"),
+                'PrerequisiteCheckFailed',
+                [System.Management.Automation.ErrorCategory]::NotEnabled,
+                $null
+            )
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
 
         Write-Host "All prerequisite checks passed"
@@ -133,7 +139,12 @@ function Test-IntunePrerequisites {
         if ($_.Exception.Message -match "Prerequisite checks failed") {
             throw
         }
-        Write-Error "Failed to validate prerequisites: $_"
-        throw
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Failed to validate prerequisites: $($_.Exception.Message)", $_.Exception),
+            'PrerequisiteValidationFailed',
+            [System.Management.Automation.ErrorCategory]::NotSpecified,
+            $null
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 }

--- a/Public/Write-HydrationLog.ps1
+++ b/Public/Write-HydrationLog.ps1
@@ -1,13 +1,21 @@
 function Write-HydrationLog {
     <#
     .SYNOPSIS
-        Writes a log entry
+        Writes a log entry to the console and log file
+    .DESCRIPTION
+        Writes a timestamped, level-tagged log entry to both the console (with color-coded
+        icons) and the current session log file. Used throughout the module to provide
+        consistent diagnostic output during hydration operations.
     .PARAMETER Message
         The message to log
     .PARAMETER Level
         Log level (Info, Warning, Error, Debug)
     .PARAMETER Data
         Additional data to include
+    .EXAMPLE
+        Write-HydrationLog -Message "Importing compliance policies" -Level Info
+    .EXAMPLE
+        Write-HydrationLog -Message "Rate limited by Graph API" -Level Warning
     #>
     [CmdletBinding()]
     param(

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ When using delete mode (`-Delete` parameter or `"delete": true` in settings), th
 
 - **`[IHD]` Name Prefix** - All imported objects are prefixed with `[IHD]` for easy identification and filtering
 - **Batch API Operations** - Groups, policies, filters, and apps use batched Graph API calls (up to 10 per batch) for ~61% faster execution
+- **Retry-After Throttle Handling** - Automatic retry with `Retry-After` header support on 429/503 Graph API responses
 - **Bundled Baselines** - OpenIntuneBaseline templates included in module (no external download required)
 - **Idempotent** - Safe to run multiple times; skips existing configurations
 - **Dry-Run Mode** - Preview changes with PowerShell `-WhatIf` before applying
@@ -713,7 +714,7 @@ IntuneHydrationKit/
 │   ├── MobileApps/
 │   ├── Notifications/
 │   └── ...
-├── Tests/                         # Pester tests (393+)
+├── Tests/                         # Pester tests (648+)
 ├── Logs/                          # Execution logs
 └── Reports/                       # Generated reports
 ```

--- a/Tests/Private/Get-GraphErrorMessage.Tests.ps1
+++ b/Tests/Private/Get-GraphErrorMessage.Tests.ps1
@@ -1,0 +1,232 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Get-GraphErrorMessage.ps1'
+    . $functionPath
+}
+
+Describe 'Get-GraphErrorMessage' {
+    Context 'Status code extraction' {
+        It 'Should include HTTP status code in output' {
+            $response = [PSCustomObject]@{ StatusCode = [System.Net.HttpStatusCode]::NotFound }
+            $exception = [System.Exception]::new('Not Found')
+            $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"ResourceNotFound","message":"Resource not found"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -BeLike 'HTTP 404*'
+        }
+
+        It 'Should handle missing status code gracefully' {
+            $exception = [System.Exception]::new('Some error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"BadRequest","message":"Invalid"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Not -BeLike 'HTTP*'
+        }
+    }
+
+    Context 'Error code extraction via regex' {
+        It 'Should extract error code from JSON error response' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"Forbidden","message":"Insufficient privileges"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Access denied - check permissions'
+        }
+    }
+
+    Context 'Detail message extraction and truncation' {
+        It 'Should extract detail message from JSON' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"BadRequest","message":"The property displayName is required"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Invalid request - The property displayName is required'
+        }
+
+        It 'Should truncate detail messages longer than 200 characters' {
+            $longMessage = 'A' * 250
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = "{`"error`":{`"code`":`"BadRequest`",`"message`":`"$longMessage`"}}"
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -BeLike '*...'
+        }
+    }
+
+    Context 'JSON string unescaping' {
+        It 'Should unescape \r\n in JSON messages' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"BadRequest","message":"Line1\\r\\nLine2"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Not -Match '\\r\\n'
+        }
+
+        It 'Should unescape escaped quotes in JSON messages' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $jsonMsg = '{"error":{"code":"BadRequest","message":"Field \"name\" is invalid"}}'
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = $jsonMsg
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -BeLike '*"name"*'
+        }
+    }
+
+    Context 'Nested JSON Message extraction' {
+        It 'Should extract inner Message field from nested JSON' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"BadRequest","message":"{\"Message\":\"The actual inner error detail\"}"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -BeLike '*actual inner error*'
+        }
+    }
+
+    Context 'Known error code mapping' -ForEach @(
+        @{ Code = 'ResourceNotFound'; Expected = 'Resource not found (may have been deleted already)' }
+        @{ Code = 'InternalServerError'; Expected = 'Server error - please retry' }
+        @{ Code = 'Forbidden'; Expected = 'Access denied - check permissions' }
+        @{ Code = 'Unauthorized'; Expected = 'Authentication failed - reconnect to Graph' }
+        @{ Code = 'TooManyRequests'; Expected = 'Rate limited - please wait and retry' }
+        @{ Code = 'ServiceUnavailable'; Expected = 'Service unavailable - please retry later' }
+    ) {
+        It 'Should map <Code> to known message' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = "{`"error`":{`"code`":`"$Code`",`"message`":`"$Code`"}}"
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be $Expected
+        }
+    }
+
+    Context 'BadRequest with detail message' {
+        It 'Should include detail in BadRequest when available' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"BadRequest","message":"Missing required field"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Invalid request - Missing required field'
+        }
+
+        It 'Should use generic message for BadRequest without detail' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"BadRequest","message":"BadRequest"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Invalid request - check template format'
+        }
+    }
+
+    Context 'Default/fallback behavior' {
+        It 'Should use error code and detail for unknown codes' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"CustomError","message":"Something went wrong"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'CustomError - Something went wrong'
+        }
+
+        It 'Should return just error code when detail matches code' {
+            $exception = [System.Exception]::new('error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"CustomError","message":"CustomError"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'CustomError'
+        }
+
+        It 'Should truncate raw message longer than 100 characters when no JSON found' {
+            $longMessage = 'X' * 150
+            $exception = [System.Exception]::new($longMessage)
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result.Length | Should -BeLessOrEqual 103
+            $result | Should -BeLike '*...'
+        }
+
+        It 'Should return raw message when short and no JSON found' {
+            $exception = [System.Exception]::new('Simple error')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Simple error'
+        }
+    }
+
+    Context 'Output format' {
+        It 'Should format as "HTTP {statusCode} - {cleanMessage}"' {
+            $response = [PSCustomObject]@{ StatusCode = [System.Net.HttpStatusCode]::Forbidden }
+            $exception = [System.Exception]::new('Forbidden')
+            $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"Forbidden","message":"Insufficient privileges"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'HTTP 403 - Access denied - check permissions'
+        }
+    }
+
+    Context 'ErrorDetails vs Exception.Message fallback' {
+        It 'Should use ErrorDetails.Message when available' {
+            $exception = [System.Exception]::new('Exception message with no JSON')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+            $errorRecord | Add-Member -NotePropertyName 'ErrorDetails' -NotePropertyValue ([PSCustomObject]@{
+                Message = '{"error":{"code":"ResourceNotFound","message":"Not found"}}'
+            }) -Force
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Resource not found (may have been deleted already)'
+        }
+
+        It 'Should fall back to Exception.Message when ErrorDetails is null' {
+            $exception = [System.Exception]::new('Plain error text')
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TestError', 'NotSpecified', $null)
+
+            $result = Get-GraphErrorMessage -ErrorRecord $errorRecord
+            $result | Should -Be 'Plain error text'
+        }
+    }
+}

--- a/Tests/Private/Get-HydrationTemplates.Tests.ps1
+++ b/Tests/Private/Get-HydrationTemplates.Tests.ps1
@@ -1,0 +1,86 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Get-HydrationTemplates.ps1'
+    . $functionPath
+}
+
+Describe 'Get-HydrationTemplates' {
+    Context 'When directory contains JSON files' {
+        BeforeAll {
+            New-Item -Path "TestDrive:\templates" -ItemType Directory -Force
+            '{}' | Set-Content -Path "TestDrive:\templates\policy1.json"
+            '{}' | Set-Content -Path "TestDrive:\templates\policy2.json"
+        }
+
+        It 'Should return JSON files from flat directory' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\templates"
+            $result | Should -HaveCount 2
+        }
+
+        It 'Should return FileInfo objects' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\templates"
+            $result[0] | Should -BeOfType [System.IO.FileInfo]
+        }
+    }
+
+    Context 'When directory contains no JSON files' {
+        BeforeAll {
+            New-Item -Path "TestDrive:\empty" -ItemType Directory -Force
+            'not json' | Set-Content -Path "TestDrive:\empty\readme.txt"
+        }
+
+        It 'Should return empty when no JSON files exist' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\empty"
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When non-JSON files are present' {
+        BeforeAll {
+            New-Item -Path "TestDrive:\mixed" -ItemType Directory -Force
+            '{}' | Set-Content -Path "TestDrive:\mixed\template.json"
+            'text' | Set-Content -Path "TestDrive:\mixed\readme.md"
+            'xml' | Set-Content -Path "TestDrive:\mixed\config.xml"
+            'ps1' | Set-Content -Path "TestDrive:\mixed\script.ps1"
+        }
+
+        It 'Should exclude non-JSON files' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\mixed"
+            $result | Should -HaveCount 1
+            $result[0].Name | Should -Be 'template.json'
+        }
+    }
+
+    Context 'Recurse switch' {
+        BeforeAll {
+            New-Item -Path "TestDrive:\nested\sub1" -ItemType Directory -Force
+            New-Item -Path "TestDrive:\nested\sub2" -ItemType Directory -Force
+            '{}' | Set-Content -Path "TestDrive:\nested\root.json"
+            '{}' | Set-Content -Path "TestDrive:\nested\sub1\child1.json"
+            '{}' | Set-Content -Path "TestDrive:\nested\sub2\child2.json"
+        }
+
+        It 'Should not recurse by default' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\nested"
+            $result | Should -HaveCount 1
+            $result[0].Name | Should -Be 'root.json'
+        }
+
+        It 'Should find nested files with -Recurse' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\nested" -Recurse
+            $result | Should -HaveCount 3
+        }
+    }
+
+    Context 'When directory is empty' {
+        BeforeAll {
+            New-Item -Path "TestDrive:\emptydir" -ItemType Directory -Force
+        }
+
+        It 'Should return empty for empty directory' {
+            $result = Get-HydrationTemplates -Path "TestDrive:\emptydir"
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Private/Get-ObfuscatedTenantId.Tests.ps1
+++ b/Tests/Private/Get-ObfuscatedTenantId.Tests.ps1
@@ -1,0 +1,71 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Get-ObfuscatedTenantId.ps1'
+    . $functionPath
+}
+
+Describe 'Get-ObfuscatedTenantId' {
+    Context 'GUID format' {
+        It 'Should obfuscate GUID "<TenantValue>"' -TestCases @(
+            @{ TenantValue = '12345678-1234-1234-1234-123456789abc'; Expected = '12345678****-****-****-123456789abc' }
+            @{ TenantValue = 'abcdef01-2345-6789-abcd-ef0123456789'; Expected = 'abcdef01****-****-****-ef0123456789' }
+            @{ TenantValue = '00000000-0000-0000-0000-000000000000'; Expected = '00000000****-****-****-000000000000' }
+        ) {
+            $result = Get-ObfuscatedTenantId -TenantId $TenantValue
+            $result | Should -Be $Expected
+        }
+    }
+
+    Context 'GUID format details' {
+        It 'Should show first 8 characters of GUID' {
+            $result = Get-ObfuscatedTenantId -TenantId '12345678-1234-1234-1234-123456789abc'
+            $result | Should -BeLike '12345678*'
+        }
+
+        It 'Should show last 12 characters of GUID' {
+            $result = Get-ObfuscatedTenantId -TenantId '12345678-1234-1234-1234-123456789abc'
+            $result | Should -BeLike '*123456789abc'
+        }
+
+        It 'Should mask the middle sections' {
+            $result = Get-ObfuscatedTenantId -TenantId '12345678-1234-1234-1234-123456789abc'
+            $result | Should -Match '\*{4}-\*{4}-\*{4}-'
+        }
+    }
+
+    Context 'Domain format' {
+        It 'Should obfuscate domain "<TenantValue>"' -TestCases @(
+            @{ TenantValue = 'contoso.onmicrosoft.com'; Expected = 'cont***' }
+            @{ TenantValue = 'fabrikam.com'; Expected = 'fabr***' }
+            @{ TenantValue = 'mycompany.onmicrosoft.com'; Expected = 'myco***' }
+        ) {
+            $result = Get-ObfuscatedTenantId -TenantId $TenantValue
+            $result | Should -Be $Expected
+        }
+    }
+
+    Context 'Short domain names' {
+        It 'Should handle domain shorter than 4 characters gracefully' {
+            $result = Get-ObfuscatedTenantId -TenantId 'ab'
+            $result | Should -Be 'ab***'
+        }
+
+        It 'Should handle domain of exactly 4 characters' {
+            $result = Get-ObfuscatedTenantId -TenantId 'test'
+            $result | Should -Be 'test***'
+        }
+
+        It 'Should handle single character domain' {
+            $result = Get-ObfuscatedTenantId -TenantId 'a'
+            $result | Should -Be 'a***'
+        }
+    }
+
+    Context 'Return type' {
+        It 'Should return a string' {
+            $result = Get-ObfuscatedTenantId -TenantId '12345678-1234-1234-1234-123456789abc'
+            $result | Should -BeOfType [string]
+        }
+    }
+}

--- a/Tests/Private/Get-PremiumP2ServicePlans.Tests.ps1
+++ b/Tests/Private/Get-PremiumP2ServicePlans.Tests.ps1
@@ -16,8 +16,9 @@ Describe 'Get-PremiumP2ServicePlans' {
             $plans.Count | Should -BeGreaterThan 0
         }
 
-        It 'Should return an array type' {
-            $plans | Should -BeOfType [string]
+        It 'Should return string elements' {
+            $plans | Should -HaveCount $plans.Count
+            $plans[0] | Should -BeOfType [string]
         }
     }
 

--- a/Tests/Private/Get-PremiumP2ServicePlans.Tests.ps1
+++ b/Tests/Private/Get-PremiumP2ServicePlans.Tests.ps1
@@ -1,0 +1,57 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Get-PremiumP2ServicePlans.ps1'
+    . $functionPath
+}
+
+Describe 'Get-PremiumP2ServicePlans' {
+    Context 'Return value' {
+        BeforeAll {
+            $plans = Get-PremiumP2ServicePlans
+        }
+
+        It 'Should return a non-empty array' {
+            $plans | Should -Not -BeNullOrEmpty
+            $plans.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should return an array type' {
+            $plans | Should -BeOfType [string]
+        }
+    }
+
+    Context 'Expected P2 plans are present' -ForEach @(
+        @{ Plan = 'AAD_PREMIUM_P2' }
+        @{ Plan = 'SPE_E5' }
+        @{ Plan = 'EMSPREMIUM' }
+        @{ Plan = 'M365EDU_A5_FACULTY' }
+        @{ Plan = 'IDENTITY_THREAT_PROTECTION' }
+        @{ Plan = 'ATA' }
+    ) {
+        It 'Should contain <Plan>' {
+            $result = Get-PremiumP2ServicePlans
+            $result | Should -Contain $Plan
+        }
+    }
+
+    Context 'Non-P2 plans are excluded' -ForEach @(
+        @{ Plan = 'INTUNE_A' }
+        @{ Plan = 'AAD_PREMIUM' }
+        @{ Plan = 'SPE_E3' }
+        @{ Plan = 'EXCHANGESTANDARD' }
+    ) {
+        It 'Should NOT contain <Plan>' {
+            $result = Get-PremiumP2ServicePlans
+            $result | Should -Not -Contain $Plan
+        }
+    }
+
+    Context 'Consistency' {
+        It 'Should return the same plans on repeated calls' {
+            $first = Get-PremiumP2ServicePlans
+            $second = Get-PremiumP2ServicePlans
+            $first | Should -Be $second
+        }
+    }
+}

--- a/Tests/Private/Get-ResultSummary.Tests.ps1
+++ b/Tests/Private/Get-ResultSummary.Tests.ps1
@@ -1,0 +1,121 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Get-ResultSummary.ps1'
+    . $functionPath
+}
+
+Describe 'Get-ResultSummary' {
+    Context 'Empty results' {
+        It 'Should return all zeros for empty array' {
+            $result = Get-ResultSummary -Results @()
+            $result.Created | Should -Be 0
+            $result.Updated | Should -Be 0
+            $result.Deleted | Should -Be 0
+            $result.Skipped | Should -Be 0
+            $result.WouldCreate | Should -Be 0
+            $result.WouldUpdate | Should -Be 0
+            $result.WouldDelete | Should -Be 0
+            $result.Failed | Should -Be 0
+        }
+
+        It 'Should return all zeros when called without parameters' {
+            $result = Get-ResultSummary
+            $result.Created | Should -Be 0
+            $result.Failed | Should -Be 0
+        }
+    }
+
+    Context 'Mixed results' {
+        BeforeAll {
+            $results = @(
+                [PSCustomObject]@{ Action = 'Created' }
+                [PSCustomObject]@{ Action = 'Created' }
+                [PSCustomObject]@{ Action = 'Updated' }
+                [PSCustomObject]@{ Action = 'Deleted' }
+                [PSCustomObject]@{ Action = 'Skipped' }
+                [PSCustomObject]@{ Action = 'Skipped' }
+                [PSCustomObject]@{ Action = 'Skipped' }
+                [PSCustomObject]@{ Action = 'Failed' }
+                [PSCustomObject]@{ Action = 'WouldCreate' }
+                [PSCustomObject]@{ Action = 'WouldDelete' }
+            )
+            $summary = Get-ResultSummary -Results $results
+        }
+
+        It 'Should count Created correctly' {
+            $summary.Created | Should -Be 2
+        }
+
+        It 'Should count Updated correctly' {
+            $summary.Updated | Should -Be 1
+        }
+
+        It 'Should count Deleted correctly' {
+            $summary.Deleted | Should -Be 1
+        }
+
+        It 'Should count Skipped correctly' {
+            $summary.Skipped | Should -Be 3
+        }
+
+        It 'Should count WouldCreate correctly' {
+            $summary.WouldCreate | Should -Be 1
+        }
+
+        It 'Should count WouldDelete correctly' {
+            $summary.WouldDelete | Should -Be 1
+        }
+
+        It 'Should count Failed correctly' {
+            $summary.Failed | Should -Be 1
+        }
+
+        It 'Should count WouldUpdate as zero when none present' {
+            $summary.WouldUpdate | Should -Be 0
+        }
+    }
+
+    Context 'Single result type' {
+        It 'Should count a single Created result' {
+            $results = @([PSCustomObject]@{ Action = 'Created' })
+            $result = Get-ResultSummary -Results $results
+            $result.Created | Should -Be 1
+            $result.Updated | Should -Be 0
+        }
+    }
+
+    Context 'Unknown action values' {
+        It 'Should ignore unknown Action values' {
+            $results = @(
+                [PSCustomObject]@{ Action = 'Created' }
+                [PSCustomObject]@{ Action = 'InvalidAction' }
+                [PSCustomObject]@{ Action = 'SomethingElse' }
+            )
+            $result = Get-ResultSummary -Results $results
+            $result.Created | Should -Be 1
+            $result.Keys | Should -Not -Contain 'InvalidAction'
+        }
+
+        It 'Should ignore results with null Action' {
+            $results = @(
+                [PSCustomObject]@{ Action = $null }
+                [PSCustomObject]@{ Action = 'Created' }
+            )
+            $result = Get-ResultSummary -Results $results
+            $result.Created | Should -Be 1
+        }
+    }
+
+    Context 'Return type' {
+        It 'Should return a hashtable' {
+            $result = Get-ResultSummary -Results @()
+            $result | Should -BeOfType [hashtable]
+        }
+
+        It 'Should contain all 8 expected keys' {
+            $result = Get-ResultSummary -Results @()
+            $result.Keys | Should -HaveCount 8
+        }
+    }
+}

--- a/Tests/Private/Invoke-GraphBatchOperation.Tests.ps1
+++ b/Tests/Private/Invoke-GraphBatchOperation.Tests.ps1
@@ -173,6 +173,48 @@ Describe 'Invoke-GraphBatchOperation' {
         }
     }
 
+    Context 'Retry on 429 throttle with Retry-After header' {
+        BeforeAll {
+            $script:callCount = 0
+            Mock Invoke-MgGraphRequest {
+                $script:callCount++
+                if ($script:callCount -eq 1) {
+                    return @{
+                        responses = @(
+                            @{ id = '1'; status = 429; headers = @{ 'Retry-After' = '5' }; body = @{ error = @{ message = 'Too Many Requests' } } }
+                        )
+                    }
+                } else {
+                    return @{
+                        responses = @(
+                            @{ id = '1'; status = 201; body = @{ id = 'throttle-guid'; displayName = 'ThrottledItem' } }
+                        )
+                    }
+                }
+            }
+
+            $items = @(
+                @{ Name = 'ThrottledItem'; BodyJson = '{"displayName":"ThrottledItem"}' }
+            )
+
+            $script:result = Invoke-GraphBatchOperation -Items $items -Operation 'POST' -BaseUrl '/test/endpoint' -ResultType 'TestType' -MaxRetries 3 -RetryDelaySeconds 1
+        }
+
+        It 'Should eventually succeed after 429 throttle' {
+            $created = $script:result | Where-Object { $_.Action -eq 'Created' }
+            $created | Should -Not -BeNullOrEmpty
+            $created.Id | Should -Be 'throttle-guid'
+        }
+
+        It 'Should have called Graph API twice' {
+            $script:callCount | Should -Be 2
+        }
+
+        It 'Should honor Retry-After delay value' {
+            Should -Invoke Start-Sleep -Times 1 -Scope Context -ParameterFilter { $Seconds -eq 5 }
+        }
+    }
+
     Context 'DELETE retry exhaustion maps to Failed' {
         BeforeAll {
             Mock Invoke-MgGraphRequest {

--- a/Tests/Private/New-HydrationResult.Tests.ps1
+++ b/Tests/Private/New-HydrationResult.Tests.ps1
@@ -1,0 +1,125 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\New-HydrationResult.ps1'
+    . $functionPath
+}
+
+Describe 'New-HydrationResult' {
+    Context 'Required properties' {
+        BeforeAll {
+            $result = New-HydrationResult -Name 'Test Policy' -Action 'Created' -Status 'Success'
+        }
+
+        It 'Should have Name property' {
+            $result.Name | Should -Be 'Test Policy'
+        }
+
+        It 'Should have Action property' {
+            $result.Action | Should -Be 'Created'
+        }
+
+        It 'Should have Status property' {
+            $result.Status | Should -Be 'Success'
+        }
+
+        It 'Should have Timestamp property' {
+            $result.Timestamp | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Timestamp in "yyyy-MM-dd HH:mm:ss" format' {
+            $result.Timestamp | Should -Match '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'
+        }
+    }
+
+    Context 'Optional properties when provided' {
+        BeforeAll {
+            $result = New-HydrationResult -Name 'Test' -Action 'Created' -Status 'Success' `
+                -Path '/templates/policy.json' -Type 'CompliancePolicy' `
+                -Id 'abc-123' -Platform 'Windows' -State 'enabled'
+        }
+
+        It 'Should include Path when provided' {
+            $result.Path | Should -Be '/templates/policy.json'
+        }
+
+        It 'Should include Type when provided' {
+            $result.Type | Should -Be 'CompliancePolicy'
+        }
+
+        It 'Should include Id when provided' {
+            $result.Id | Should -Be 'abc-123'
+        }
+
+        It 'Should include Platform when provided' {
+            $result.Platform | Should -Be 'Windows'
+        }
+
+        It 'Should include State when provided' {
+            $result.State | Should -Be 'enabled'
+        }
+    }
+
+    Context 'Optional properties when NOT provided' {
+        BeforeAll {
+            $result = New-HydrationResult -Name 'Test' -Action 'Deleted' -Status 'Success'
+        }
+
+        It 'Should NOT have Path property' {
+            $result.PSObject.Properties['Path'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should NOT have Type property' {
+            $result.PSObject.Properties['Type'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should NOT have Id property' {
+            $result.PSObject.Properties['Id'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should NOT have Platform property' {
+            $result.PSObject.Properties['Platform'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should NOT have State property' {
+            $result.PSObject.Properties['State'] | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Selective optional properties' {
+        It 'Should add only Path when only Path is provided' {
+            $result = New-HydrationResult -Name 'Test' -Action 'Created' -Status 'OK' -Path '/test.json'
+            $result.PSObject.Properties['Path'] | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties['Type'] | Should -BeNullOrEmpty
+            $result.PSObject.Properties['Id'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should add only Platform when only Platform is provided' {
+            $result = New-HydrationResult -Name 'Test' -Action 'Created' -Status 'OK' -Platform 'macOS'
+            $result.PSObject.Properties['Platform'] | Should -Not -BeNullOrEmpty
+            $result.Platform | Should -Be 'macOS'
+            $result.PSObject.Properties['Path'] | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Return type' {
+        It 'Should return a PSCustomObject' {
+            $result = New-HydrationResult -Name 'Test' -Action 'Created' -Status 'Success'
+            $result | Should -BeOfType [PSCustomObject]
+        }
+    }
+
+    Context 'Different action types' -ForEach @(
+        @{ Action = 'Created' }
+        @{ Action = 'Updated' }
+        @{ Action = 'Deleted' }
+        @{ Action = 'Skipped' }
+        @{ Action = 'WouldCreate' }
+        @{ Action = 'Failed' }
+    ) {
+        It 'Should accept Action "<Action>"' {
+            $result = New-HydrationResult -Name 'Test' -Action $Action -Status 'OK'
+            $result.Action | Should -Be $Action
+        }
+    }
+}

--- a/Tests/Private/Remove-ReadOnlyGraphProperties.Tests.ps1
+++ b/Tests/Private/Remove-ReadOnlyGraphProperties.Tests.ps1
@@ -1,0 +1,131 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Remove-ReadOnlyGraphProperties.ps1'
+    . $functionPath
+}
+
+Describe 'Remove-ReadOnlyGraphProperties' {
+    Context 'Core read-only properties' {
+        It 'Should remove id property' {
+            $obj = [PSCustomObject]@{ id = 'abc-123'; displayName = 'Test' }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.PSObject.Properties['id'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should remove createdDateTime property' {
+            $obj = [PSCustomObject]@{ createdDateTime = '2024-01-01'; displayName = 'Test' }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.PSObject.Properties['createdDateTime'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should remove lastModifiedDateTime property' {
+            $obj = [PSCustomObject]@{ lastModifiedDateTime = '2024-01-01'; displayName = 'Test' }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.PSObject.Properties['lastModifiedDateTime'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should remove version property' {
+            $obj = [PSCustomObject]@{ version = '1'; displayName = 'Test' }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.PSObject.Properties['version'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should remove @odata.context property' {
+            $obj = [PSCustomObject]@{ '@odata.context' = 'https://graph.microsoft.com'; displayName = 'Test' }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.PSObject.Properties['@odata.context'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should remove all core read-only properties at once' {
+            $obj = [PSCustomObject]@{
+                id                   = 'abc-123'
+                createdDateTime      = '2024-01-01'
+                lastModifiedDateTime = '2024-06-01'
+                version              = '3'
+                '@odata.context'     = 'https://graph.microsoft.com'
+                displayName          = 'Keep This'
+                description          = 'Also keep'
+            }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.PSObject.Properties['id'] | Should -BeNullOrEmpty
+            $obj.PSObject.Properties['createdDateTime'] | Should -BeNullOrEmpty
+            $obj.PSObject.Properties['lastModifiedDateTime'] | Should -BeNullOrEmpty
+            $obj.PSObject.Properties['version'] | Should -BeNullOrEmpty
+            $obj.PSObject.Properties['@odata.context'] | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Preserving non-read-only properties' {
+        It 'Should preserve displayName and description' {
+            $obj = [PSCustomObject]@{
+                id          = 'abc-123'
+                displayName = 'My Policy'
+                description = 'Important policy'
+            }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.displayName | Should -Be 'My Policy'
+            $obj.description | Should -Be 'Important policy'
+        }
+
+        It 'Should preserve custom properties' {
+            $obj = [PSCustomObject]@{
+                id         = 'abc-123'
+                customProp = 'value'
+                '@odata.type' = '#microsoft.graph.policy'
+            }
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj.customProp | Should -Be 'value'
+            $obj.'@odata.type' | Should -Be '#microsoft.graph.policy'
+        }
+    }
+
+    Context 'AdditionalProperties parameter' {
+        It 'Should remove additional specified properties' {
+            $obj = [PSCustomObject]@{
+                id               = 'abc-123'
+                displayName      = 'Test'
+                roleScopeTagIds  = @('0')
+                settingCount     = 5
+            }
+            Remove-ReadOnlyGraphProperties -InputObject $obj -AdditionalProperties @('roleScopeTagIds', 'settingCount')
+            $obj.PSObject.Properties['roleScopeTagIds'] | Should -BeNullOrEmpty
+            $obj.PSObject.Properties['settingCount'] | Should -BeNullOrEmpty
+            $obj.displayName | Should -Be 'Test'
+        }
+
+        It 'Should remove both core and additional properties' {
+            $obj = [PSCustomObject]@{
+                id          = 'abc-123'
+                displayName = 'Test'
+                customField = 'remove me'
+            }
+            Remove-ReadOnlyGraphProperties -InputObject $obj -AdditionalProperties @('customField')
+            $obj.PSObject.Properties['id'] | Should -BeNullOrEmpty
+            $obj.PSObject.Properties['customField'] | Should -BeNullOrEmpty
+            $obj.displayName | Should -Be 'Test'
+        }
+    }
+
+    Context 'Properties that do not exist' {
+        It 'Should not error when properties are missing from object' {
+            $obj = [PSCustomObject]@{ displayName = 'Test' }
+            { Remove-ReadOnlyGraphProperties -InputObject $obj } | Should -Not -Throw
+        }
+
+        It 'Should not error when additional properties are missing' {
+            $obj = [PSCustomObject]@{ displayName = 'Test' }
+            { Remove-ReadOnlyGraphProperties -InputObject $obj -AdditionalProperties @('nonExistent') } | Should -Not -Throw
+        }
+    }
+
+    Context 'In-place modification' {
+        It 'Should modify the original object (not return a copy)' {
+            $obj = [PSCustomObject]@{ id = 'abc-123'; displayName = 'Test' }
+            $originalRef = $obj
+            Remove-ReadOnlyGraphProperties -InputObject $obj
+            $obj | Should -Be $originalRef
+            $obj.PSObject.Properties['id'] | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Private/Test-ConditionalAccessPolicyRequiresP2.Tests.ps1
+++ b/Tests/Private/Test-ConditionalAccessPolicyRequiresP2.Tests.ps1
@@ -1,0 +1,184 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Test-ConditionalAccessPolicyRequiresP2.ps1'
+    . $functionPath
+}
+
+Describe 'Test-ConditionalAccessPolicyRequiresP2' {
+    Context 'signInRiskLevels' {
+        It 'Should return $true when signInRiskLevels has items' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    signInRiskLevels = @('high', 'medium')
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $false when signInRiskLevels is empty array' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    signInRiskLevels = @()
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+    }
+
+    Context 'userRiskLevels' {
+        It 'Should return $true when userRiskLevels has items' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    userRiskLevels = @('high')
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $false when userRiskLevels is empty array' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    userRiskLevels = @()
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+    }
+
+    Context 'insiderRiskLevels' {
+        It 'Should return $true when insiderRiskLevels is a non-null string' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    insiderRiskLevels = 'elevated'
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $false when insiderRiskLevels is "null" string' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    insiderRiskLevels = 'null'
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+
+        It 'Should return $false when insiderRiskLevels is empty string' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    insiderRiskLevels = ''
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+    }
+
+    Context 'agentIdRiskLevels' {
+        It 'Should return $true when agentIdRiskLevels is an array with items' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    agentIdRiskLevels = @('high')
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $true when agentIdRiskLevels is a non-empty string' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    agentIdRiskLevels = 'high'
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $false when agentIdRiskLevels is empty array' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    agentIdRiskLevels = @()
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+    }
+
+    Context 'servicePrincipalRiskLevels' {
+        It 'Should return $true when servicePrincipalRiskLevels is an array with items' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    servicePrincipalRiskLevels = @('medium', 'high')
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $true when servicePrincipalRiskLevels is a non-empty string' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    servicePrincipalRiskLevels = 'high'
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeTrue
+        }
+
+        It 'Should return $false when servicePrincipalRiskLevels is empty array' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    servicePrincipalRiskLevels = @()
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+    }
+
+    Context 'No conditions or no risk levels' {
+        It 'Should return $false when conditions is missing' {
+            $policy = [PSCustomObject]@{ displayName = 'Basic Policy' }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+
+        It 'Should return $false when no risk levels are set' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{ includeApplications = @('All') }
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+
+        It 'Should return $false when all risk level arrays are empty' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    signInRiskLevels           = @()
+                    userRiskLevels             = @()
+                    agentIdRiskLevels          = @()
+                    servicePrincipalRiskLevels = @()
+                }
+            }
+            Test-ConditionalAccessPolicyRequiresP2 -Policy $policy | Should -BeFalse
+        }
+    }
+
+    Context 'Return type' {
+        It 'Should return a boolean' -TestCases @(
+            @{
+                Policy = [PSCustomObject]@{
+                    conditions = [PSCustomObject]@{ signInRiskLevels = @('high') }
+                }
+                Expected = $true
+            }
+            @{
+                Policy = [PSCustomObject]@{
+                    conditions = [PSCustomObject]@{ signInRiskLevels = @() }
+                }
+                Expected = $false
+            }
+        ) {
+            $result = Test-ConditionalAccessPolicyRequiresP2 -Policy $Policy
+            $result | Should -BeOfType [bool]
+            $result | Should -Be $Expected
+        }
+    }
+}

--- a/Tests/Private/Test-ConditionalAccessPolicyRequiresPreview.Tests.ps1
+++ b/Tests/Private/Test-ConditionalAccessPolicyRequiresPreview.Tests.ps1
@@ -1,0 +1,105 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\Test-ConditionalAccessPolicyRequiresPreview.ps1'
+    . $functionPath
+}
+
+Describe 'Test-ConditionalAccessPolicyRequiresPreview' {
+    Context 'AccountRecovery user action' {
+        It 'Should return "AccountRecovery" when includeUserActions contains accountrecovery' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeUserActions = @('urn:user:accountrecovery')
+                    }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -Be 'AccountRecovery'
+        }
+
+        It 'Should return "AccountRecovery" when accountrecovery is among multiple actions' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeUserActions = @(
+                            'urn:user:registersecurityinfo',
+                            'urn:user:accountrecovery'
+                        )
+                    }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -Be 'AccountRecovery'
+        }
+    }
+
+    Context 'No preview features required' {
+        It 'Should return $null when no user actions are defined' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeApplications = @('All')
+                    }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null when user actions do not include accountrecovery' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeUserActions = @('urn:user:registersecurityinfo')
+                    }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null when conditions is missing' {
+            $policy = [PSCustomObject]@{ displayName = 'Simple Policy' }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null when applications is missing from conditions' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    users = [PSCustomObject]@{ includeUsers = @('All') }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null when includeUserActions is empty' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeUserActions = @()
+                    }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Return type' {
+        It 'Should return a string when preview is required' {
+            $policy = [PSCustomObject]@{
+                conditions = [PSCustomObject]@{
+                    applications = [PSCustomObject]@{
+                        includeUserActions = @('urn:user:accountrecovery')
+                    }
+                }
+            }
+            $result = Test-ConditionalAccessPolicyRequiresPreview -Policy $policy
+            $result | Should -BeOfType [string]
+        }
+    }
+}

--- a/Tests/Public/Import-IntuneAppProtectionPolicy.Tests.ps1
+++ b/Tests/Public/Import-IntuneAppProtectionPolicy.Tests.ps1
@@ -1,0 +1,268 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+}
+
+AfterAll {
+    Remove-Module IntuneHydrationKit -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Import-IntuneAppProtectionPolicy' {
+    BeforeAll {
+        # Catch-all mock prevents real Graph API calls (which would hang on auth)
+        Mock Invoke-MgGraphRequest { return @{ value = @() } } -ModuleName IntuneHydrationKit
+        Mock Write-HydrationLog -ModuleName IntuneHydrationKit
+        Mock Get-GraphErrorMessage { return "Test error message" } -ModuleName IntuneHydrationKit
+        Mock Test-HydrationKitObject { return $true } -ModuleName IntuneHydrationKit
+    }
+
+    Context 'Parameter Validation' {
+        It 'Should have TemplatePath parameter' {
+            $command = Get-Command Import-IntuneAppProtectionPolicy
+            $param = $command.Parameters['TemplatePath']
+
+            $param | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Platform parameter with ValidateSet' {
+            $command = Get-Command Import-IntuneAppProtectionPolicy
+            $param = $command.Parameters['Platform']
+
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet.ValidValues | Should -Contain 'iOS'
+            $validateSet.ValidValues | Should -Contain 'Android'
+            $validateSet.ValidValues | Should -Contain 'All'
+        }
+
+        It 'Should support ShouldProcess' {
+            $command = Get-Command Import-IntuneAppProtectionPolicy
+            $cmdletBinding = $command.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+
+            $cmdletBinding.SupportsShouldProcess | Should -Be $true
+        }
+
+        It 'Should have RemoveExisting switch parameter' {
+            $command = Get-Command Import-IntuneAppProtectionPolicy
+            $param = $command.Parameters['RemoveExisting']
+
+            $param | Should -Not -BeNullOrEmpty
+            $param.ParameterType | Should -Be ([switch])
+        }
+    }
+
+    Context 'Template Loading' {
+        It 'Should return empty array when template directory does not exist' {
+            $result = Import-IntuneAppProtectionPolicy -TemplatePath 'TestDrive:\NonExistent'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return empty array when no templates found' {
+            New-Item -Path 'TestDrive:\EmptyAppProtection' -ItemType Directory -Force | Out-Null
+
+            Mock Get-FilteredTemplates { @() } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneAppProtectionPolicy -TemplatePath 'TestDrive:\EmptyAppProtection'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Create Mode - Android Policy' {
+        BeforeEach {
+            Mock Get-FilteredTemplates {
+                @([PSCustomObject]@{
+                        FullName = 'TestPath\Android-AppProtection.json'
+                        Name     = 'Android-AppProtection.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-Content {
+                @'
+{
+    "@odata.type": "#microsoft.graph.androidManagedAppProtection",
+    "displayName": "Android MAM Policy",
+    "description": "Test Android app protection"
+}
+'@
+            } -ModuleName IntuneHydrationKit
+
+            Mock Copy-DeepObject {
+                param($InputObject)
+                return $InputObject
+            } -ModuleName IntuneHydrationKit
+
+            Mock Remove-ReadOnlyGraphProperties -ModuleName IntuneHydrationKit
+            Mock New-HydrationDescription { return "Imported by Intune Hydration Kit" } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should skip policy if it already exists and is tagged' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET') {
+                    return @{ value = @(@{
+                                id          = 'existing-id'
+                                displayName = '[IHD] Android MAM Policy'
+                                description = 'Imported by Intune Hydration Kit'
+                            }) }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneAppProtectionPolicy
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' })
+            $skipped.Count | Should -BeGreaterOrEqual 1
+        }
+
+        It 'Should create policy when it does not exist' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET') { return @{ value = @() } }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-GraphBatchOperation {
+                return @([PSCustomObject]@{ Name = '[IHD] Android MAM Policy'; Type = 'AppProtection'; Action = 'Created'; Status = 'Success' })
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneAppProtectionPolicy
+
+            $created = @($result | Where-Object { $_.Action -eq 'Created' })
+            $created.Count | Should -Be 1
+            Should -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit
+        }
+    }
+
+    Context 'WhatIf Support' {
+        BeforeEach {
+            Mock Get-FilteredTemplates {
+                @([PSCustomObject]@{ FullName = 'TestPath\iOS-AppProtection.json'; Name = 'iOS-AppProtection.json' })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-Content {
+                '{"@odata.type": "#microsoft.graph.iosManagedAppProtection", "displayName": "iOS MAM Policy", "description": ""}'
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method)
+                if ($Method -eq 'GET') { return @{ value = @() } }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Copy-DeepObject { param($InputObject) return $InputObject } -ModuleName IntuneHydrationKit
+            Mock Remove-ReadOnlyGraphProperties -ModuleName IntuneHydrationKit
+            Mock New-HydrationDescription { return "Imported by Intune Hydration Kit" } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should return WouldCreate action when WhatIf is specified' {
+            $result = Import-IntuneAppProtectionPolicy -WhatIf
+
+            $result | Should -Not -BeNullOrEmpty
+            $result[0].Action | Should -Be 'WouldCreate'
+        }
+
+        It 'Should not call batch operation when WhatIf is specified' {
+            Mock Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit
+
+            Import-IntuneAppProtectionPolicy -WhatIf
+
+            Should -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit -Times 0
+        }
+    }
+
+    Context 'Delete Mode' {
+        BeforeAll {
+            Mock Get-FilteredTemplates {
+                @([PSCustomObject]@{ FullName = 'TestPath\Android-AppProtection.json'; Name = 'Android-AppProtection.json' })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-Content {
+                '{"@odata.type": "#microsoft.graph.androidManagedAppProtection", "displayName": "Test Policy"}'
+            } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should only delete policies with hydration marker and matching template names' {
+            Mock Test-HydrationKitObject {
+                param($Description, $ObjectName)
+                return $Description -like '*Imported by Intune Hydration Kit*'
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-TemplateDisplayNames {
+                $hashSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                $hashSet.Add('Test Policy') | Out-Null
+                return $hashSet
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET') {
+                    return @{
+                        value = @(
+                            @{ id = 'policy-1'; displayName = '[IHD] Test Policy'; description = 'Imported by Intune Hydration Kit' },
+                            @{ id = 'policy-2'; displayName = 'Manual Policy'; description = 'Created manually' }
+                        )
+                    }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-GraphBatchOperation {
+                return @([PSCustomObject]@{ Name = '[IHD] Test Policy'; Type = 'AppProtection'; Action = 'Deleted'; Status = 'Success' })
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneAppProtectionPolicy -RemoveExisting -Confirm:$false
+
+            $deleted = @($result | Where-Object { $_.Action -eq 'Deleted' })
+            $deleted.Count | Should -Be 1
+            $deleted[0].Name | Should -Be '[IHD] Test Policy'
+        }
+
+        It 'Should return WouldDelete in WhatIf mode' {
+            Mock Test-HydrationKitObject { return $true } -ModuleName IntuneHydrationKit
+
+            Mock Get-TemplateDisplayNames {
+                $hashSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                $hashSet.Add('Test Policy') | Out-Null
+                return $hashSet
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method)
+                if ($Method -eq 'GET') {
+                    return @{
+                        value = @(
+                            @{ id = 'policy-1'; displayName = '[IHD] Test Policy'; description = 'Imported by Intune Hydration Kit' }
+                        )
+                    }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneAppProtectionPolicy -RemoveExisting -WhatIf
+
+            $wouldDelete = @($result | Where-Object { $_.Action -eq 'WouldDelete' })
+            $wouldDelete.Count | Should -Be 1
+        }
+    }
+
+    Context 'Error Handling' {
+        BeforeEach {
+            Mock Get-FilteredTemplates {
+                @([PSCustomObject]@{ FullName = 'TestPath\Android-Bad.json'; Name = 'Android-Bad.json' })
+            } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should handle template with missing displayName or @odata.type' {
+            Mock Get-Content { '{"description": "missing required fields"}' } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method)
+                if ($Method -eq 'GET') { return @{ value = @() } }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneAppProtectionPolicy
+
+            $failed = @($result | Where-Object { $_.Action -eq 'Failed' })
+            $failed.Count | Should -Be 1
+            $failed[0].Status | Should -BeLike '*Missing displayName*'
+        }
+    }
+}

--- a/Tests/Public/Import-IntuneBaseline.Tests.ps1
+++ b/Tests/Public/Import-IntuneBaseline.Tests.ps1
@@ -1,0 +1,311 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+}
+
+AfterAll {
+    Remove-Module IntuneHydrationKit -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Import-IntuneBaseline' {
+    BeforeAll {
+        # Catch-all mock prevents real Graph API calls (which would hang on auth)
+        Mock Invoke-MgGraphRequest { return @{ value = @() } } -ModuleName IntuneHydrationKit
+        Mock Write-HydrationLog -ModuleName IntuneHydrationKit
+        Mock Get-GraphErrorMessage { return "Test error message" } -ModuleName IntuneHydrationKit
+        Mock Test-HydrationKitObject { return $true } -ModuleName IntuneHydrationKit
+        Mock New-HydrationDescription { return "Imported by Intune Hydration Kit" } -ModuleName IntuneHydrationKit
+    }
+
+    Context 'Parameter Validation' {
+        It 'Should have BaselinePath parameter' {
+            $command = Get-Command Import-IntuneBaseline
+            $param = $command.Parameters['BaselinePath']
+
+            $param | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Platform parameter with ValidateSet' {
+            $command = Get-Command Import-IntuneBaseline
+            $param = $command.Parameters['Platform']
+
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet.ValidValues | Should -Contain 'Windows'
+            $validateSet.ValidValues | Should -Contain 'macOS'
+            $validateSet.ValidValues | Should -Contain 'iOS'
+            $validateSet.ValidValues | Should -Contain 'Android'
+            $validateSet.ValidValues | Should -Contain 'All'
+        }
+
+        It 'Should support ShouldProcess' {
+            $command = Get-Command Import-IntuneBaseline
+            $cmdletBinding = $command.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+
+            $cmdletBinding.SupportsShouldProcess | Should -Be $true
+        }
+
+        It 'Should have RemoveExisting switch parameter' {
+            $command = Get-Command Import-IntuneBaseline
+            $param = $command.Parameters['RemoveExisting']
+
+            $param | Should -Not -BeNullOrEmpty
+            $param.ParameterType | Should -Be ([switch])
+        }
+    }
+
+    Context 'Missing TenantId' {
+        It 'Should throw terminating error when TenantId is not provided and not connected' {
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = $null; Connected = $false }
+                $script:TemplatesPath = 'TestDrive:\Templates'
+            }
+
+            { Import-IntuneBaseline -ErrorAction Stop } | Should -Throw '*TenantId is required*'
+        }
+    }
+
+    Context 'Missing BaselinePath' {
+        It 'Should throw terminating error when baseline templates not found' {
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = '00000000-0000-0000-0000-000000000001'; Connected = $true }
+                $script:TemplatesPath = 'TestDrive:\NonExistent'
+                $script:ModuleRoot = 'TestDrive:\NonExistent'
+            }
+
+            # Mock Test-Path to return false for any OpenIntuneBaseline path resolution
+            Mock Test-Path {
+                return $false
+            } -ModuleName IntuneHydrationKit
+
+            { Import-IntuneBaseline -TenantId '00000000-0000-0000-0000-000000000001' -ErrorAction Stop } | Should -Throw '*not found*'
+        }
+    }
+
+    Context 'Platform Filtering' {
+        BeforeAll {
+            # Build folder structure for platform filtering test
+            $baseDir = Join-Path 'TestDrive:' 'BaselineTemplates'
+            New-Item -Path $baseDir -ItemType Directory -Force | Out-Null
+            foreach ($osDir in @('WINDOWS', 'MACOS', 'BYOD')) {
+                $imDir = Join-Path $baseDir "$osDir\IntuneManagement"
+                New-Item -Path $imDir -ItemType Directory -Force | Out-Null
+                $policyJson = @{
+                    '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration'
+                    displayName   = "$osDir Test Policy"
+                    description   = ''
+                } | ConvertTo-Json
+                Set-Content -Path (Join-Path $imDir 'TestPolicy.json') -Value $policyJson
+            }
+
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = '00000000-0000-0000-0000-000000000001'; Connected = $true }
+                $script:ImportPrefix = '[IHD] '
+            }
+
+            Mock Get-GraphPagedResults { return @() } -ModuleName IntuneHydrationKit
+            Mock Invoke-GraphBatchOperation { return @() } -ModuleName IntuneHydrationKit
+            Mock Copy-DeepObject { param($InputObject) return $InputObject } -ModuleName IntuneHydrationKit
+            Mock Remove-ReadOnlyGraphProperties -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should only process Windows folders when -Platform Windows' {
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'BaselineTemplates') -Platform Windows -TenantId '00000000-0000-0000-0000-000000000001'
+
+            $resultTypes = $result | ForEach-Object { $_.Type }
+            $resultTypes | Should -Not -Contain 'MACOS/IntuneManagement'
+            $resultTypes | Should -Not -Contain 'BYOD/IntuneManagement'
+        }
+    }
+
+    Context 'WhatIf Support' {
+        BeforeAll {
+            $baseDir = Join-Path 'TestDrive:' 'WhatIfBaseline'
+            $imDir = Join-Path $baseDir 'WINDOWS\IntuneManagement'
+            New-Item -Path $imDir -ItemType Directory -Force | Out-Null
+            $policyJson = @{
+                '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration'
+                displayName   = 'WhatIf Test Policy'
+                description   = ''
+            } | ConvertTo-Json
+            Set-Content -Path (Join-Path $imDir 'WhatIfPolicy.json') -Value $policyJson
+
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = '00000000-0000-0000-0000-000000000001'; Connected = $true }
+                $script:ImportPrefix = '[IHD] '
+            }
+
+            Mock Get-GraphPagedResults { return @() } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should return WouldCreate results without calling Graph' {
+            Mock Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'WhatIfBaseline') -Platform Windows -TenantId '00000000-0000-0000-0000-000000000001' -WhatIf
+
+            $result | Should -Not -BeNullOrEmpty
+            $result[0].Action | Should -Be 'WouldCreate'
+            Should -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit -Times 0
+        }
+    }
+
+    Context 'RemoveExisting Mode' {
+        BeforeAll {
+            $baseDir = Join-Path 'TestDrive:' 'DeleteBaseline'
+            $imDir = Join-Path $baseDir 'WINDOWS\IntuneManagement'
+            New-Item -Path $imDir -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $imDir 'Dummy.json') -Value '{}'
+
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = '00000000-0000-0000-0000-000000000001'; Connected = $true }
+                $script:ImportPrefix = '[IHD] '
+            }
+
+            Mock Get-TemplateDisplayNames {
+                $hashSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                $hashSet.Add('Test Policy') | Out-Null
+                return $hashSet
+            } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should delete tagged policies and return results' {
+            Mock Get-GraphPagedResults {
+                return @(
+                    @{ id = 'policy-1'; displayName = '[IHD] Test Policy'; description = 'Imported by Intune Hydration Kit' }
+                )
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-GraphBatchOperation {
+                return @([PSCustomObject]@{ Name = '[IHD] Test Policy'; Type = 'BaselinePolicy'; Action = 'Deleted'; Status = 'Success' })
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'DeleteBaseline') -RemoveExisting -TenantId '00000000-0000-0000-0000-000000000001' -Confirm:$false
+
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should return WouldDelete in WhatIf mode' {
+            Mock Get-GraphPagedResults {
+                return @(
+                    @{ id = 'policy-1'; displayName = '[IHD] Test Policy'; description = 'Imported by Intune Hydration Kit' }
+                )
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'DeleteBaseline') -RemoveExisting -TenantId '00000000-0000-0000-0000-000000000001' -WhatIf
+
+            $result | Should -Not -BeNullOrEmpty
+            $result[0].Action | Should -Be 'WouldDelete'
+        }
+
+        It 'Should skip policies not created by this kit' {
+            Mock Test-HydrationKitObject { return $false } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults {
+                return @(
+                    @{ id = 'policy-1'; displayName = 'Manual Policy'; description = 'Created manually' }
+                )
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'DeleteBaseline') -RemoveExisting -TenantId '00000000-0000-0000-0000-000000000001' -WhatIf
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'IntuneManagement Folder Routing' {
+        BeforeAll {
+            $baseDir = Join-Path 'TestDrive:' 'RoutingBaseline'
+            $imDir = Join-Path $baseDir 'WINDOWS\IntuneManagement'
+            New-Item -Path $imDir -ItemType Directory -Force | Out-Null
+            $policyJson = @{
+                '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration'
+                displayName   = 'Device Config Policy'
+                description   = 'Test device configuration'
+            } | ConvertTo-Json
+            Set-Content -Path (Join-Path $imDir 'DeviceConfig.json') -Value $policyJson
+
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = '00000000-0000-0000-0000-000000000001'; Connected = $true }
+                $script:ImportPrefix = '[IHD] '
+            }
+
+            Mock Get-GraphPagedResults { return @() } -ModuleName IntuneHydrationKit
+            Mock Copy-DeepObject { param($InputObject) return $InputObject } -ModuleName IntuneHydrationKit
+            Mock Remove-ReadOnlyGraphProperties -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should route IntuneManagement policies by @odata.type' {
+            Mock Invoke-GraphBatchOperation {
+                param($Items)
+                foreach ($item in $Items) {
+                    [PSCustomObject]@{ Name = $item.Name; Type = 'BaselinePolicy'; Action = 'Created'; Status = 'Success' }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'RoutingBaseline') -TenantId '00000000-0000-0000-0000-000000000001'
+
+            Should -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Items[0].Url -like '*/deviceConfigurations*'
+            }
+        }
+
+        It 'Should skip policy with unsupported @odata.type' {
+            $unsupportedDir = Join-Path 'TestDrive:' 'UnsupportedType\WINDOWS\IntuneManagement'
+            New-Item -Path $unsupportedDir -ItemType Directory -Force | Out-Null
+            $unsupportedJson = @{
+                '@odata.type' = '#microsoft.graph.unsupportedType'
+                displayName   = 'Unsupported Policy'
+            } | ConvertTo-Json
+            Set-Content -Path (Join-Path $unsupportedDir 'Unsupported.json') -Value $unsupportedJson
+
+            Mock Invoke-GraphBatchOperation { return @() } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'UnsupportedType') -TenantId '00000000-0000-0000-0000-000000000001'
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' })
+            $skipped.Count | Should -BeGreaterOrEqual 1
+            $skipped[0].Status | Should -BeLike '*Unsupported*'
+        }
+    }
+
+    Context 'Existing Policy Skip' {
+        BeforeAll {
+            $baseDir = Join-Path 'TestDrive:' 'SkipBaseline'
+            $imDir = Join-Path $baseDir 'WINDOWS\IntuneManagement'
+            New-Item -Path $imDir -ItemType Directory -Force | Out-Null
+            $policyJson = @{
+                '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration'
+                displayName   = 'Existing Policy'
+                description   = ''
+            } | ConvertTo-Json
+            Set-Content -Path (Join-Path $imDir 'Existing.json') -Value $policyJson
+
+            InModuleScope IntuneHydrationKit {
+                $script:HydrationState = @{ TenantId = '00000000-0000-0000-0000-000000000001'; Connected = $true }
+                $script:ImportPrefix = '[IHD] '
+            }
+
+            Mock Copy-DeepObject { param($InputObject) return $InputObject } -ModuleName IntuneHydrationKit
+            Mock Remove-ReadOnlyGraphProperties -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should skip policies that already exist in tenant' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(@{ displayName = '[IHD] Existing Policy'; id = 'existing-id' })
+                }
+                return @()
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-GraphBatchOperation { return @() } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneBaseline -BaselinePath (Join-Path 'TestDrive:' 'SkipBaseline') -TenantId '00000000-0000-0000-0000-000000000001'
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -eq 'Already exists' })
+            $skipped.Count | Should -BeGreaterOrEqual 1
+        }
+    }
+}

--- a/Tests/Public/Import-IntuneCompliancePolicy.Tests.ps1
+++ b/Tests/Public/Import-IntuneCompliancePolicy.Tests.ps1
@@ -147,11 +147,15 @@ Describe 'Import-IntuneCompliancePolicy' {
                 if ($Method -eq 'GET') {
                     return @{ value = @() }
                 }
-                if ($Method -eq 'POST') {
-                    # Verify the body contains the hydration marker
-                    $bodyObj = $Body | ConvertFrom-Json
-                    $bodyObj.description | Should -BeLike '*Imported by Intune Hydration Kit*'
-                    return @{ id = 'new-policy-id'; displayName = 'Windows 10 Compliance Policy' }
+                if ($Method -eq 'POST' -and $Uri -like '*$batch*') {
+                    # Body is a JSON batch envelope; verify the nested policy description
+                    $batchObj = $Body | ConvertFrom-Json
+                    $batchObj.requests[0].body.description | Should -BeLike '*Imported by Intune Hydration Kit*'
+                    return @{
+                        responses = @(
+                            @{ id = '1'; status = 201; body = @{ id = 'new-policy-id'; displayName = '[IHD] Windows 10 Compliance Policy' } }
+                        )
+                    }
                 }
             } -ModuleName IntuneHydrationKit
 

--- a/Tests/Public/Import-IntuneConditionalAccessPolicy.Tests.ps1
+++ b/Tests/Public/Import-IntuneConditionalAccessPolicy.Tests.ps1
@@ -1,0 +1,302 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+}
+
+AfterAll {
+    Remove-Module IntuneHydrationKit -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Import-IntuneConditionalAccessPolicy' {
+    BeforeAll {
+        # Catch-all mock prevents real Graph API calls (which would hang on auth)
+        Mock Invoke-MgGraphRequest { return @{ value = @() } } -ModuleName IntuneHydrationKit
+        Mock Write-HydrationLog -ModuleName IntuneHydrationKit
+        Mock Get-GraphErrorMessage { return "Test error message" } -ModuleName IntuneHydrationKit
+
+        InModuleScope IntuneHydrationKit {
+            $script:TemplatesPath = 'TestDrive:\Templates'
+            $script:ImportPrefix = '[IHD] '
+        }
+    }
+
+    Context 'Parameter Validation' {
+        It 'Should have TemplatePath parameter' {
+            $command = Get-Command Import-IntuneConditionalAccessPolicy
+            $param = $command.Parameters['TemplatePath']
+
+            $param | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Prefix parameter' {
+            $command = Get-Command Import-IntuneConditionalAccessPolicy
+            $param = $command.Parameters['Prefix']
+
+            $param | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should support ShouldProcess' {
+            $command = Get-Command Import-IntuneConditionalAccessPolicy
+            $cmdletBinding = $command.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+
+            $cmdletBinding.SupportsShouldProcess | Should -Be $true
+        }
+
+        It 'Should have RemoveExisting switch parameter' {
+            $command = Get-Command Import-IntuneConditionalAccessPolicy
+            $param = $command.Parameters['RemoveExisting']
+
+            $param | Should -Not -BeNullOrEmpty
+            $param.ParameterType | Should -Be ([switch])
+        }
+    }
+
+    Context 'Template Path Validation' {
+        It 'Should throw terminating error when template path not found' {
+            { Import-IntuneConditionalAccessPolicy -TemplatePath 'TestDrive:\NonExistent' -ErrorAction Stop } | Should -Throw '*not found*'
+        }
+    }
+
+    Context 'Create Mode' {
+        BeforeAll {
+            # Create template directory and files
+            $caDir = Join-Path 'TestDrive:' 'CATemplates'
+            New-Item -Path $caDir -ItemType Directory -Force | Out-Null
+            $caPolicy = @{
+                displayName   = 'Block Legacy Auth'
+                state         = 'enabled'
+                conditions    = @{ applications = @{ includeApplications = @('All') } }
+                grantControls = @{ operator = 'OR'; builtInControls = @('block') }
+            } | ConvertTo-Json -Depth 10
+            Set-Content -Path (Join-Path $caDir 'Block Legacy Auth.json') -Value $caPolicy
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'CATemplates\Block Legacy Auth.json')
+                        Name     = 'Block Legacy Auth.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-PremiumP2ServicePlans { return @('AAD_PREMIUM_P2', 'ENTRA_ID_GOVERNANCE') } -ModuleName IntuneHydrationKit
+            Mock Test-ConditionalAccessPolicyRequiresP2 { return $false } -ModuleName IntuneHydrationKit
+            Mock Test-ConditionalAccessPolicyRequiresPreview { return $null } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should force all policies to disabled state' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*subscribedSkus*') {
+                    return @{ value = @(@{ capabilityStatus = 'Enabled'; servicePlans = @(@{ servicePlanName = 'AAD_PREMIUM_P2'; provisioningStatus = 'Success' }) }) }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+
+            Mock Invoke-GraphBatchOperation {
+                param($Items)
+                foreach ($item in $Items) {
+                    $bodyObj = $item.BodyJson | ConvertFrom-Json
+                    $bodyObj.state | Should -Be 'disabled'
+                    [PSCustomObject]@{ Name = $item.Name; Type = 'ConditionalAccessPolicy'; Action = 'Created'; Status = 'Success' }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CATemplates')
+
+            $created = @($result | Where-Object { $_.Action -eq 'Created' })
+            $created.Count | Should -Be 1
+        }
+
+        It 'Should skip policy that already exists' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*subscribedSkus*') {
+                    return @{ value = @(@{ capabilityStatus = 'Enabled'; servicePlans = @(@{ servicePlanName = 'AAD_PREMIUM_P2'; provisioningStatus = 'Success' }) }) }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'existing-id'; displayName = '[IHD] Block Legacy Auth'; state = 'disabled' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CATemplates')
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -eq 'Already exists' })
+            $skipped.Count | Should -Be 1
+        }
+
+        It 'Should skip policies requiring P2 when no P2 license' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*subscribedSkus*') {
+                    return @{ value = @(@{ capabilityStatus = 'Enabled'; servicePlans = @(@{ servicePlanName = 'BASIC_PLAN'; provisioningStatus = 'Success' }) }) }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+
+            Mock Test-ConditionalAccessPolicyRequiresP2 { return $true } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CATemplates')
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -like '*Premium P2*' })
+            $skipped.Count | Should -Be 1
+        }
+
+        It 'Should skip policies requiring private preview features' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*subscribedSkus*') {
+                    return @{ value = @(@{ capabilityStatus = 'Enabled'; servicePlans = @(@{ servicePlanName = 'AAD_PREMIUM_P2'; provisioningStatus = 'Success' }) }) }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+
+            Mock Test-ConditionalAccessPolicyRequiresPreview { return 'networkAccess' } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CATemplates')
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -like '*preview*' })
+            $skipped.Count | Should -Be 1
+        }
+    }
+
+    Context 'WhatIf Support' {
+        BeforeAll {
+            $caDir = Join-Path 'TestDrive:' 'CAWhatIf'
+            New-Item -Path $caDir -ItemType Directory -Force | Out-Null
+            $caPolicy = @{
+                displayName   = 'Require MFA'
+                state         = 'enabled'
+                conditions    = @{ applications = @{ includeApplications = @('All') } }
+                grantControls = @{ operator = 'OR'; builtInControls = @('mfa') }
+            } | ConvertTo-Json -Depth 10
+            Set-Content -Path (Join-Path $caDir 'Require MFA.json') -Value $caPolicy
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'CAWhatIf\Require MFA.json')
+                        Name     = 'Require MFA.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-PremiumP2ServicePlans { return @('AAD_PREMIUM_P2') } -ModuleName IntuneHydrationKit
+            Mock Test-ConditionalAccessPolicyRequiresP2 { return $false } -ModuleName IntuneHydrationKit
+            Mock Test-ConditionalAccessPolicyRequiresPreview { return $null } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*subscribedSkus*') {
+                    return @{ value = @(@{ capabilityStatus = 'Enabled'; servicePlans = @(@{ servicePlanName = 'AAD_PREMIUM_P2'; provisioningStatus = 'Success' }) }) }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should return WouldCreate when WhatIf is specified' {
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CAWhatIf') -WhatIf
+
+            $result | Should -Not -BeNullOrEmpty
+            $result[0].Action | Should -Be 'WouldCreate'
+        }
+
+        It 'Should not call batch operation when WhatIf is specified' {
+            Mock Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit
+
+            Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CAWhatIf') -WhatIf
+
+            Should -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit -Times 0
+        }
+    }
+
+    Context 'Delete Mode' {
+        BeforeAll {
+            $caDir = Join-Path 'TestDrive:' 'CADelete'
+            New-Item -Path $caDir -ItemType Directory -Force | Out-Null
+            $caPolicy = @{
+                displayName   = 'Block Legacy Auth'
+                state         = 'disabled'
+                conditions    = @{ applications = @{ includeApplications = @('All') } }
+                grantControls = @{ operator = 'OR'; builtInControls = @('block') }
+            } | ConvertTo-Json -Depth 10
+            Set-Content -Path (Join-Path $caDir 'Block Legacy Auth.json') -Value $caPolicy
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'CADelete\Block Legacy Auth.json')
+                        Name     = 'Block Legacy Auth.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-PremiumP2ServicePlans { return @('AAD_PREMIUM_P2') } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*subscribedSkus*') {
+                    return @{ value = @(@{ capabilityStatus = 'Enabled'; servicePlans = @(@{ servicePlanName = 'AAD_PREMIUM_P2'; provisioningStatus = 'Success' }) }) }
+                }
+            } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should delete disabled policies matching template names' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'ca-1'; displayName = '[IHD] Block Legacy Auth'; state = 'disabled' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-GraphBatchOperation {
+                return @([PSCustomObject]@{ Name = '[IHD] Block Legacy Auth'; Type = 'ConditionalAccessPolicy'; Action = 'Deleted'; Status = 'Success' })
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CADelete') -RemoveExisting -Confirm:$false
+
+            $deleted = @($result | Where-Object { $_.Action -eq 'Deleted' })
+            $deleted.Count | Should -Be 1
+        }
+
+        It 'Should skip enabled policies during delete' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'ca-1'; displayName = '[IHD] Block Legacy Auth'; state = 'enabled' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CADelete') -RemoveExisting -Confirm:$false
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -like '*must be disabled*' })
+            $skipped.Count | Should -Be 1
+        }
+
+        It 'Should return WouldDelete in WhatIf mode' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'ca-1'; displayName = '[IHD] Block Legacy Auth'; state = 'disabled' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneConditionalAccessPolicy -TemplatePath (Join-Path 'TestDrive:' 'CADelete') -RemoveExisting -WhatIf
+
+            $wouldDelete = @($result | Where-Object { $_.Action -eq 'WouldDelete' })
+            $wouldDelete.Count | Should -Be 1
+        }
+    }
+}

--- a/Tests/Public/Import-IntuneEnrollmentProfile.Tests.ps1
+++ b/Tests/Public/Import-IntuneEnrollmentProfile.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'Import-IntuneEnrollmentProfile' {
                     return @{ value = @() }
                 }
                 if ($Method -eq 'POST') {
-                    $Body.deviceNameTemplate | Should -Be 'CORP-%SERIAL%'
+                    ($Body | ConvertFrom-Json).deviceNameTemplate | Should -Be 'CORP-%SERIAL%'
                     return @{ id = 'new-profile-id'; displayName = 'Default Autopilot Profile' }
                 }
             } -ModuleName IntuneHydrationKit
@@ -175,7 +175,7 @@ Describe 'Import-IntuneEnrollmentProfile' {
                     return @{ value = @() }
                 }
                 if ($Method -eq 'POST') {
-                    $Body.description | Should -BeLike '*Imported by Intune Hydration Kit*'
+                    ($Body | ConvertFrom-Json).description | Should -BeLike '*Imported by Intune Hydration Kit*'
                     return @{ id = 'new-profile-id'; displayName = 'Default Autopilot Profile' }
                 }
             } -ModuleName IntuneHydrationKit

--- a/Tests/Public/Import-IntuneNotificationTemplate.Tests.ps1
+++ b/Tests/Public/Import-IntuneNotificationTemplate.Tests.ps1
@@ -181,7 +181,11 @@ Describe 'Import-IntuneNotificationTemplate' {
                 param($Method, $Uri)
                 # Targeted GET fails → template was deleted (stale listing)
                 if ($Method -eq 'GET' -and $Uri -like '*notificationMessageTemplates/stale-id*') {
-                    throw [System.Net.Http.HttpRequestException]::new("Response status code does not indicate success: 404 (Not Found).")
+                    throw [System.Net.Http.HttpRequestException]::new(
+                        "Response status code does not indicate success: 404 (Not Found).",
+                        $null,
+                        [System.Net.HttpStatusCode]::NotFound
+                    )
                 }
                 if ($Method -eq 'POST' -and $Uri -like '*notificationMessageTemplates') {
                     return @{ id = 'new-id'; displayName = '[IHD] Compliance Reminder' }

--- a/Tests/Public/Import-IntuneNotificationTemplate.Tests.ps1
+++ b/Tests/Public/Import-IntuneNotificationTemplate.Tests.ps1
@@ -119,7 +119,7 @@ Describe 'Import-IntuneNotificationTemplate' {
             }
         }
 
-        It 'Should skip template that already exists' {
+        It 'Should skip template that already exists (verified by targeted GET)' {
             Mock Get-GraphPagedResults {
                 param($Uri, $ProcessItems)
                 if ($ProcessItems) {
@@ -129,13 +129,21 @@ Describe 'Import-IntuneNotificationTemplate' {
                 }
             } -ModuleName IntuneHydrationKit
 
+            # Targeted GET succeeds → template genuinely exists
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*notificationMessageTemplates/existing-id*') {
+                    return @{ id = 'existing-id'; displayName = '[IHD] Compliance Reminder' }
+                }
+            } -ModuleName IntuneHydrationKit
+
             $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifTemplates')
 
             $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -eq 'Already exists' })
             $skipped.Count | Should -Be 1
         }
 
-        It 'Should skip template matching legacy unprefixed name' {
+        It 'Should skip template matching legacy unprefixed name (verified by targeted GET)' {
             Mock Get-GraphPagedResults {
                 param($Uri, $ProcessItems)
                 if ($ProcessItems) {
@@ -145,10 +153,49 @@ Describe 'Import-IntuneNotificationTemplate' {
                 }
             } -ModuleName IntuneHydrationKit
 
+            # Targeted GET succeeds → legacy template genuinely exists
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'GET' -and $Uri -like '*notificationMessageTemplates/legacy-id*') {
+                    return @{ id = 'legacy-id'; displayName = 'Compliance Reminder' }
+                }
+            } -ModuleName IntuneHydrationKit
+
             $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifTemplates')
 
             $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -like '*legacy*' })
             $skipped.Count | Should -Be 1
+        }
+
+        It 'Should create template when prefetch returns stale data (targeted GET returns 404)' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'stale-id'; displayName = '[IHD] Compliance Reminder' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                # Targeted GET fails → template was deleted (stale listing)
+                if ($Method -eq 'GET' -and $Uri -like '*notificationMessageTemplates/stale-id*') {
+                    throw [System.Net.Http.HttpRequestException]::new("Response status code does not indicate success: 404 (Not Found).")
+                }
+                if ($Method -eq 'POST' -and $Uri -like '*notificationMessageTemplates') {
+                    return @{ id = 'new-id'; displayName = '[IHD] Compliance Reminder' }
+                }
+                if ($Method -eq 'POST' -and $Uri -like '*localizedNotificationMessages*') {
+                    return @{ id = 'locale-id' }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifTemplates')
+
+            $created = @($result | Where-Object { $_.Action -eq 'Created' })
+            $created.Count | Should -Be 1
+            $created[0].Name | Should -Be '[IHD] Compliance Reminder'
         }
     }
 

--- a/Tests/Public/Import-IntuneNotificationTemplate.Tests.ps1
+++ b/Tests/Public/Import-IntuneNotificationTemplate.Tests.ps1
@@ -1,0 +1,269 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+}
+
+AfterAll {
+    Remove-Module IntuneHydrationKit -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Import-IntuneNotificationTemplate' {
+    BeforeAll {
+        # Catch-all mock prevents real Graph API calls (which would hang on auth)
+        Mock Invoke-MgGraphRequest { return @{ value = @() } } -ModuleName IntuneHydrationKit
+        Mock Write-HydrationLog -ModuleName IntuneHydrationKit
+        Mock Get-GraphErrorMessage { return "Test error message" } -ModuleName IntuneHydrationKit
+
+        InModuleScope IntuneHydrationKit {
+            $script:TemplatesPath = 'TestDrive:\Templates'
+            $script:ImportPrefix = '[IHD] '
+        }
+    }
+
+    Context 'Parameter Validation' {
+        It 'Should have TemplatePath parameter' {
+            $command = Get-Command Import-IntuneNotificationTemplate
+            $param = $command.Parameters['TemplatePath']
+
+            $param | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should support ShouldProcess' {
+            $command = Get-Command Import-IntuneNotificationTemplate
+            $cmdletBinding = $command.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+
+            $cmdletBinding.SupportsShouldProcess | Should -Be $true
+        }
+
+        It 'Should have RemoveExisting switch parameter' {
+            $command = Get-Command Import-IntuneNotificationTemplate
+            $param = $command.Parameters['RemoveExisting']
+
+            $param | Should -Not -BeNullOrEmpty
+            $param.ParameterType | Should -Be ([switch])
+        }
+    }
+
+    Context 'Template Loading' {
+        It 'Should return empty array when template directory does not exist' {
+            $result = Import-IntuneNotificationTemplate -TemplatePath 'TestDrive:\NonExistent'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return empty array when no templates found' {
+            New-Item -Path 'TestDrive:\EmptyNotifications' -ItemType Directory -Force | Out-Null
+
+            Mock Get-HydrationTemplates { @() } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath 'TestDrive:\EmptyNotifications'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Create Mode' {
+        BeforeAll {
+            $notifDir = Join-Path 'TestDrive:' 'NotifTemplates'
+            New-Item -Path $notifDir -ItemType Directory -Force | Out-Null
+            $templateJson = @{
+                displayName       = 'Compliance Reminder'
+                brandingOptions   = 'includeCompanyLogo'
+                localizedMessages = @(
+                    @{
+                        locale          = 'en-us'
+                        subject         = 'Device Compliance Required'
+                        messageTemplate = 'Your device is not compliant.'
+                        isDefault       = $true
+                    }
+                )
+            } | ConvertTo-Json -Depth 10
+            Set-Content -Path (Join-Path $notifDir 'ComplianceReminder.json') -Value $templateJson
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'NotifTemplates\ComplianceReminder.json')
+                        Name     = 'ComplianceReminder.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Copy-DeepObject {
+                param($InputObject)
+                return $InputObject
+            } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should create notification template and localized messages' {
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'POST' -and $Uri -like '*notificationMessageTemplates') {
+                    return @{ id = 'new-template-id'; displayName = '[IHD] Compliance Reminder' }
+                }
+                if ($Method -eq 'POST' -and $Uri -like '*localizedNotificationMessages*') {
+                    return @{ id = 'locale-id' }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifTemplates')
+
+            $created = @($result | Where-Object { $_.Action -eq 'Created' })
+            $created.Count | Should -Be 1
+            $created[0].Name | Should -Be '[IHD] Compliance Reminder'
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'POST' -and $Uri -like '*localizedNotificationMessages*'
+            }
+        }
+
+        It 'Should skip template that already exists' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'existing-id'; displayName = '[IHD] Compliance Reminder' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifTemplates')
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -eq 'Already exists' })
+            $skipped.Count | Should -Be 1
+        }
+
+        It 'Should skip template matching legacy unprefixed name' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'legacy-id'; displayName = 'Compliance Reminder' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifTemplates')
+
+            $skipped = @($result | Where-Object { $_.Action -eq 'Skipped' -and $_.Status -like '*legacy*' })
+            $skipped.Count | Should -Be 1
+        }
+    }
+
+    Context 'WhatIf Support' {
+        BeforeAll {
+            $notifDir = Join-Path 'TestDrive:' 'NotifWhatIf'
+            New-Item -Path $notifDir -ItemType Directory -Force | Out-Null
+            $templateJson = @{
+                displayName     = 'WhatIf Template'
+                brandingOptions = 'includeCompanyLogo'
+            } | ConvertTo-Json -Depth 10
+            Set-Content -Path (Join-Path $notifDir 'WhatIfTemplate.json') -Value $templateJson
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'NotifWhatIf\WhatIfTemplate.json')
+                        Name     = 'WhatIfTemplate.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+            Mock Copy-DeepObject { param($InputObject) return $InputObject } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should return WouldCreate without calling Graph POST' {
+            Mock Invoke-MgGraphRequest -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifWhatIf') -WhatIf
+
+            $result | Should -Not -BeNullOrEmpty
+            $result[0].Action | Should -Be 'WouldCreate'
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'POST'
+            } -Times 0
+        }
+    }
+
+    Context 'Delete Mode' {
+        BeforeAll {
+            $notifDir = Join-Path 'TestDrive:' 'NotifDelete'
+            New-Item -Path $notifDir -ItemType Directory -Force | Out-Null
+            $templateJson = @{
+                displayName     = 'Delete Template'
+                brandingOptions = 'includeCompanyLogo'
+            } | ConvertTo-Json -Depth 10
+            Set-Content -Path (Join-Path $notifDir 'DeleteTemplate.json') -Value $templateJson
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'NotifDelete\DeleteTemplate.json')
+                        Name     = 'DeleteTemplate.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should delete templates matching template file names' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'tmpl-1'; displayName = '[IHD] Delete Template' },
+                        @{ id = 'tmpl-2'; displayName = 'Unrelated Template' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri)
+                if ($Method -eq 'DELETE') { return $null }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifDelete') -RemoveExisting -Confirm:$false
+
+            $deleted = @($result | Where-Object { $_.Action -eq 'Deleted' })
+            $deleted.Count | Should -Be 1
+            $deleted[0].Name | Should -Be '[IHD] Delete Template'
+        }
+
+        It 'Should return WouldDelete in WhatIf mode' {
+            Mock Get-GraphPagedResults {
+                param($Uri, $ProcessItems)
+                if ($ProcessItems) {
+                    & $ProcessItems @(
+                        @{ id = 'tmpl-1'; displayName = 'Delete Template' }
+                    )
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifDelete') -RemoveExisting -WhatIf
+
+            $wouldDelete = @($result | Where-Object { $_.Action -eq 'WouldDelete' })
+            $wouldDelete.Count | Should -Be 1
+        }
+    }
+
+    Context 'Error Handling' {
+        It 'Should handle missing displayName in template' {
+            $badDir = Join-Path 'TestDrive:' 'NotifBad'
+            New-Item -Path $badDir -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $badDir 'Bad.json') -Value '{"brandingOptions": "none"}'
+
+            Mock Get-HydrationTemplates {
+                @([PSCustomObject]@{
+                        FullName = (Join-Path 'TestDrive:' 'NotifBad\Bad.json')
+                        Name     = 'Bad.json'
+                    })
+            } -ModuleName IntuneHydrationKit
+
+            Mock Get-GraphPagedResults -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneNotificationTemplate -TemplatePath (Join-Path 'TestDrive:' 'NotifBad')
+
+            $failed = @($result | Where-Object { $_.Action -eq 'Failed' })
+            $failed.Count | Should -Be 1
+            $failed[0].Status | Should -BeLike '*Missing displayName*'
+        }
+    }
+}


### PR DESCRIPTION
- [x] Fix `Import-IntuneCompliancePolicy.ps1`: normalize `beta/` prefix to avoid `beta/beta/` double prefix
- [x] Fix `Import-IntuneNotificationTemplate.ps1`: only treat HTTP 404 as "not found"; re-throw 403/429/5xx
- [x] Fix `Import-IntuneEnrollmentProfile.ps1`: only treat HTTP 404 as "not found" in all three existence-check catch blocks (Autopilot, ESP, Device Prep)
- [x] Fix `Get-PremiumP2ServicePlans.Tests.ps1`: assert element type `[string]` (not array) to match `[string[]]` return contract
- [x] Fix `Import-IntuneCompliancePolicy.Tests.ps1`: batch body is a JSON string — parse nested `requests[0].body.description` and return proper batch response envelope
- [x] Fix `Import-IntuneEnrollmentProfile.Tests.ps1`: profile body is a JSON string — use `ConvertFrom-Json` before accessing `.deviceNameTemplate` / `.description`
- [x] All 649 tests pass