### PR TITLE
Add WinGet Win32 app import engine

### DIFF
--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -50,6 +50,7 @@
         'Import-IntuneDeviceFilter',
         'Import-IntuneConditionalAccessPolicy',
         'Import-IntuneMobileApp',
+        'Import-IntuneWinGetApp',
         # Helper functions
         'Initialize-HydrationLogging',
         'Write-HydrationLog',

--- a/IntuneHydrationKit.psm1
+++ b/IntuneHydrationKit.psm1
@@ -19,6 +19,9 @@ $script:HydrationState = @{
 $script:LogPath = $null
 $script:VerboseLogging = $false
 $script:CurrentLogFile = $null
+$script:HydrationSessionId = $null
+$script:GeneratedScriptsPath = $null
+$script:GeneratedScriptsNoticeWritten = $false
 
 # Module-level state for Graph environment
 $script:GraphEnvironment = $null
@@ -88,6 +91,7 @@ $publicFunctions = @(
     'Import-IntuneDeviceFilter',
     'Import-IntuneConditionalAccessPolicy',
     'Import-IntuneMobileApp',
+    'Import-IntuneWinGetApp',
     # Helper functions
     'Initialize-HydrationLogging',
     'Write-HydrationLog',

--- a/Private/Graph/ConvertFrom-GraphEscapedString.ps1
+++ b/Private/Graph/ConvertFrom-GraphEscapedString.ps1
@@ -1,0 +1,33 @@
+function ConvertFrom-GraphEscapedString {
+    <#
+    .SYNOPSIS
+        Converts escaped characters in Graph API error messages to readable text.
+    .DESCRIPTION
+        Handles unescaping of common escape sequences (\r\n, \n, \\, \") that appear in Graph API
+        error responses. Supports nested message format for inner JSON message extraction.
+    .PARAMETER Value
+        The escaped string to convert.
+    .PARAMETER NestedMessage
+        When true, uses less aggressive unescaping (skips \\ → \ conversion) for nested JSON messages.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]$Value,
+
+        [Parameter()]
+        [switch]$NestedMessage
+    )
+
+    # Base unescaping: always handle line endings and quotes
+    $unescaped = $Value -replace '\\r\\n', ' ' -replace '\\n', ' ' -replace '\\"', '"'
+
+    # Additional unescaping for non-nested messages (includes carriage return and backslash)
+    if (-not $NestedMessage) {
+        $unescaped = $unescaped -replace '\\r', ' ' -replace '\\\\', '\'
+    }
+
+    return $unescaped
+}

--- a/Private/Graph/ConvertFrom-GraphEscapedString.ps1
+++ b/Private/Graph/ConvertFrom-GraphEscapedString.ps1
@@ -26,7 +26,7 @@ function ConvertFrom-GraphEscapedString {
 
     # Additional unescaping for non-nested messages (includes carriage return and backslash)
     if (-not $NestedMessage) {
-        $unescaped = $unescaped -replace '\\r', ' ' -replace '\\\\', '\'
+        $unescaped = ($unescaped -replace '\\r', ' ').Replace('\\', '\')
     }
 
     return $unescaped

--- a/Private/Graph/Invoke-HydrationGraphRequest.ps1
+++ b/Private/Graph/Invoke-HydrationGraphRequest.ps1
@@ -1,0 +1,213 @@
+function Invoke-HydrationGraphRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('GET', 'POST', 'PUT', 'PATCH', 'DELETE')]
+        [string]$Method,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Uri,
+
+        [Parameter()]
+        [AllowNull()]
+        [object]$Body,
+
+        [Parameter()]
+        [string]$ContentType = 'application/json',
+
+        [Parameter()]
+        [int]$MaxRetries = 3,
+
+        [Parameter()]
+        [int]$RetryDelaySeconds = 2
+    )
+
+    function Resolve-GraphUri {
+        param(
+            [Parameter(Mandatory)]
+            [string]$RawUri
+        )
+
+        if ([string]::IsNullOrWhiteSpace($RawUri)) {
+            return $RawUri
+        }
+
+        if ($RawUri -match '^https?://') {
+            $graphEndpoint = if ($script:GraphEndpoint) {
+                $script:GraphEndpoint.TrimEnd('/')
+            } else {
+                'https://graph.microsoft.com'
+            }
+
+            if ($RawUri.StartsWith($graphEndpoint, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return ($RawUri.Substring($graphEndpoint.Length)).TrimStart('/')
+            }
+
+            return $RawUri
+        }
+
+        return $RawUri.TrimStart('/')
+    }
+
+    function Get-GraphUriForLogging {
+        param(
+            [Parameter(Mandatory)]
+            [string]$RawUri
+        )
+
+        $uriSegments = $RawUri -split '\?', 2
+        if ($uriSegments.Count -eq 1) {
+            return $uriSegments[0]
+        }
+
+        $queryKeys = foreach ($pair in ($uriSegments[1] -split '&')) {
+            if ([string]::IsNullOrWhiteSpace($pair)) {
+                continue
+            }
+
+            $queryPair = $pair -split '=', 2
+            '{0}=...' -f $queryPair[0]
+        }
+
+        return '{0}?{1}' -f $uriSegments[0], ($queryKeys -join '&')
+    }
+
+    function Get-GraphBodySummary {
+        param(
+            [Parameter()]
+            [AllowNull()]
+            [object]$Value,
+
+            [Parameter()]
+            [string]$ResolvedContentType
+        )
+
+        if ($null -eq $Value) {
+            return 'Body=None'
+        }
+
+        if ($Value -is [string]) {
+            return "Body=String(Length=$($Value.Length), ContentType='$ResolvedContentType')"
+        }
+
+        if ($Value -is [System.Collections.IDictionary]) {
+            $bodyKeys = @($Value.Keys)
+            return "Body=Dictionary(KeyCount=$($bodyKeys.Count), Keys='$((@($bodyKeys | Select-Object -First 8)) -join ', ')')"
+        }
+
+        $propertyNames = @($Value.PSObject.Properties.Name)
+        if ($propertyNames.Count -gt 0) {
+            return "Body=Object(Type='$($Value.GetType().FullName)', PropertyCount=$($propertyNames.Count), Properties='$((@($propertyNames | Select-Object -First 8)) -join ', ')')"
+        }
+
+        return "Body=Object(Type='$($Value.GetType().FullName)')"
+    }
+
+    function Get-RetryDelay {
+        param(
+            [Parameter(Mandatory)]
+            [System.Management.Automation.ErrorRecord]$ErrorRecord,
+
+            [Parameter(Mandatory)]
+            [int]$Attempt,
+
+            [Parameter(Mandatory)]
+            [int]$BaseDelaySeconds
+        )
+
+        $headerCandidates = @(
+            $ErrorRecord.Exception.ResponseHeaders,
+            $ErrorRecord.Exception.Response.Headers,
+            $ErrorRecord.Exception.Headers
+        )
+
+        foreach ($headers in $headerCandidates) {
+            if (-not $headers) {
+                continue
+            }
+
+            foreach ($headerName in @('Retry-After', 'retry-after')) {
+                $headerValue = $null
+                if ($headers -is [System.Collections.IDictionary] -and $headers.Contains($headerName)) {
+                    $headerValue = $headers[$headerName]
+                } elseif ($headers.PSObject -and $headers.PSObject.Properties[$headerName]) {
+                    $headerValue = $headers.$headerName
+                }
+
+                $parsedValue = 0
+                if ([int]::TryParse([string]$headerValue, [ref]$parsedValue) -and $parsedValue -gt 0) {
+                    return $parsedValue
+                }
+            }
+        }
+
+        return $BaseDelaySeconds * [Math]::Pow(2, $Attempt - 1)
+    }
+
+    function Resolve-GraphErrorRecord {
+        param(
+            [Parameter(Mandatory)]
+            [System.Management.Automation.ErrorRecord]$ErrorRecord
+        )
+
+        $candidateRecords = @(
+            $ErrorRecord,
+            $ErrorRecord.Exception.ErrorRecord,
+            $ErrorRecord.Exception.InnerException.ErrorRecord
+        )
+
+        foreach ($candidateRecord in $candidateRecords) {
+            if ($null -eq $candidateRecord) {
+                continue
+            }
+
+            $candidateStatusCode = Get-GraphStatusCode -ErrorRecord $candidateRecord
+            if ($candidateStatusCode) {
+                return $candidateRecord
+            }
+        }
+
+        return $ErrorRecord
+    }
+
+    $resolvedUri = Resolve-GraphUri -RawUri $Uri
+    $uriForLogging = Get-GraphUriForLogging -RawUri $resolvedUri
+    $invokeParams = @{
+        Method      = $Method
+        Uri         = $resolvedUri
+        ErrorAction = 'Stop'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Body')) {
+        if ($Body -is [string]) {
+            $invokeParams['Body'] = $Body
+            if ($ContentType) {
+                $invokeParams['ContentType'] = $ContentType
+            }
+        } else {
+            $invokeParams['Body'] = $Body
+        }
+    }
+
+    $bodySummary = Get-GraphBodySummary -Value $Body -ResolvedContentType $ContentType
+    Write-Debug "Invoking Graph request Method='$Method', Uri='$uriForLogging', $bodySummary."
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            return Invoke-MgGraphRequest @invokeParams
+        } catch {
+            $graphErrorRecord = Resolve-GraphErrorRecord -ErrorRecord $_
+            $statusCode = Get-GraphStatusCode -ErrorRecord $graphErrorRecord
+            $isRetryableStatusCode = $null -ne $statusCode -and ($statusCode -eq 429 -or ($statusCode -ge 500 -and $statusCode -lt 600))
+            Write-Debug "Graph request failed Method='$Method', Uri='$uriForLogging', StatusCode='$statusCode', Attempt=$attempt/$MaxRetries, Retryable=$isRetryableStatusCode, Error='$($_.Exception.Message)'."
+            if (-not $isRetryableStatusCode -or $attempt -eq $MaxRetries) {
+                throw
+            }
+
+            $delaySeconds = Get-RetryDelay -ErrorRecord $graphErrorRecord -Attempt $attempt -BaseDelaySeconds $RetryDelaySeconds
+            Write-Verbose "Graph request failed with HTTP $statusCode. Retrying in $delaySeconds second(s) (attempt $attempt of $MaxRetries)."
+            Start-Sleep -Seconds $delaySeconds
+        }
+    }
+}

--- a/Private/Graph/Limit-GraphMessage.ps1
+++ b/Private/Graph/Limit-GraphMessage.ps1
@@ -19,6 +19,7 @@ function Limit-GraphMessage {
         [string]$Message,
 
         [Parameter(Mandatory)]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]$MaximumLength
     )
 

--- a/Private/Graph/Limit-GraphMessage.ps1
+++ b/Private/Graph/Limit-GraphMessage.ps1
@@ -1,0 +1,34 @@
+function Limit-GraphMessage {
+    <#
+    .SYNOPSIS
+        Truncates a Graph error message to a maximum length.
+    .DESCRIPTION
+        Truncates a message string to the specified maximum length and appends ellipsis (...) if truncation occurs.
+        Returns the original message if it's shorter than or equal to MaximumLength.
+    .PARAMETER Message
+        The message to truncate.
+    .PARAMETER MaximumLength
+        The maximum allowed length for the output message.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Message,
+
+        [Parameter(Mandatory)]
+        [int]$MaximumLength
+    )
+
+    if ($null -eq $Message) {
+        return ''
+    }
+
+    if ($Message.Length -gt $MaximumLength) {
+        return $Message.Substring(0, $MaximumLength) + '...'
+    }
+
+    return $Message
+}

--- a/Private/Hydration/Add-HydrationDryRunResult.ps1
+++ b/Private/Hydration/Add-HydrationDryRunResult.ps1
@@ -1,0 +1,56 @@
+function Add-HydrationDryRunResult {
+    <#
+    .SYNOPSIS
+        Logs a dry-run action and returns a standardized hydration result.
+    .DESCRIPTION
+        Centralizes WhatIf output handling by emitting a consistent log message and
+        returning a New-HydrationResult object with Status='DryRun'.
+    .PARAMETER Action
+        Dry-run action to record. Valid values: WouldCreate, WouldUpdate, WouldDelete.
+    .PARAMETER Name
+        Resource display name.
+    .PARAMETER Type
+        Resource type label for the result object.
+    .PARAMETER Path
+        Optional template or source path.
+    .PARAMETER Id
+        Optional existing resource identifier.
+    .PARAMETER Platform
+        Optional platform label (Windows, macOS, iOS, Android, Linux).
+    .PARAMETER State
+        Optional resource state label.
+    .EXAMPLE
+        Add-HydrationDryRunResult -Action WouldDelete -Name '[IHD] Baseline Policy' -Type 'CompliancePolicy'
+    .OUTPUTS
+        PSCustomObject
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('WouldCreate', 'WouldUpdate', 'WouldDelete')]
+        [string]$Action,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$Type,
+
+        [Parameter()]
+        [string]$Path,
+
+        [Parameter()]
+        [string]$Id,
+
+        [Parameter()]
+        [string]$Platform,
+
+        [Parameter()]
+        [string]$State
+    )
+
+    Write-HydrationLog -Message "  ${Action}: $Name" -Level Info
+    return New-HydrationResult -Name $Name -Path $Path -Type $Type -Action $Action -Status 'DryRun' -Id $Id -Platform $Platform -State $State
+}

--- a/Private/Hydration/Add-HydrationStepResults.ps1
+++ b/Private/Hydration/Add-HydrationStepResults.ps1
@@ -1,0 +1,40 @@
+function Add-HydrationStepResults {
+    <#
+    .SYNOPSIS
+        Adds import step results to the results collection, surfacing nulls as warnings.
+    .DESCRIPTION
+        Iterates over step results and adds non-null items to $allResults.
+        Logs a warning for any null result so issues are surfaced instead of silently dropped.
+    .PARAMETER Results
+        Array reference to accumulate results into.
+    .PARAMETER StepResults
+        The results returned by the import step.
+    .PARAMETER StepName
+        Name of the step for warning messages.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ref]$Results,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [array]$StepResults,
+
+        [Parameter(Mandatory)]
+        [string]$StepName
+    )
+
+    if ($null -eq $StepResults) {
+        return
+    }
+
+    foreach ($result in $StepResults) {
+        if ($null -ne $result) {
+            $Results.Value += $result
+        } else {
+            Write-HydrationLog -Message "  Warning: $StepName step returned a null result object" -Level Warning
+        }
+    }
+}

--- a/Private/Hydration/Deduplicate-HydrationDeleteCandidates.ps1
+++ b/Private/Hydration/Deduplicate-HydrationDeleteCandidates.ps1
@@ -21,12 +21,14 @@ function Deduplicate-HydrationDeleteCandidates {
         [hashtable[]]$Candidates
     )
 
-    $deduplicated = @{}
+    $seenNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $deduplicated = [System.Collections.Generic.List[hashtable]]::new()
+
     foreach ($candidate in $Candidates) {
-        if (-not $deduplicated.ContainsKey($candidate.Name)) {
-            $deduplicated[$candidate.Name] = $candidate
+        if ($seenNames.Add([string]$candidate.Name)) {
+            $deduplicated.Add($candidate)
         }
     }
 
-    return @($deduplicated.Values)
+    return @($deduplicated)
 }

--- a/Private/Hydration/Deduplicate-HydrationDeleteCandidates.ps1
+++ b/Private/Hydration/Deduplicate-HydrationDeleteCandidates.ps1
@@ -1,0 +1,32 @@
+function Deduplicate-HydrationDeleteCandidates {
+    <#
+    .SYNOPSIS
+        Deduplicates delete candidate objects by name.
+    .DESCRIPTION
+        Removes duplicate delete candidate entries, keeping the first occurrence of each unique name.
+        Useful when multiple delete endpoints or queries may return the same resource.
+    .PARAMETER Candidates
+        Array of delete candidate objects with Name and Id properties.
+    .EXAMPLE
+        $deduped = Deduplicate-HydrationDeleteCandidates -Candidates $deleteCandidates
+
+        Returns only the first entry for each unique Name.
+    .OUTPUTS
+        hashtable[] containing deduplicated Name, Id, and Url for batch delete operations.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable[]])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable[]]$Candidates
+    )
+
+    $deduplicated = @{}
+    foreach ($candidate in $Candidates) {
+        if (-not $deduplicated.ContainsKey($candidate.Name)) {
+            $deduplicated[$candidate.Name] = $candidate
+        }
+    }
+
+    return @($deduplicated.Values)
+}

--- a/Private/Hydration/Save-HydrationGeneratedScript.ps1
+++ b/Private/Hydration/Save-HydrationGeneratedScript.ps1
@@ -36,7 +36,22 @@ function Save-HydrationGeneratedScript {
         New-Item -Path $script:GeneratedScriptsPath -ItemType Directory -Force -WhatIf:$false -ErrorAction Stop | Out-Null
     }
 
-    $destinationPath = Join-Path -Path $script:GeneratedScriptsPath -ChildPath $RelativePath
+    if ([System.IO.Path]::IsPathRooted($RelativePath)) {
+        throw 'RelativePath must not be rooted.'
+    }
+
+    $generatedScriptsRoot = [System.IO.Path]::GetFullPath($script:GeneratedScriptsPath)
+    $destinationPath = [System.IO.Path]::GetFullPath((Join-Path -Path $generatedScriptsRoot -ChildPath $RelativePath))
+    $rootWithSeparator = if ($generatedScriptsRoot.EndsWith([System.IO.Path]::DirectorySeparatorChar) -or $generatedScriptsRoot.EndsWith([System.IO.Path]::AltDirectorySeparatorChar)) {
+        $generatedScriptsRoot
+    } else {
+        $generatedScriptsRoot + [System.IO.Path]::DirectorySeparatorChar
+    }
+
+    if (-not $destinationPath.StartsWith($rootWithSeparator, [System.StringComparison]::Ordinal)) {
+        throw 'RelativePath must stay within the generated scripts directory.'
+    }
+
     $destinationDirectory = Split-Path -Path $destinationPath -Parent
     if (-not [string]::IsNullOrWhiteSpace($destinationDirectory) -and -not (Test-Path -LiteralPath $destinationDirectory)) {
         New-Item -Path $destinationDirectory -ItemType Directory -Force -WhatIf:$false -ErrorAction Stop | Out-Null

--- a/Private/Hydration/Save-HydrationGeneratedScript.ps1
+++ b/Private/Hydration/Save-HydrationGeneratedScript.ps1
@@ -1,0 +1,61 @@
+function Save-HydrationGeneratedScript {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RelativePath,
+
+        [Parameter()]
+        [AllowNull()]
+        [string]$Content,
+
+        [Parameter()]
+        [string]$SourcePath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RelativePath)) {
+        throw 'RelativePath is required.'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Content) -and [string]::IsNullOrWhiteSpace($SourcePath)) {
+        throw 'Either Content or SourcePath must be provided.'
+    }
+
+    if (-not $script:GeneratedScriptsPath) {
+        $sessionId = if ([string]::IsNullOrWhiteSpace($script:HydrationSessionId)) {
+            Get-Date -Format 'yyyyMMdd-HHmmss'
+        } else {
+            $script:HydrationSessionId
+        }
+
+        $tempBase = [System.IO.Path]::GetTempPath()
+        $script:GeneratedScriptsPath = Join-Path -Path $tempBase -ChildPath "IntuneHydrationKit/GeneratedScripts/$sessionId"
+    }
+
+    if (-not (Test-Path -LiteralPath $script:GeneratedScriptsPath)) {
+        New-Item -Path $script:GeneratedScriptsPath -ItemType Directory -Force -WhatIf:$false -ErrorAction Stop | Out-Null
+    }
+
+    $destinationPath = Join-Path -Path $script:GeneratedScriptsPath -ChildPath $RelativePath
+    $destinationDirectory = Split-Path -Path $destinationPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($destinationDirectory) -and -not (Test-Path -LiteralPath $destinationDirectory)) {
+        New-Item -Path $destinationDirectory -ItemType Directory -Force -WhatIf:$false -ErrorAction Stop | Out-Null
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($SourcePath)) {
+        if (-not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) {
+            throw "SourcePath must be an existing file: $SourcePath"
+        }
+
+        Copy-Item -LiteralPath $SourcePath -Destination $destinationPath -Force -WhatIf:$false -ErrorAction Stop
+    } else {
+        Set-Content -LiteralPath $destinationPath -Value $Content -Encoding utf8 -WhatIf:$false -ErrorAction Stop
+    }
+
+    if (-not $script:GeneratedScriptsNoticeWritten) {
+        Write-HydrationLog -Message "Generated PowerShell scripts saved to: $($script:GeneratedScriptsPath)" -Level Info
+        $script:GeneratedScriptsNoticeWritten = $true
+    }
+
+    return $destinationPath
+}

--- a/Private/MobileApps/Get-HydrationMobileAppDisplayName.ps1
+++ b/Private/MobileApps/Get-HydrationMobileAppDisplayName.ps1
@@ -1,0 +1,28 @@
+function Get-HydrationMobileAppDisplayName {
+    <#
+    .SYNOPSIS
+        Returns the Intune Hydration Kit display name for a mobile app.
+    .DESCRIPTION
+        Appends the mobile app identification suffix used by Intune Hydration Kit.
+        Existing suffixed names are returned unchanged so templates can safely be
+        processed more than once.
+    .PARAMETER DisplayName
+        The template display name to format.
+    .OUTPUTS
+        System.String
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$DisplayName
+    )
+
+    $suffix = ' - [IHD]'
+    if ([string]::IsNullOrWhiteSpace($DisplayName) -or $DisplayName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $DisplayName
+    }
+
+    return "$DisplayName$suffix"
+}

--- a/Private/MobileApps/Get-MobileAppImportConfiguration.ps1
+++ b/Private/MobileApps/Get-MobileAppImportConfiguration.ps1
@@ -1,0 +1,46 @@
+function Get-MobileAppImportConfiguration {
+    <#
+    .SYNOPSIS
+        Resolves mobile app import settings from the hydration settings hashtable.
+    .DESCRIPTION
+        Extracts presetId, templateIds, and remediation enabled flag from the
+        settings structure, applying sensible defaults and filtering blank values.
+    .PARAMETER Settings
+        The hydration settings hashtable.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Settings
+    )
+
+    $configuration = @{
+        presetId           = $null
+        templateIds        = @()
+        remediationEnabled = $true
+    }
+
+    $mobileApps = Get-ConfigurationSection -InputObject $Settings -Name 'mobileApps'
+    if ($mobileApps.Count -eq 0) {
+        return $configuration
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($mobileApps.presetId)) {
+        $configuration.presetId = [string]$mobileApps.presetId
+    }
+
+    if ($null -ne $mobileApps.templateIds) {
+        $configuration.templateIds = @(
+            $mobileApps.templateIds |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+    }
+
+    $remediation = Get-ConfigurationSection -InputObject $mobileApps -Name 'remediation'
+    if ($remediation.ContainsKey('enabled') -and $null -ne $remediation.enabled) {
+        $configuration.remediationEnabled = [bool]$remediation.enabled
+    }
+
+    return $configuration
+}

--- a/Private/MobileApps/Get-MobileAppTemplateNameSet.ps1
+++ b/Private/MobileApps/Get-MobileAppTemplateNameSet.ps1
@@ -1,0 +1,34 @@
+function Get-MobileAppTemplateNameSet {
+    <#
+    .SYNOPSIS
+        Builds a HashSet of display names from mobile app template files.
+    .DESCRIPTION
+        Reads each template file, extracts the displayName, applies the
+        hydration mobile-app display-name transformation (suffix), and
+        returns a case-insensitive HashSet of
+        the resulting names. Used for scoping deletion to known templates.
+    .PARAMETER TemplateFiles
+        Array of FileInfo objects representing the template files to read.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.HashSet[string]])]
+    param(
+        [Parameter(Mandatory)]
+        [System.IO.FileInfo[]]$TemplateFiles
+    )
+
+    $displayNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($templateFile in $TemplateFiles) {
+        try {
+            $template = Get-Content -Path $templateFile.FullName -Raw -Encoding utf8 | ConvertFrom-Json
+            if (-not [string]::IsNullOrWhiteSpace($template.displayName)) {
+                $templateDisplayName = [string]$template.displayName
+                [void]$displayNames.Add((Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName))
+            }
+        } catch {
+            Write-Verbose "Skipping template display-name lookup for '$($templateFile.FullName)': $($_.Exception.Message)"
+        }
+    }
+
+    return $displayNames
+}

--- a/Private/MobileApps/Test-IsWinGetTemplateFile.ps1
+++ b/Private/MobileApps/Test-IsWinGetTemplateFile.ps1
@@ -1,0 +1,34 @@
+function Test-IsWinGetTemplateFile {
+    <#
+    .SYNOPSIS
+        Tests whether a template file resides under a WinGet directory.
+    .DESCRIPTION
+        Walks up the directory tree from the template file to detect if any
+        parent directory is named 'WinGet'. Used to exclude WinGet-backed
+        templates from the generic mobile app import path.
+    .PARAMETER TemplateFile
+        The FileInfo object representing the template file to test.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [System.IO.FileInfo]$TemplateFile
+    )
+
+    $currentPath = $TemplateFile.DirectoryName
+    while (-not [string]::IsNullOrWhiteSpace($currentPath)) {
+        if ((Split-Path -Path $currentPath -Leaf) -eq 'WinGet') {
+            return $true
+        }
+
+        $parentPath = Split-Path -Path $currentPath -Parent
+        if ([string]::IsNullOrWhiteSpace($parentPath) -or $parentPath -eq $currentPath) {
+            break
+        }
+
+        $currentPath = $parentPath
+    }
+
+    return $false
+}

--- a/Private/Utilities/ConvertTo-HydrationBoolValue.ps1
+++ b/Private/Utilities/ConvertTo-HydrationBoolValue.ps1
@@ -1,0 +1,41 @@
+function ConvertTo-HydrationBoolValue {
+    <#
+    .SYNOPSIS
+        Normalizes an input value to a boolean.
+    .DESCRIPTION
+        Converts common string representations ('true', '1', 'yes', 'false', '0', 'no')
+        and raw booleans into a proper [bool]. Null values return $false.
+    .PARAMETER Value
+        The value to convert.
+    .OUTPUTS
+        [bool]
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [bool]) {
+        return $Value
+    }
+
+    $normalizedValue = ([string]$Value).Trim()
+    switch -Regex ($normalizedValue) {
+        '^(?i:true|1|yes)$' { return $true }
+        '^(?i:false|0|no)$' { return $false }
+        default {
+            if ($Value -is [string]) {
+                throw "Unsupported boolean string value: '$Value'"
+            }
+
+            return [bool]$Value
+        }
+    }
+}

--- a/Private/Utilities/Get-ConfigurationSection.ps1
+++ b/Private/Utilities/Get-ConfigurationSection.ps1
@@ -1,0 +1,29 @@
+function Get-ConfigurationSection {
+    <#
+    .SYNOPSIS
+        Gets a named section from a configuration hashtable.
+    .DESCRIPTION
+        Returns an empty hashtable when the requested section does not exist or is null.
+    .PARAMETER InputObject
+        Source configuration hashtable.
+    .PARAMETER Name
+        Section name to retrieve.
+    .OUTPUTS
+        object
+    #>
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if ($InputObject.ContainsKey($Name) -and $null -ne $InputObject[$Name]) {
+        return $InputObject[$Name]
+    }
+
+    return @{}
+}

--- a/Private/Utilities/Get-NormalizedArchitectures.ps1
+++ b/Private/Utilities/Get-NormalizedArchitectures.ps1
@@ -1,0 +1,14 @@
+function Get-NormalizedArchitectures {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter()]
+        [object[]]$Architecture
+    )
+
+    return @(
+        $Architecture |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object { [string]$_ }
+    )
+}

--- a/Private/Utilities/Get-PrimaryArchitecture.ps1
+++ b/Private/Utilities/Get-PrimaryArchitecture.ps1
@@ -1,0 +1,15 @@
+function Get-PrimaryArchitecture {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [object[]]$Architecture
+    )
+
+    $architectures = @(Get-NormalizedArchitectures -Architecture $Architecture)
+    if ($architectures.Count -eq 0) {
+        return 'All'
+    }
+
+    return $architectures[0]
+}

--- a/Private/Utilities/Get-RequirementArchitecture.ps1
+++ b/Private/Utilities/Get-RequirementArchitecture.ps1
@@ -1,0 +1,15 @@
+function Get-RequirementArchitecture {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [object[]]$Architecture
+    )
+
+    $architectures = @(Get-NormalizedArchitectures -Architecture $Architecture)
+    if ($architectures.Count -ne 1) {
+        return 'All'
+    }
+
+    return $architectures[0]
+}

--- a/Private/Utilities/Resolve-ApplicableArchitecture.ps1
+++ b/Private/Utilities/Resolve-ApplicableArchitecture.ps1
@@ -1,0 +1,34 @@
+function Resolve-ApplicableArchitecture {
+    <#
+    .SYNOPSIS
+        Resolves a requirement architecture value to a Graph payload value.
+    .DESCRIPTION
+        Returns `$null` for empty values or `All`; returns supported values unchanged.
+    .PARAMETER Architecture
+        Architecture value from configuration.
+    .OUTPUTS
+        string
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [string]$Architecture
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Architecture) -or $Architecture -eq 'All') {
+        return $null
+    }
+
+    $architectureMap = @{
+        'x64'   = 'x64'
+        'x86'   = 'x86'
+        'arm64' = 'arm64'
+    }
+
+    if ($architectureMap.ContainsKey($Architecture)) {
+        return $architectureMap[$Architecture]
+    }
+
+    return $null
+}

--- a/Private/Utilities/Resolve-MinimumSupportedOperatingSystem.ps1
+++ b/Private/Utilities/Resolve-MinimumSupportedOperatingSystem.ps1
@@ -1,0 +1,49 @@
+function Resolve-MinimumSupportedOperatingSystem {
+    <#
+    .SYNOPSIS
+        Maps Windows release labels to Graph minimum supported operating system payload keys.
+    .PARAMETER Release
+        The Windows release label (for example W10_22H2 or W11_24H2).
+    .OUTPUTS
+        hashtable
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]$Release
+    )
+
+    $releaseMap = @{
+        'W10_1607' = 'v10_1607'
+        'W10_1703' = 'v10_1703'
+        'W10_1709' = 'v10_1709'
+        'W10_1803' = 'v10_1803'
+        'W10_1809' = 'v10_1809'
+        'W10_1903' = 'v10_1903'
+        'W10_1909' = 'v10_1909'
+        'W10_2004' = 'v10_2004'
+        'W10_20H2' = 'v10_20H2'
+        'W10_21H1' = 'v10_21H1'
+        'W10_21H2' = 'v10_21H1'
+        'W10_22H2' = 'v10_21H1'
+        'W11_21H2' = 'v10_21H1'
+        'W11_22H2' = 'v10_21H1'
+        'W11_23H2' = 'v10_21H1'
+        'W11_24H2' = 'v10_21H1'
+    }
+
+    $resolvedRelease = if ([string]::IsNullOrWhiteSpace($Release)) {
+        'W10_1607'
+    } else {
+        $Release
+    }
+
+    $operatingSystemKey = if ($releaseMap.ContainsKey($resolvedRelease)) {
+        $releaseMap[$resolvedRelease]
+    } else {
+        'v10_1607'
+    }
+
+    return @{ $operatingSystemKey = $true }
+}

--- a/Private/Utilities/Test-HydrationNonEmptyArrayValue.ps1
+++ b/Private/Utilities/Test-HydrationNonEmptyArrayValue.ps1
@@ -1,0 +1,19 @@
+function Test-HydrationNonEmptyArrayValue {
+    <#
+    .SYNOPSIS
+        Checks whether a value is a non-empty array.
+    .PARAMETER Value
+        The value to evaluate.
+    .OUTPUTS
+        System.Boolean
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object]$Value
+    )
+
+    return $Value -is [array] -and $Value.Count -gt 0
+}

--- a/Private/Utilities/Test-HydrationNonEmptyStringValue.ps1
+++ b/Private/Utilities/Test-HydrationNonEmptyStringValue.ps1
@@ -1,0 +1,34 @@
+function Test-HydrationNonEmptyStringValue {
+    <#
+    .SYNOPSIS
+        Checks whether a value is a non-empty string.
+    .DESCRIPTION
+        Treats null, empty, whitespace-only strings, and the literal string 'null' as empty.
+    .PARAMETER Value
+        The value to evaluate.
+    .OUTPUTS
+        System.Boolean
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [array]) {
+        return $false
+    }
+
+    $stringValue = $Value.ToString()
+    if ([string]::IsNullOrWhiteSpace($stringValue)) {
+        return $false
+    }
+
+    return $stringValue -ne 'null'
+}

--- a/Private/WinGet/ConvertTo-IntuneWinDetectionRule.ps1
+++ b/Private/WinGet/ConvertTo-IntuneWinDetectionRule.ps1
@@ -1,0 +1,152 @@
+function ConvertTo-IntuneWinDetectionRule {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Rule,
+
+        [Parameter()]
+        [string]$ScriptRootPath
+    )
+
+    $ruleType = [string]($Rule.DetectionType ?? $Rule.Type)
+    switch ($ruleType) {
+        'MSI' {
+            return @{
+                '@odata.type'          = '#microsoft.graph.win32LobAppProductCodeRule'
+                ruleType               = 'detection'
+                productCode            = $Rule.ProductCode
+                productVersionOperator = ($Rule.ProductVersionOperator ?? 'notConfigured')
+                productVersion         = ($Rule.ProductVersion ?? '')
+            }
+        }
+        'Registry' {
+            $operationSource = [string]($Rule.RegistryDetectionType ?? $Rule.DetectionMethod ?? $Rule.DetectionType ?? 'existence')
+            $normalizedOperation = $operationSource.ToLowerInvariant()
+            $registryRule = @{
+                '@odata.type'        = '#microsoft.graph.win32LobAppRegistryRule'
+                ruleType             = 'detection'
+                keyPath              = $Rule.KeyPath
+                valueName            = $Rule.ValueName
+                check32BitOn64System = ConvertTo-HydrationBoolValue -Value ($Rule.Check32BitOn64System ?? $Rule.check32BitOn64System)
+            }
+
+            switch ($normalizedOperation) {
+                { $_ -in @('existence', 'exists') } {
+                    $registryRule.operationType = 'exists'
+                    $registryRule.operator = 'notConfigured'
+                    break
+                }
+                { $_ -in @('notexists', 'doesnotexist') } {
+                    $registryRule.operationType = 'doesNotExist'
+                    $registryRule.operator = 'notConfigured'
+                    break
+                }
+                { $_ -in @('versioncomparison', 'version') } {
+                    $registryRule.operationType = 'version'
+                    $registryRule.operator = ($Rule.Operator ?? 'greaterThanOrEqual')
+                    $registryRule.comparisonValue = ($Rule.Value ?? '')
+                    break
+                }
+                { $_ -in @('stringcomparison', 'string') } {
+                    $registryRule.operationType = 'string'
+                    $registryRule.operator = ($Rule.Operator ?? 'equal')
+                    $registryRule.comparisonValue = ($Rule.Value ?? '')
+                    break
+                }
+                { $_ -in @('integercomparison', 'integer') } {
+                    $registryRule.operationType = 'integer'
+                    $registryRule.operator = ($Rule.Operator ?? 'greaterThanOrEqual')
+                    $registryRule.comparisonValue = ($Rule.Value ?? '')
+                    break
+                }
+                default {
+                    throw "Unsupported registry detection method '$operationSource'."
+                }
+            }
+
+            return $registryRule
+        }
+        'File' {
+            $operationSource = [string]($Rule.FileDetectionType ?? $Rule.DetectionMethod ?? $Rule.DetectionType ?? 'exists')
+            $normalizedOperation = $operationSource.ToLowerInvariant()
+            $fileRule = @{
+                '@odata.type'        = '#microsoft.graph.win32LobAppFileSystemRule'
+                ruleType             = 'detection'
+                path                 = $Rule.Path
+                fileOrFolderName     = ($Rule.FileOrFolderName ?? $Rule.FileOrFolder)
+                check32BitOn64System = ConvertTo-HydrationBoolValue -Value ($Rule.Check32BitOn64System ?? $Rule.check32BitOn64System)
+            }
+
+            switch ($normalizedOperation) {
+                { $_ -in @('exists', 'existence') } {
+                    $fileRule.operationType = 'exists'
+                    $fileRule.operator = 'notConfigured'
+                    break
+                }
+                { $_ -in @('notexists', 'doesnotexist') } {
+                    $fileRule.operationType = 'doesNotExist'
+                    $fileRule.operator = 'notConfigured'
+                    break
+                }
+                { $_ -in @('versioncomparison', 'version') } {
+                    $fileRule.operationType = 'version'
+                    $fileRule.operator = ($Rule.Operator ?? 'greaterThanOrEqual')
+                    $fileRule.comparisonValue = ($Rule.VersionValue ?? $Rule.Value ?? '')
+                    break
+                }
+                { $_ -in @('stringcomparison', 'string') } {
+                    $fileRule.operationType = 'string'
+                    $fileRule.operator = ($Rule.Operator ?? 'equal')
+                    $fileRule.comparisonValue = ($Rule.Value ?? '')
+                    break
+                }
+                { $_ -in @('integercomparison', 'integer', 'sizeinmb', 'size') } {
+                    $fileRule.operationType = 'sizeInMB'
+                    $fileRule.operator = ($Rule.Operator ?? 'greaterThanOrEqual')
+                    $fileRule.comparisonValue = ($Rule.Value ?? '')
+                    break
+                }
+                default {
+                    throw "Unsupported file detection method '$operationSource'."
+                }
+            }
+
+            return $fileRule
+        }
+        'Script' {
+            $scriptFile = [string]$Rule.ScriptFile
+            if ([string]::IsNullOrWhiteSpace($ScriptRootPath)) {
+                throw "ScriptRootPath is required for script detection rule '$scriptFile'."
+            }
+
+            $scriptPath = Join-Path -Path $ScriptRootPath -ChildPath $scriptFile
+            $scriptContent = Get-Content -Path $scriptPath -Raw -ErrorAction Stop
+            $encodedScriptContent = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($scriptContent))
+            $scriptRule = @{
+                '@odata.type'         = '#microsoft.graph.win32LobAppPowerShellScriptRule'
+                ruleType              = 'detection'
+                scriptContent         = $encodedScriptContent
+                enforceSignatureCheck = ConvertTo-HydrationBoolValue -Value $Rule.EnforceSignatureCheck
+                runAs32Bit            = ConvertTo-HydrationBoolValue -Value $Rule.RunAs32Bit
+            }
+
+            if ($Rule.OperationType) {
+                $scriptRule.operationType = $Rule.OperationType
+            }
+
+            if ($Rule.Operator) {
+                $scriptRule.operator = $Rule.Operator
+            }
+
+            if ($null -ne $Rule.ComparisonValue) {
+                $scriptRule.comparisonValue = $Rule.ComparisonValue
+            }
+
+            return $scriptRule
+        }
+        default {
+            throw "Unsupported detection rule type '$ruleType'."
+        }
+    }
+}

--- a/Private/WinGet/ConvertTo-IntuneWinDetectionRule.ps1
+++ b/Private/WinGet/ConvertTo-IntuneWinDetectionRule.ps1
@@ -21,7 +21,7 @@ function ConvertTo-IntuneWinDetectionRule {
             }
         }
         'Registry' {
-            $operationSource = [string]($Rule.RegistryDetectionType ?? $Rule.DetectionMethod ?? $Rule.DetectionType ?? 'existence')
+            $operationSource = [string]($Rule.RegistryDetectionType ?? $Rule.DetectionMethod ?? 'existence')
             $normalizedOperation = $operationSource.ToLowerInvariant()
             $registryRule = @{
                 '@odata.type'        = '#microsoft.graph.win32LobAppRegistryRule'
@@ -68,7 +68,7 @@ function ConvertTo-IntuneWinDetectionRule {
             return $registryRule
         }
         'File' {
-            $operationSource = [string]($Rule.FileDetectionType ?? $Rule.DetectionMethod ?? $Rule.DetectionType ?? 'exists')
+            $operationSource = [string]($Rule.FileDetectionType ?? $Rule.DetectionMethod ?? 'exists')
             $normalizedOperation = $operationSource.ToLowerInvariant()
             $fileRule = @{
                 '@odata.type'        = '#microsoft.graph.win32LobAppFileSystemRule'

--- a/Private/WinGet/ConvertTo-IntuneWinRequirementRule.ps1
+++ b/Private/WinGet/ConvertTo-IntuneWinRequirementRule.ps1
@@ -1,0 +1,74 @@
+function ConvertTo-IntuneWinRequirementRule {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Rule,
+
+        [Parameter()]
+        [string]$ScriptRootPath
+    )
+
+    $ruleType = [string]($Rule.RequirementType ?? $Rule.Type)
+    switch ($ruleType) {
+        'Registry' {
+            return @{
+                '@odata.type'        = '#microsoft.graph.win32LobAppRegistryRequirement'
+                operator             = ($Rule.Operator ?? 'greaterThanOrEqual')
+                detectionValue       = ($Rule.Value ?? '')
+                keyPath              = $Rule.KeyPath
+                valueName            = $Rule.ValueName
+                check32BitOn64System = ConvertTo-HydrationBoolValue -Value ($Rule.Check32BitOn64System ?? $Rule.check32BitOn64System)
+                operationType        = ($Rule.OperationType ?? $Rule.DetectionMethod ?? 'version')
+            }
+        }
+        'File' {
+            $operationType = ($Rule.OperationType ?? $Rule.DetectionMethod ?? 'version')
+            return @{
+                '@odata.type'        = '#microsoft.graph.win32LobAppFileSystemRequirement'
+                operator             = ($Rule.Operator ?? 'greaterThanOrEqual')
+                detectionValue       = ($Rule.VersionValue ?? $Rule.Value ?? '')
+                path                 = $Rule.Path
+                fileOrFolderName     = ($Rule.FileOrFolderName ?? $Rule.FileOrFolder)
+                check32BitOn64System = ConvertTo-HydrationBoolValue -Value ($Rule.Check32BitOn64System ?? $Rule.check32BitOn64System)
+                operationType        = $operationType
+            }
+        }
+        'Script' {
+            $scriptFile = [string]$Rule.ScriptFile
+            if ([string]::IsNullOrWhiteSpace($ScriptRootPath)) {
+                throw "ScriptRootPath is required for script requirement rule '$scriptFile'."
+            }
+
+            $scriptPath = Join-Path -Path $ScriptRootPath -ChildPath $scriptFile
+            $scriptContent = Get-Content -Path $scriptPath -Raw -ErrorAction Stop
+            $encodedScriptContent = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($scriptContent))
+            $scriptRule = @{
+                '@odata.type'         = '#microsoft.graph.win32LobAppPowerShellScriptRequirement'
+                operator              = ($Rule.Operator ?? 'greaterThanOrEqual')
+                detectionValue        = ($Rule.Value ?? '')
+                scriptContent         = $encodedScriptContent
+                enforceSignatureCheck = ConvertTo-HydrationBoolValue -Value $Rule.EnforceSignatureCheck
+                runAs32Bit            = ConvertTo-HydrationBoolValue -Value $Rule.RunAs32Bit
+            }
+
+            if ($Rule.RunAsAccount) {
+                $scriptRule.runAsAccount = $Rule.RunAsAccount
+            }
+
+            return $scriptRule
+        }
+        'MSI' {
+            return @{
+                '@odata.type'  = '#microsoft.graph.win32LobAppProductCodeRequirement'
+                operator       = ($Rule.Operator ?? 'greaterThanOrEqual')
+                detectionValue = ($Rule.ProductVersion ?? $Rule.Value ?? '')
+                productCode    = $Rule.ProductCode
+                productVersion = ($Rule.ProductVersion ?? $Rule.Value ?? '')
+            }
+        }
+        default {
+            throw "Unsupported requirement rule type '$ruleType'."
+        }
+    }
+}

--- a/Private/WinGet/Expand-IntuneWinPackageEncryptedContent.ps1
+++ b/Private/WinGet/Expand-IntuneWinPackageEncryptedContent.ps1
@@ -19,7 +19,7 @@ function Expand-IntuneWinPackageEncryptedContent {
 
     $destinationDirectory = Split-Path -Path $DestinationPath -Parent
     if (-not [string]::IsNullOrWhiteSpace($destinationDirectory) -and -not (Test-Path -Path $destinationDirectory)) {
-        $null = New-Item -Path $destinationDirectory -ItemType Directory -Force
+        $null = New-Item -Path $destinationDirectory -ItemType Directory -Force -ErrorAction Stop
     }
 
     $archive = [System.IO.Compression.ZipFile]::OpenRead($IntuneWinPath)

--- a/Private/WinGet/Expand-IntuneWinPackageEncryptedContent.ps1
+++ b/Private/WinGet/Expand-IntuneWinPackageEncryptedContent.ps1
@@ -1,0 +1,48 @@
+function Expand-IntuneWinPackageEncryptedContent {
+    [CmdletBinding()]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IntuneWinPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FileName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DestinationPath
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $destinationDirectory = Split-Path -Path $DestinationPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($destinationDirectory) -and -not (Test-Path -Path $destinationDirectory)) {
+        $null = New-Item -Path $destinationDirectory -ItemType Directory -Force
+    }
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($IntuneWinPath)
+    try {
+        $encryptedContentEntry = $archive.Entries |
+            Where-Object { $_.Name -eq $FileName -or $_.FullName -like "*/$FileName" } |
+            Select-Object -First 1
+
+        if (-not $encryptedContentEntry) {
+            throw "Encrypted content '$FileName' was not found in package '$IntuneWinPath'."
+        }
+
+        $entryStream = $encryptedContentEntry.Open()
+        $fileStream = [System.IO.File]::Create($DestinationPath)
+        try {
+            $entryStream.CopyTo($fileStream)
+        } finally {
+            $fileStream.Dispose()
+            $entryStream.Dispose()
+        }
+
+        return Get-Item -Path $DestinationPath
+    } finally {
+        $archive.Dispose()
+    }
+}

--- a/Private/WinGet/Format-WinGetInstallerSummary.ps1
+++ b/Private/WinGet/Format-WinGetInstallerSummary.ps1
@@ -1,0 +1,23 @@
+function Format-WinGetInstallerSummary {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [psobject]$Installer
+    )
+
+    if (-not $Installer) {
+        return 'None'
+    }
+
+    $installerFileName = $null
+    if (-not [string]::IsNullOrWhiteSpace($Installer.InstallerUrl)) {
+        try {
+            $installerFileName = [System.IO.Path]::GetFileName(([System.Uri]$Installer.InstallerUrl).AbsolutePath)
+        } catch {
+            $installerFileName = $Installer.InstallerUrl
+        }
+    }
+
+    return "Architecture='$($Installer.Architecture)', Scope='$($Installer.Scope)', Locale='$($Installer.InstallerLocale)', Type='$($Installer.InstallerType)', File='$installerFileName'"
+}

--- a/Private/WinGet/Get-ExistingWinGetApps.ps1
+++ b/Private/WinGet/Get-ExistingWinGetApps.ps1
@@ -1,0 +1,66 @@
+function Get-ExistingWinGetApps {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.Generic.HashSet[string]]$KnownTemplateNames
+    )
+
+    $apps = [System.Collections.Generic.List[object]]::new()
+    $appLookup = @{}
+    $listUri = "beta/deviceAppManagement/mobileApps?`$select=id,displayName,description,notes"
+    $visitedUris = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $pageCount = 0
+    $maxPages = 1000
+
+    do {
+        $pageCount++
+        if ($pageCount -gt $maxPages) {
+            throw "Graph pagination exceeded the maximum page limit of $maxPages while listing mobile apps."
+        }
+        if (-not $visitedUris.Add($listUri)) {
+            throw 'Graph pagination returned a repeated nextLink while listing mobile apps.'
+        }
+
+        $response = Invoke-HydrationGraphRequest -Method GET -Uri $listUri
+        foreach ($existingApp in @($response.value)) {
+            $appToEvaluate = $existingApp
+            $appName = [string]$existingApp.displayName
+            $isPotentialMatch = $KnownTemplateNames.Contains($appName)
+
+            if ($isPotentialMatch -and [string]::IsNullOrWhiteSpace($existingApp.description) -and [string]::IsNullOrWhiteSpace($existingApp.notes)) {
+                try {
+                    $appToEvaluate = Invoke-HydrationGraphRequest -Method GET -Uri "beta/deviceAppManagement/mobileApps/$($existingApp.id)"
+                } catch {
+                    Write-Verbose "Could not retrieve full details for app '$appName': $($_.Exception.Message)"
+                }
+            }
+
+            $isOwned = Test-IntuneWinGetAppOwnership -Description $appToEvaluate.description -Notes $appToEvaluate.notes -ObjectName $appName
+            $appRecord = [PSCustomObject]@{
+                Id          = $appToEvaluate.id
+                DisplayName = $appName
+                Description = [string]$appToEvaluate.description
+                Notes       = [string]$appToEvaluate.notes
+                IsOwned     = $isOwned
+            }
+
+            $apps.Add($appRecord)
+
+            if (-not [string]::IsNullOrWhiteSpace($appRecord.DisplayName)) {
+                if (-not $appLookup.ContainsKey($appRecord.DisplayName)) {
+                    $appLookup[$appRecord.DisplayName] = $appRecord
+                } elseif ($appRecord.IsOwned -and -not $appLookup[$appRecord.DisplayName].IsOwned) {
+                    $appLookup[$appRecord.DisplayName] = $appRecord
+                }
+            }
+        }
+
+        $listUri = $response.'@odata.nextLink'
+    } while ($listUri)
+
+    return [PSCustomObject]@{
+        Items  = @($apps)
+        Lookup = $appLookup
+    }
+}

--- a/Private/WinGet/Get-HydrationWinGetAppTemplates.ps1
+++ b/Private/WinGet/Get-HydrationWinGetAppTemplates.ps1
@@ -1,0 +1,202 @@
+function Get-HydrationWinGetAppTemplates {
+    <#
+    .SYNOPSIS
+        Gets WinGet app templates from the repo-owned starter pack.
+    .DESCRIPTION
+        Loads WinGet app templates from Templates/MobileApps/Windows/WinGet/Apps and validates them
+        against the repo-owned JSON schema. Optionally filters by template ID or a
+        preset definition from Templates/MobileApps/Windows/WinGet/Presets.
+    .PARAMETER TemplatePath
+        The root WinGet template path. Defaults to Templates/MobileApps/Windows/WinGet.
+    .PARAMETER TemplateId
+        One or more template IDs to load.
+    .PARAMETER PresetId
+        Optional preset ID to resolve from Templates/MobileApps/Windows/WinGet/Presets.
+    .OUTPUTS
+        PSCustomObject
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject[]])]
+    param(
+        [Parameter()]
+        [string]$TemplatePath,
+
+        [Parameter()]
+        [string[]]$TemplateId,
+
+        [Parameter()]
+        [string]$PresetId
+    )
+
+    function Get-TemplateErrorRecord {
+        param(
+            [Parameter(Mandatory)]
+            [System.Exception]$Exception,
+
+            [Parameter(Mandatory)]
+            [string]$ErrorId,
+
+            [Parameter(Mandatory)]
+            [System.Management.Automation.ErrorCategory]$Category,
+
+            [Parameter()]
+            [object]$TargetObject
+        )
+
+        return [System.Management.Automation.ErrorRecord]::new(
+            $Exception,
+            $ErrorId,
+            $Category,
+            $TargetObject
+        )
+    }
+
+    function Confirm-TemplatePath {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path,
+
+            [Parameter(Mandatory)]
+            [string]$ErrorId,
+
+            [Parameter(Mandatory)]
+            [string]$Message
+        )
+
+        if (-not (Test-Path -Path $Path)) {
+            $errorRecord = Get-TemplateErrorRecord -Exception ([System.IO.FileNotFoundException]::new($Message)) `
+                -ErrorId $ErrorId `
+                -Category ([System.Management.Automation.ErrorCategory]::ObjectNotFound) `
+                -TargetObject $Path
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
+        }
+    }
+
+    function Add-ResolvedTemplateId {
+        param(
+            [Parameter()]
+            [AllowNull()]
+            [string]$Id
+        )
+
+        if (-not [string]::IsNullOrWhiteSpace($Id) -and -not $resolvedTemplateIds.Contains($Id)) {
+            $resolvedTemplateIds.Add($Id)
+        }
+    }
+
+    function Test-WinGetTemplateJson {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path,
+
+            [Parameter(Mandatory)]
+            [string]$SchemaPath,
+
+            [Parameter(Mandatory)]
+            [string]$ValidationErrorId,
+
+            [Parameter(Mandatory)]
+            [string]$InvalidErrorId,
+
+            [Parameter(Mandatory)]
+            [string]$InvalidMessage
+        )
+
+        try {
+            $templateIsValid = Test-Json -Path $Path -SchemaFile $SchemaPath -ErrorAction Stop
+        } catch {
+            $errorRecord = Get-TemplateErrorRecord -Exception $_.Exception `
+                -ErrorId $ValidationErrorId `
+                -Category ([System.Management.Automation.ErrorCategory]::InvalidData) `
+                -TargetObject $Path
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
+        }
+
+        if (-not $templateIsValid) {
+            $errorRecord = Get-TemplateErrorRecord -Exception ([System.InvalidOperationException]::new($InvalidMessage)) `
+                -ErrorId $InvalidErrorId `
+                -Category ([System.Management.Automation.ErrorCategory]::InvalidData) `
+                -TargetObject $Path
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
+        }
+    }
+
+    $templatePathWasProvided = $PSBoundParameters.ContainsKey('TemplatePath')
+    if (-not $TemplatePath) {
+        $TemplatePath = Join-Path -Path $script:TemplatesPath -ChildPath 'MobileApps/Windows/WinGet'
+    }
+
+    $appPath = Join-Path -Path $TemplatePath -ChildPath 'Apps'
+    $presetPath = Join-Path -Path $TemplatePath -ChildPath 'Presets'
+    $schemaPath = Join-Path -Path $TemplatePath -ChildPath 'Schemas/winGetAppTemplate.schema.json'
+    $presetSchemaPath = Join-Path -Path $TemplatePath -ChildPath 'Schemas/winGetAppPreset.schema.json'
+    $requestedTemplateIds = @($TemplateId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+    if (-not (Test-Path -Path $TemplatePath) -and -not $templatePathWasProvided -and -not $PresetId -and $requestedTemplateIds.Count -eq 0) {
+        Write-Verbose "WinGet template root not found: $TemplatePath"
+        return @()
+    }
+
+    Confirm-TemplatePath -Path $TemplatePath -ErrorId 'WinGetTemplateRootNotFound' -Message "WinGet template root not found: $TemplatePath"
+    Confirm-TemplatePath -Path $appPath -ErrorId 'WinGetTemplateAppPathNotFound' -Message "WinGet template app path not found: $appPath"
+    Confirm-TemplatePath -Path $schemaPath -ErrorId 'WinGetTemplateSchemaNotFound' -Message "WinGet app template schema not found: $schemaPath"
+    Confirm-TemplatePath -Path $presetSchemaPath -ErrorId 'WinGetPresetSchemaNotFound' -Message "WinGet preset schema not found: $presetSchemaPath"
+
+    $resolvedTemplateIds = [System.Collections.Generic.List[string]]::new()
+
+    if ($PresetId) {
+        Confirm-TemplatePath -Path $presetPath -ErrorId 'WinGetTemplatePresetPathNotFound' -Message "WinGet template preset path not found: $presetPath"
+
+        $presetFile = Join-Path -Path $presetPath -ChildPath "$PresetId.json"
+        Confirm-TemplatePath -Path $presetFile -ErrorId 'WinGetTemplatePresetNotFound' -Message "WinGet template preset not found: $presetFile"
+
+        Test-WinGetTemplateJson -Path $presetFile `
+            -SchemaPath $presetSchemaPath `
+            -ValidationErrorId 'WinGetTemplatePresetValidationFailed' `
+            -InvalidErrorId 'WinGetTemplatePresetInvalid' `
+            -InvalidMessage "WinGet preset failed schema validation: $presetFile"
+
+        $presetDefinition = Get-Content -Path $presetFile -Raw -Encoding utf8 | ConvertFrom-Json -Depth 100
+        foreach ($presetTemplateId in $presetDefinition.appIds) {
+            Add-ResolvedTemplateId -Id $presetTemplateId
+        }
+    }
+
+    foreach ($requestedTemplateId in $requestedTemplateIds) {
+        Add-ResolvedTemplateId -Id $requestedTemplateId
+    }
+
+    if ($resolvedTemplateIds.Count -gt 0) {
+        $templateFiles = foreach ($currentTemplateId in $resolvedTemplateIds) {
+            $currentTemplatePath = Join-Path -Path $appPath -ChildPath "$currentTemplateId.json"
+            Confirm-TemplatePath -Path $currentTemplatePath `
+                -ErrorId 'WinGetTemplateFileNotFound' `
+                -Message "WinGet template file not found: $currentTemplatePath"
+
+            Get-Item -Path $currentTemplatePath
+        }
+    } else {
+        $templateFiles = Get-ChildItem -Path $appPath -Filter '*.json' -File | Sort-Object -Property Name
+    }
+
+    $templates = foreach ($templateFile in $templateFiles) {
+        Test-WinGetTemplateJson -Path $templateFile.FullName `
+            -SchemaPath $schemaPath `
+            -ValidationErrorId 'WinGetTemplateValidationFailed' `
+            -InvalidErrorId 'WinGetTemplateInvalid' `
+            -InvalidMessage "WinGet template failed schema validation: $($templateFile.FullName)"
+
+        $template = Get-Content -Path $templateFile.FullName -Raw -Encoding utf8 | ConvertFrom-Json -Depth 100
+        $template | Add-Member -NotePropertyName 'TemplatePath' -NotePropertyValue $templateFile.FullName -Force
+
+        if ($PresetId) {
+            $template | Add-Member -NotePropertyName 'PresetId' -NotePropertyValue $PresetId -Force
+        }
+
+        $template
+    }
+
+    Write-Verbose "Loaded $($templates.Count) WinGet app template(s) from $TemplatePath"
+
+    return $templates
+}

--- a/Private/WinGet/Get-HydrationWinGetAppTemplates.ps1
+++ b/Private/WinGet/Get-HydrationWinGetAppTemplates.ps1
@@ -84,6 +84,27 @@ function Get-HydrationWinGetAppTemplates {
         }
     }
 
+    function Get-TemplateFileById {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Id,
+
+            [Parameter(Mandatory)]
+            [System.Collections.Generic.Dictionary[string, System.IO.FileInfo]]$TemplateFileIndex
+        )
+
+        if ($TemplateFileIndex.ContainsKey($Id)) {
+            return $TemplateFileIndex[$Id]
+        }
+
+        $currentTemplatePath = Join-Path -Path $appPath -ChildPath "$Id.json"
+        $errorRecord = Get-TemplateErrorRecord -Exception ([System.IO.FileNotFoundException]::new("WinGet template file not found: $currentTemplatePath")) `
+            -ErrorId 'WinGetTemplateFileNotFound' `
+            -Category ([System.Management.Automation.ErrorCategory]::ObjectNotFound) `
+            -TargetObject $currentTemplatePath
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
+    }
+
     function Test-WinGetTemplateJson {
         param(
             [Parameter(Mandatory)]
@@ -167,13 +188,16 @@ function Get-HydrationWinGetAppTemplates {
     }
 
     if ($resolvedTemplateIds.Count -gt 0) {
-        $templateFiles = foreach ($currentTemplateId in $resolvedTemplateIds) {
-            $currentTemplatePath = Join-Path -Path $appPath -ChildPath "$currentTemplateId.json"
-            Confirm-TemplatePath -Path $currentTemplatePath `
-                -ErrorId 'WinGetTemplateFileNotFound' `
-                -Message "WinGet template file not found: $currentTemplatePath"
+        $templateFileIndex = [System.Collections.Generic.Dictionary[string, System.IO.FileInfo]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($templateFile in Get-ChildItem -Path $appPath -Filter '*.json' -File) {
+            $templateIdFromFile = [System.IO.Path]::GetFileNameWithoutExtension($templateFile.Name)
+            if (-not $templateFileIndex.ContainsKey($templateIdFromFile)) {
+                $templateFileIndex[$templateIdFromFile] = $templateFile
+            }
+        }
 
-            Get-Item -Path $currentTemplatePath
+        $templateFiles = foreach ($currentTemplateId in $resolvedTemplateIds) {
+            Get-TemplateFileById -Id $currentTemplateId -TemplateFileIndex $templateFileIndex
         }
     } else {
         $templateFiles = Get-ChildItem -Path $appPath -Filter '*.json' -File | Sort-Object -Property Name

--- a/Private/WinGet/Get-IntuneProactiveRemediationAvailability.ps1
+++ b/Private/WinGet/Get-IntuneProactiveRemediationAvailability.ps1
@@ -1,0 +1,43 @@
+function Get-IntuneProactiveRemediationAvailability {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param()
+
+    try {
+        Invoke-HydrationGraphRequest -Method GET -Uri "beta/deviceManagement/deviceHealthScripts?`$top=1" | Out-Null
+        Write-Debug 'Proactive remediation availability check passed.'
+        return [pscustomobject]@{
+            IsAvailable = $true
+            Status      = 'Available'
+            Message     = 'Proactive remediations are available.'
+        }
+    } catch {
+        $statusCode = Get-GraphStatusCode -ErrorRecord $_
+        $errorMessage = Get-GraphErrorMessage -ErrorRecord $_
+
+        $isPermissionIssue = $statusCode -eq 403 -or
+        $errorMessage -match 'forbidden|access denied|insufficient privileges|insufficient permission'
+        $isFeatureUnavailable = $statusCode -eq 404 -or
+        $errorMessage -match 'license|not enabled|not found'
+
+        if ($isPermissionIssue) {
+            Write-Debug "Proactive remediation availability check failed due to permissions: $errorMessage"
+            return [pscustomobject]@{
+                IsAvailable = $false
+                Status      = 'InsufficientPermissions'
+                Message     = 'Insufficient permissions to access device health scripts.'
+            }
+        }
+
+        if ($isFeatureUnavailable) {
+            Write-Debug "Proactive remediation availability check failed because the feature is unavailable: $errorMessage"
+            return [pscustomobject]@{
+                IsAvailable = $false
+                Status      = 'FeatureUnavailable'
+                Message     = 'Device health scripts are not available in this tenant.'
+            }
+        }
+
+        throw
+    }
+}

--- a/Private/WinGet/Get-IntuneWin32RenewedUploadUri.ps1
+++ b/Private/WinGet/Get-IntuneWin32RenewedUploadUri.ps1
@@ -1,0 +1,42 @@
+function Get-IntuneWin32RenewedUploadUri {
+    <#
+    .SYNOPSIS
+        Renews the Azure Storage upload URI for a Win32 content file.
+    .PARAMETER AppId
+        Target Intune app identifier.
+    .PARAMETER ContentVersionId
+        Content version identifier.
+    .PARAMETER ContentFileId
+        Content file identifier.
+    .PARAMETER ContentFileUri
+        Base Graph URI for content files under the content version.
+    .PARAMETER TimeoutSeconds
+        Timeout used when waiting for renewal success state.
+    .OUTPUTS
+        System.String
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$AppId,
+
+        [Parameter(Mandatory)]
+        [string]$ContentVersionId,
+
+        [Parameter(Mandatory)]
+        [string]$ContentFileId,
+
+        [Parameter(Mandatory)]
+        [string]$ContentFileUri,
+
+        [Parameter(Mandatory)]
+        [int]$TimeoutSeconds
+    )
+
+    Write-Debug "Renewing Azure Storage upload URI for content file '$ContentFileId'."
+    Invoke-HydrationGraphRequest -Method POST -Uri "$ContentFileUri/$ContentFileId/renewUpload" -Body @{} | Out-Null
+
+    $renewedFileInfo = Wait-IntuneWin32ContentState -AppId $AppId -ContentVersionId $ContentVersionId -FileId $ContentFileId -DesiredState 'azureStorageUriRenewalSuccess' -TimeoutSeconds $TimeoutSeconds
+    return $renewedFileInfo.azureStorageUri
+}

--- a/Private/WinGet/Get-IntuneWinPackageMetadata.ps1
+++ b/Private/WinGet/Get-IntuneWinPackageMetadata.ps1
@@ -1,0 +1,47 @@
+function Get-IntuneWinPackageMetadata {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IntuneWinPath
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($IntuneWinPath)
+    try {
+        $detectionXmlEntry = $archive.Entries |
+            Where-Object { $_.FullName -match 'Detection\.xml$' } |
+            Select-Object -First 1
+
+        if (-not $detectionXmlEntry) {
+            throw "Detection.xml not found in package '$IntuneWinPath'."
+        }
+
+        $metadataStream = $detectionXmlEntry.Open()
+        $reader = [System.IO.StreamReader]::new($metadataStream)
+        try {
+            [xml]$metadataXml = $reader.ReadToEnd()
+        } finally {
+            $reader.Dispose()
+            $metadataStream.Dispose()
+        }
+
+        $encryptionInfo = $metadataXml.ApplicationInfo.EncryptionInfo
+        return [PSCustomObject]@{
+            FileName             = [string]$metadataXml.ApplicationInfo.FileName
+            SetupFile            = [string]$metadataXml.ApplicationInfo.SetupFile
+            UnencryptedSize      = [int64]$metadataXml.ApplicationInfo.UnencryptedContentSize
+            EncryptionKey        = [string]$encryptionInfo.EncryptionKey
+            MacKey               = [string]$encryptionInfo.MacKey
+            InitializationVector = [string]$encryptionInfo.InitializationVector
+            Mac                  = [string]$encryptionInfo.Mac
+            ProfileIdentifier    = [string]$encryptionInfo.ProfileIdentifier
+            FileDigest           = [string]$encryptionInfo.FileDigest
+            FileDigestAlgorithm  = [string]$encryptionInfo.FileDigestAlgorithm
+        }
+    } finally {
+        $archive.Dispose()
+    }
+}

--- a/Private/WinGet/Get-IntuneWinPackagingCapability.ps1
+++ b/Private/WinGet/Get-IntuneWinPackagingCapability.ps1
@@ -1,0 +1,47 @@
+function Get-IntuneWinPackagingCapability {
+    <#
+    .SYNOPSIS
+        Reports cross-platform primitives available for .intunewin packaging.
+    .DESCRIPTION
+        Validates the .NET APIs a repo-owned .intunewin packager will need so future work
+        can stay PowerShell 7 cross-platform instead of depending on IntuneWinAppUtil.exe.
+    .OUTPUTS
+        PSCustomObject describing packaging capability status.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param()
+
+    $capabilityChecks = [ordered]@{
+        ZipArchive      = $null -ne ('System.IO.Compression.ZipArchive' -as [type])
+        Aes             = $null -ne ('System.Security.Cryptography.Aes' -as [type])
+        HmacSha256      = $null -ne ('System.Security.Cryptography.HMACSHA256' -as [type])
+        Sha256          = $null -ne ('System.Security.Cryptography.SHA256' -as [type])
+        XmlDocument     = $null -ne ('System.Xml.XmlDocument' -as [type])
+        FileCompression = $null -ne ('System.IO.Compression.CompressionLevel' -as [type])
+    }
+
+    $missingCapabilities = $capabilityChecks.GetEnumerator() |
+        Where-Object { -not $_.Value } |
+        Select-Object -ExpandProperty Key
+    $supportsCrossPlatformIntuneWin = $missingCapabilities.Count -eq 0
+
+    $platform = if ($IsWindows) {
+        'Windows'
+    } elseif ($IsMacOS) {
+        'macOS'
+    } elseif ($IsLinux) {
+        'Linux'
+    } else {
+        'Unknown'
+    }
+
+    return [PSCustomObject]@{
+        Platform                       = $platform
+        PowerShellEdition              = $PSVersionTable.PSEdition
+        PowerShellVersion              = $PSVersionTable.PSVersion.ToString()
+        SupportsCrossPlatformIntuneWin = $supportsCrossPlatformIntuneWin
+        MissingCapabilities            = @($missingCapabilities)
+        Capabilities                   = [PSCustomObject]$capabilityChecks
+    }
+}

--- a/Private/WinGet/Get-IntuneWinUploadChunkLength.ps1
+++ b/Private/WinGet/Get-IntuneWinUploadChunkLength.ps1
@@ -1,0 +1,25 @@
+function Get-IntuneWinUploadChunkLength {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateRange(0, [int64]::MaxValue)]
+        [int64]$FileSize,
+
+        [Parameter(Mandatory)]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$ChunkIndex,
+
+        [Parameter(Mandatory)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$ChunkSizeBytes
+    )
+
+    $chunkSize = [int64]$ChunkSizeBytes
+    $chunkOffset = [int64]$ChunkIndex * $chunkSize
+    if ($chunkOffset -ge $FileSize) {
+        return 0
+    }
+
+    return [int][Math]::Min($chunkSize, $FileSize - $chunkOffset)
+}

--- a/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
+++ b/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
@@ -1,0 +1,146 @@
+function Get-WinGetBootstrapScriptFragment {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$LogFunctionName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BootstrapMessage
+    )
+
+    $escapedBootstrapMessage = $BootstrapMessage -replace "'", "''"
+
+    return @"
+function Get-WinGetExecutablePath {
+    [CmdletBinding()]
+    param()
+
+    `$programDataWingetRoot = Join-Path -Path `$env:ProgramData -ChildPath 'Microsoft.DesktopAppInstaller'
+    `$programDataWingetExe = Join-Path -Path `$programDataWingetRoot -ChildPath 'winget.exe'
+    `$isSystem = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name -eq 'NT AUTHORITY\SYSTEM'
+
+    function Test-WinGetExecutable {
+        param(
+            [Parameter(Mandatory)]
+            [string]`$Path
+        )
+
+        if (-not (Test-Path -Path `$Path -PathType Leaf)) {
+            return `$false
+        }
+
+        try {
+            `$versionOutput = & `$Path --version 2>&1
+            return `$LASTEXITCODE -eq 0 -or `$versionOutput -match 'v?\d+\.\d+'
+        } catch {
+            return `$false
+        }
+    }
+
+    function Install-WinGetSystemBootstrap {
+        [CmdletBinding()]
+        param()
+
+        function Get-AppInstallerMsixPath {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory)]
+                [string]`$Path
+            )
+
+            foreach (`$filter in @('AppInstaller*_x64*.msix', 'AppInstaller*.msix')) {
+                `$msixPath = Get-ChildItem -Path `$Path -Filter `$filter -File -ErrorAction SilentlyContinue |
+                    Sort-Object -Property Name -Descending |
+                    Select-Object -First 1
+
+                if (`$msixPath) {
+                    return `$msixPath
+                }
+            }
+
+            throw 'Unable to locate App Installer MSIX payload inside the downloaded bundle.'
+        }
+
+        `$stagingRoot = Join-Path -Path `$env:TEMP -ChildPath 'IntuneHydrationKit-WinGetBootstrap'
+        `$bundlePath = Join-Path -Path `$stagingRoot -ChildPath 'Microsoft.DesktopAppInstaller.msixbundle'
+        `$bundleExtractPath = Join-Path -Path `$stagingRoot -ChildPath 'bundle'
+        `$msixExtractPath = Join-Path -Path `$stagingRoot -ChildPath 'appinstaller'
+        `$vcRedistPath = Join-Path -Path `$stagingRoot -ChildPath 'vc_redist.x64.exe'
+
+        $LogFunctionName -Message '$escapedBootstrapMessage'
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+        if (Test-Path -Path `$stagingRoot) {
+            Remove-Item -Path `$stagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        foreach (`$directoryPath in @(`$stagingRoot, `$bundleExtractPath, `$msixExtractPath)) {
+            `$null = New-Item -Path `$directoryPath -ItemType Directory -Force
+        }
+
+        try {
+            Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile `$vcRedistPath -UseBasicParsing -TimeoutSec 120
+            `$vcRedist = Start-Process -FilePath `$vcRedistPath -ArgumentList '/q /norestart' -Wait -PassThru
+            $LogFunctionName -Message "VC++ bootstrap exited with code `$(`$vcRedist.ExitCode)."
+        } catch {
+            $LogFunctionName -Message "VC++ bootstrap failed: `$(`$_.Exception.Message)" -Level 'WARN'
+        }
+
+        Invoke-WebRequest -Uri 'https://aka.ms/getwinget' -OutFile `$bundlePath -UseBasicParsing -TimeoutSec 120
+        [System.IO.Compression.ZipFile]::ExtractToDirectory(`$bundlePath, `$bundleExtractPath)
+        `$msixPath = Get-AppInstallerMsixPath -Path `$bundleExtractPath
+
+        if (Test-Path -Path `$programDataWingetRoot) {
+            Remove-Item -Path `$programDataWingetRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        `$null = New-Item -Path `$programDataWingetRoot -ItemType Directory -Force
+        [System.IO.Compression.ZipFile]::ExtractToDirectory(`$msixPath.FullName, `$msixExtractPath)
+        Copy-Item -Path (Join-Path -Path `$msixExtractPath -ChildPath '*') -Destination `$programDataWingetRoot -Recurse -Force
+        $LogFunctionName -Message "Bootstrapped WinGet to '`$programDataWingetRoot'."
+    }
+
+    if (Test-WinGetExecutable -Path `$programDataWingetExe) {
+        return `$programDataWingetExe
+    }
+
+    if (-not `$isSystem) {
+        `$command = Get-Command -Name 'winget.exe' -ErrorAction SilentlyContinue
+        if (`$command -and -not [string]::IsNullOrWhiteSpace(`$command.Source) -and (Test-WinGetExecutable -Path `$command.Source)) {
+            return `$command.Source
+        }
+
+        `$searchPatterns = @(
+            (Join-Path -Path `$env:LOCALAPPDATA -ChildPath 'Microsoft\WindowsApps\winget.exe'),
+            (Join-Path -Path `$env:ProgramFiles -ChildPath 'WindowsApps\Microsoft.DesktopAppInstaller_*__8wekyb3d8bbwe\winget.exe')
+        )
+
+        if (`${env:ProgramFiles(x86)}) {
+            `$searchPatterns += Join-Path -Path `${env:ProgramFiles(x86)} -ChildPath 'WindowsApps\Microsoft.DesktopAppInstaller_*__8wekyb3d8bbwe\winget.exe'
+        }
+
+        foreach (`$pattern in `$searchPatterns) {
+            if ([string]::IsNullOrWhiteSpace(`$pattern)) {
+                continue
+            }
+
+            `$candidateFiles = @(Get-ChildItem -Path `$pattern -File -ErrorAction SilentlyContinue | Sort-Object -Property FullName -Descending)
+            if (`$candidateFiles.Count -gt 0 -and (Test-WinGetExecutable -Path `$candidateFiles[0].FullName)) {
+                return `$candidateFiles[0].FullName
+            }
+        }
+    }
+
+    Install-WinGetSystemBootstrap
+    if (Test-WinGetExecutable -Path `$programDataWingetExe) {
+        return `$programDataWingetExe
+    }
+
+    throw 'winget.exe could not be located or bootstrapped successfully for this context.'
+}
+"@
+}

--- a/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
+++ b/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
@@ -18,7 +18,8 @@ function Get-WinGetExecutablePath {
     [CmdletBinding()]
     param()
 
-    `$programDataWingetRoot = Join-Path -Path `$env:ProgramData -ChildPath 'Microsoft.DesktopAppInstaller'
+    `$programDataRoot = if ([string]::IsNullOrWhiteSpace(`$env:ProgramData)) { 'C:\ProgramData' } else { `$env:ProgramData }
+    `$programDataWingetRoot = Join-Path -Path `$programDataRoot -ChildPath 'Microsoft.DesktopAppInstaller'
     `$programDataWingetExe = Join-Path -Path `$programDataWingetRoot -ChildPath 'winget.exe'
     `$isSystem = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name -eq 'NT AUTHORITY\SYSTEM'
 

--- a/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
+++ b/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
@@ -88,7 +88,12 @@ function Get-WinGetExecutablePath {
             Invoke-WebRequest @downloadParams
         }
 
-        `$stagingRoot = Join-Path -Path `$env:TEMP -ChildPath 'IntuneHydrationKit-WinGetBootstrap'
+        `$tempRoot = [System.IO.Path]::GetTempPath()
+        if ([string]::IsNullOrWhiteSpace(`$tempRoot)) {
+            `$tempRoot = if ([string]::IsNullOrWhiteSpace(`$env:TEMP)) { 'C:\Windows\Temp' } else { `$env:TEMP }
+        }
+
+        `$stagingRoot = Join-Path -Path `$tempRoot -ChildPath 'IntuneHydrationKit-WinGetBootstrap'
         `$bundlePath = Join-Path -Path `$stagingRoot -ChildPath 'Microsoft.DesktopAppInstaller.msixbundle'
         `$bundleExtractPath = Join-Path -Path `$stagingRoot -ChildPath 'bundle'
         `$msixExtractPath = Join-Path -Path `$stagingRoot -ChildPath 'appinstaller'

--- a/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
+++ b/Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
@@ -64,6 +64,29 @@ function Get-WinGetExecutablePath {
             throw 'Unable to locate App Installer MSIX payload inside the downloaded bundle.'
         }
 
+        function Invoke-WinGetBootstrapDownload {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory)]
+                [string]`$Uri,
+
+                [Parameter(Mandatory)]
+                [string]`$OutFile
+            )
+
+            `$downloadParams = @{
+                Uri        = `$Uri
+                OutFile    = `$OutFile
+                TimeoutSec = 120
+            }
+
+            if (`$PSVersionTable.PSVersion.Major -lt 6) {
+                `$downloadParams.UseBasicParsing = `$true
+            }
+
+            Invoke-WebRequest @downloadParams
+        }
+
         `$stagingRoot = Join-Path -Path `$env:TEMP -ChildPath 'IntuneHydrationKit-WinGetBootstrap'
         `$bundlePath = Join-Path -Path `$stagingRoot -ChildPath 'Microsoft.DesktopAppInstaller.msixbundle'
         `$bundleExtractPath = Join-Path -Path `$stagingRoot -ChildPath 'bundle'
@@ -83,14 +106,14 @@ function Get-WinGetExecutablePath {
         }
 
         try {
-            Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile `$vcRedistPath -UseBasicParsing -TimeoutSec 120
+            Invoke-WinGetBootstrapDownload -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile `$vcRedistPath
             `$vcRedist = Start-Process -FilePath `$vcRedistPath -ArgumentList '/q /norestart' -Wait -PassThru
             $LogFunctionName -Message "VC++ bootstrap exited with code `$(`$vcRedist.ExitCode)."
         } catch {
             $LogFunctionName -Message "VC++ bootstrap failed: `$(`$_.Exception.Message)" -Level 'WARN'
         }
 
-        Invoke-WebRequest -Uri 'https://aka.ms/getwinget' -OutFile `$bundlePath -UseBasicParsing -TimeoutSec 120
+        Invoke-WinGetBootstrapDownload -Uri 'https://aka.ms/getwinget' -OutFile `$bundlePath
         [System.IO.Compression.ZipFile]::ExtractToDirectory(`$bundlePath, `$bundleExtractPath)
         `$msixPath = Get-AppInstallerMsixPath -Path `$bundleExtractPath
 

--- a/Private/WinGet/Get-WinGetDetectionRules.ps1
+++ b/Private/WinGet/Get-WinGetDetectionRules.ps1
@@ -1,0 +1,38 @@
+function Get-WinGetDetectionRules {
+    [CmdletBinding()]
+    [OutputType([hashtable[]])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Template,
+
+        [Parameter()]
+        [psobject]$PackageMetadata
+    )
+
+    if ($Template.detection.strategy) {
+        if ([string]$Template.detection.strategy -ne 'generated') {
+            throw "Detection strategy '$($Template.detection.strategy)' is not supported for WinGet Win32 imports."
+        }
+    } elseif ($Template.detection.operator -and $Template.detection.operator -ne 'all') {
+        throw "Detection operator '$($Template.detection.operator)' is not supported for WinGet Win32 imports yet."
+    }
+
+    if ($PackageMetadata -and $PackageMetadata.SelectedInstaller) {
+        $installer = $PackageMetadata.SelectedInstaller
+        $installerType = if ($installer.InstallerType) { $installer.InstallerType } else { '' }
+        $productCode = if ($installer.ProductCode) { $installer.ProductCode } else { '' }
+
+        if ($installerType -in @('msi', 'wix', 'burn') -and -not [string]::IsNullOrWhiteSpace($productCode)) {
+            Write-Debug "Ignoring manifest ProductCode detection for '$($Template.templateId)' (Type='$installerType', ProductCode='$productCode'); generated WinGet detection is more stable across package updates."
+        }
+    }
+
+    return @(
+        @{
+            DetectionType         = 'Script'
+            ScriptFile            = 'Detect-WinGetPackage.ps1'
+            EnforceSignatureCheck = $false
+            RunAs32Bit            = $false
+        }
+    )
+}

--- a/Private/WinGet/Get-WinGetDetectionScriptContent.ps1
+++ b/Private/WinGet/Get-WinGetDetectionScriptContent.ps1
@@ -1,0 +1,134 @@
+function Get-WinGetDetectionScriptContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PackageIdentifier,
+
+        [Parameter()]
+        [string]$DisplayName,
+
+        [Parameter()]
+        [string]$Publisher
+    )
+
+    $escapedPackageIdentifier = $PackageIdentifier -replace "'", "''"
+    $escapedPackageIdentifierPattern = [regex]::Escape($PackageIdentifier) -replace "'", "''"
+    $escapedDisplayName = $DisplayName -replace "'", "''"
+    $escapedPublisher = $Publisher -replace "'", "''"
+    $bootstrapFragment = Get-WinGetBootstrapScriptFragment -LogFunctionName 'Write-WinGetDetectionLog' -BootstrapMessage 'Bootstrapping WinGet for detection.'
+
+    return @"
+`$PackageIdentifier = '$escapedPackageIdentifier'
+`$PackageIdentifierPattern = '$escapedPackageIdentifierPattern'
+`$DisplayName = '$escapedDisplayName'
+`$Publisher = '$escapedPublisher'
+
+function Write-WinGetDetectionLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]`$Message,
+
+        [Parameter()]
+        [ValidateSet('INFO', 'WARN', 'ERROR')]
+        [string]`$Level = 'INFO'
+    )
+
+    Write-Host "[`$Level] `$Message"
+}
+
+$bootstrapFragment
+
+function Test-InstalledApplicationRegistry {
+    [CmdletBinding()]
+    param()
+
+    function Test-ApplicationPublisher {
+        [CmdletBinding()]
+        param(
+            [Parameter()]
+            [string]`$InstalledPublisher
+        )
+
+        if ([string]::IsNullOrWhiteSpace(`$Publisher)) {
+            return `$true
+        }
+
+        if ([string]::IsNullOrWhiteSpace(`$InstalledPublisher)) {
+            return `$false
+        }
+
+        return `$InstalledPublisher.IndexOf(`$Publisher, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    }
+
+    function Test-ApplicationDisplayName {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]`$InstalledDisplayName
+        )
+
+        `$namePatterns = @(`$PackageIdentifier)
+        if (-not [string]::IsNullOrWhiteSpace(`$DisplayName)) {
+            `$namePatterns += `$DisplayName
+        }
+
+        foreach (`$namePattern in `$namePatterns) {
+            if ([string]::IsNullOrWhiteSpace(`$namePattern)) {
+                continue
+            }
+
+            if (`$InstalledDisplayName.Equals(`$namePattern, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return `$true
+            }
+
+            if (`$InstalledDisplayName.StartsWith(`$namePattern, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return `$true
+            }
+        }
+
+        return `$false
+    }
+
+    `$registryPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+
+    foreach (`$registryPath in `$registryPaths) {
+        `$applications = Get-ItemProperty -Path `$registryPath -ErrorAction SilentlyContinue
+        foreach (`$application in `$applications) {
+            if ([string]::IsNullOrWhiteSpace(`$application.DisplayName)) {
+                continue
+            }
+
+            if (-not (Test-ApplicationPublisher -InstalledPublisher `$application.Publisher)) {
+                continue
+            }
+
+            if (Test-ApplicationDisplayName -InstalledDisplayName `$application.DisplayName) {
+                Write-WinGetDetectionLog -Message "Detected '`$(`$application.DisplayName)' from uninstall registry."
+                return `$true
+            }
+        }
+    }
+
+    return `$false
+}
+
+`$Winget = Get-WinGetExecutablePath
+`$installed = & `$Winget list --id "`$PackageIdentifier" --exact --accept-source-agreements 2>&1
+if (`$installed -match `$PackageIdentifierPattern) {
+    Write-Host "`$PackageIdentifier is installed"
+    exit 0
+} elseif (Test-InstalledApplicationRegistry) {
+    Write-Host "`$PackageIdentifier is installed"
+    exit 0
+} else {
+    Write-Host "`$PackageIdentifier is not installed"
+    exit 1
+}
+"@
+}

--- a/Private/WinGet/Get-WinGetDetectionScriptContent.ps1
+++ b/Private/WinGet/Get-WinGetDetectionScriptContent.ps1
@@ -35,7 +35,7 @@ function Write-WinGetDetectionLog {
         [string]`$Level = 'INFO'
     )
 
-    Write-Host "[`$Level] `$Message"
+    Write-Output "[`$Level] `$Message"
 }
 
 $bootstrapFragment
@@ -121,13 +121,13 @@ function Test-InstalledApplicationRegistry {
 `$Winget = Get-WinGetExecutablePath
 `$installed = & `$Winget list --id "`$PackageIdentifier" --exact --accept-source-agreements 2>&1
 if (`$installed -match `$PackageIdentifierPattern) {
-    Write-Host "`$PackageIdentifier is installed"
+    Write-Output "`$PackageIdentifier is installed"
     exit 0
 } elseif (Test-InstalledApplicationRegistry) {
-    Write-Host "`$PackageIdentifier is installed"
+    Write-Output "`$PackageIdentifier is installed"
     exit 0
 } else {
-    Write-Host "`$PackageIdentifier is not installed"
+    Write-Output "`$PackageIdentifier is not installed"
     exit 1
 }
 "@

--- a/Private/WinGet/Get-WinGetRemediationDefinition.ps1
+++ b/Private/WinGet/Get-WinGetRemediationDefinition.ps1
@@ -1,0 +1,29 @@
+function Get-WinGetRemediationDefinition {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('system', 'user')]
+        [string]$Scope,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$TemplateSet
+    )
+
+    $packageScope = if ($Scope -eq 'system') { 'machine' } else { 'user' }
+    $packageIdentifiers = @(
+        $TemplateSet |
+            Where-Object { [string]$_.package.match.scope -eq $packageScope } |
+            ForEach-Object { [string]$_.packageIdentifier } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+
+    return [PSCustomObject]@{
+        Scope              = $Scope
+        DisplayName        = "WinGet App Updates ($([cultureinfo]::InvariantCulture.TextInfo.ToTitleCase($Scope)))"
+        RunAsAccount       = if ($Scope -eq 'system') { 'system' } else { 'user' }
+        PackageIdentifiers = $packageIdentifiers
+        Description        = if ($packageIdentifiers.Count -gt 0) { New-WinGetRemediationDescription -Scope $Scope -PackageIdentifiers $packageIdentifiers } else { $null }
+    }
+}

--- a/Private/WinGet/Get-WinGetRemediationFingerprint.ps1
+++ b/Private/WinGet/Get-WinGetRemediationFingerprint.ps1
@@ -1,0 +1,23 @@
+function Get-WinGetRemediationFingerprint {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$PackageIdentifiers
+    )
+
+    $normalizedIds = @(
+        $PackageIdentifiers |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+    $joinedIdentifiers = $normalizedIds -join '|'
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($joinedIdentifiers))
+    } finally {
+        $sha256.Dispose()
+    }
+
+    return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').Substring(0, 16)
+}

--- a/Private/WinGet/Get-WinGetWrapperScriptContent.ps1
+++ b/Private/WinGet/Get-WinGetWrapperScriptContent.ps1
@@ -1,0 +1,165 @@
+function Get-WinGetWrapperScriptContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WingetCommand,
+
+        [Parameter(Mandatory)]
+        [string]$PackageIdentifier,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Install', 'Uninstall')]
+        [string]$Operation
+    )
+
+    $escapedCommand = $WingetCommand -replace "'", "''"
+    $escapedPackageIdentifier = $PackageIdentifier -replace "'", "''"
+    $escapedOperation = $Operation -replace "'", "''"
+    $bootstrapFragment = Get-WinGetBootstrapScriptFragment -LogFunctionName 'Write-WinGetWrapperLog' -BootstrapMessage 'Bootstrapping WinGet for SYSTEM context.'
+
+    return @"
+`$ErrorActionPreference = 'Stop'
+`$packageIdentifier = '$escapedPackageIdentifier'
+`$operationName = '$escapedOperation'
+
+function Get-IntuneManagementExtensionLogDirectory {
+    [CmdletBinding()]
+    param()
+
+    `$programDataPath = if (-not [string]::IsNullOrWhiteSpace(`$env:ProgramData)) {
+        `$env:ProgramData
+    } else {
+        'C:\ProgramData'
+    }
+
+    `$logDirectory = Join-Path -Path `$programDataPath -ChildPath 'Microsoft\IntuneManagementExtension\Logs'
+    if (-not (Test-Path -Path `$logDirectory)) {
+        `$null = New-Item -Path `$logDirectory -ItemType Directory -Force
+    }
+
+    return `$logDirectory
+}
+
+function Get-WinGetWrapperLogFileName {
+    [CmdletBinding()]
+    param()
+
+    `$safePackageIdentifier = (`$packageIdentifier -replace '[^A-Za-z0-9._-]+', '-').Trim('-')
+    if ([string]::IsNullOrWhiteSpace(`$safePackageIdentifier)) {
+        `$safePackageIdentifier = 'package'
+    }
+
+    return "IntuneHydrationKit-WinGet-`$operationName-`$safePackageIdentifier.log"
+}
+
+function Write-WinGetWrapperLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]`$Message,
+
+        [Parameter()]
+        [ValidateSet('INFO', 'WARN', 'ERROR')]
+        [string]`$Level = 'INFO'
+    )
+
+    `$timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
+    Add-Content -Path `$script:logPath -Value "``[`$timestamp``] ``[`$Level``] `$Message"
+}
+
+function Write-WinGetProcessStreamToLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]`$Path,
+
+        [Parameter(Mandatory)]
+        [string]`$Label,
+
+        [Parameter()]
+        [ValidateSet('INFO', 'WARN', 'ERROR')]
+        [string]`$Level = 'INFO'
+    )
+
+    if (-not (Test-Path -Path `$Path)) {
+        return
+    }
+
+    `$lines = @(Get-Content -Path `$Path -ErrorAction SilentlyContinue)
+    if (`$lines.Count -eq 0) {
+        return
+    }
+
+    Write-WinGetWrapperLog -Message "`${Label}:" -Level `$Level
+    foreach (`$line in `$lines) {
+        if ([string]::IsNullOrWhiteSpace(`$line)) {
+            continue
+        }
+
+        Write-WinGetWrapperLog -Message `$line -Level `$Level
+    }
+}
+
+function Test-WinGetAlreadyInstalledNoUpgradeOutput {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]`$Output
+    )
+
+    `$outputText = (`$Output -join [Environment]::NewLine)
+    `$foundExistingPackage = `$outputText -match 'Found an existing package already installed\. Trying to upgrade the installed package'
+    `$noUpgradeAvailable = `$outputText -match 'No available upgrade found' -or
+        `$outputText -match 'No newer package versions are available'
+
+    return `$foundExistingPackage -and `$noUpgradeAvailable
+}
+
+$bootstrapFragment
+
+`$wingetCommand = '$escapedCommand'
+`$argumentString = (`$wingetCommand -replace '^\s*winget(?:\.exe)?\s*', '').Trim()
+if ([string]::IsNullOrWhiteSpace(`$argumentString)) {
+    throw "Unable to derive WinGet arguments from command '`$wingetCommand'."
+}
+
+`$logDirectory = Get-IntuneManagementExtensionLogDirectory
+`$logFileName = Get-WinGetWrapperLogFileName
+`$script:logPath = Join-Path -Path `$logDirectory -ChildPath `$logFileName
+`$baseLogName = [System.IO.Path]::GetFileNameWithoutExtension(`$logFileName)
+`$stdoutPath = Join-Path -Path `$logDirectory -ChildPath "`$baseLogName.stdout.log"
+`$stderrPath = Join-Path -Path `$logDirectory -ChildPath "`$baseLogName.stderr.log"
+
+foreach (`$streamPath in @(`$stdoutPath, `$stderrPath)) {
+    if (Test-Path -Path `$streamPath) {
+        Remove-Item -Path `$streamPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-WinGetWrapperLog -Message "Starting `$operationName for package '`$packageIdentifier'."
+Write-WinGetWrapperLog -Message "Resolved IME log path: `$script:logPath"
+Write-WinGetWrapperLog -Message "Executing WinGet command: `$wingetCommand"
+
+try {
+    `$wingetPath = Get-WinGetExecutablePath
+    Write-WinGetWrapperLog -Message "Resolved winget executable: `$wingetPath"
+    `$process = Start-Process -FilePath `$wingetPath -ArgumentList `$argumentString -Wait -PassThru -NoNewWindow -RedirectStandardOutput `$stdoutPath -RedirectStandardError `$stderrPath
+    Write-WinGetProcessStreamToLog -Path `$stdoutPath -Label 'WinGet standard output'
+    Write-WinGetProcessStreamToLog -Path `$stderrPath -Label 'WinGet standard error' -Level 'WARN'
+    `$standardOutput = if (Test-Path -Path `$stdoutPath) { @(Get-Content -Path `$stdoutPath -ErrorAction SilentlyContinue) } else { @() }
+    `$exitCode = [int]`$process.ExitCode
+    Write-WinGetWrapperLog -Message "WinGet process exited with code `$exitCode."
+    if (`$operationName -eq 'Install' -and (`$exitCode -eq -1978335189 -or (Test-WinGetAlreadyInstalledNoUpgradeOutput -Output `$standardOutput))) {
+        Write-WinGetWrapperLog -Message "Package already installed (no upgrade needed). Treating as success." -Level 'INFO'
+        `$exitCode = 0
+    }
+    exit `$exitCode
+} catch {
+    Write-WinGetProcessStreamToLog -Path `$stdoutPath -Label 'WinGet standard output'
+    Write-WinGetProcessStreamToLog -Path `$stderrPath -Label 'WinGet standard error' -Level 'WARN'
+    Write-WinGetWrapperLog -Message "Wrapper execution failed: `$(`$_.Exception.Message)" -Level 'ERROR'
+    throw
+}
+"@
+}

--- a/Private/WinGet/Invoke-IntuneWinAzureStorageBlockUpload.ps1
+++ b/Private/WinGet/Invoke-IntuneWinAzureStorageBlockUpload.ps1
@@ -1,0 +1,21 @@
+function Invoke-IntuneWinAzureStorageBlockUpload {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Uri,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        [byte[]]$Body,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$TimeoutSec = 300
+    )
+
+    Invoke-WebRequest -Method PUT -Uri $Uri -Body $Body -Headers @{
+        'Content-Type'   = 'application/octet-stream'
+        'x-ms-blob-type' = 'BlockBlob'
+    } -TimeoutSec $TimeoutSec -ErrorAction Stop | Out-Null
+}

--- a/Private/WinGet/Invoke-IntuneWinGetAppTemplate.ps1
+++ b/Private/WinGet/Invoke-IntuneWinGetAppTemplate.ps1
@@ -1,0 +1,132 @@
+function Invoke-IntuneWinGetAppTemplate {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Template,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$WorkingDirectory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Template.packageIdentifier)) {
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.ArgumentException]::new("WinGet template '$($Template.templateId)' has a missing or blank packageIdentifier."),
+            'WinGetTemplateMissingPackageIdentifier',
+            [System.Management.Automation.ErrorCategory]::InvalidArgument,
+            $Template
+        )
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
+    }
+
+    $stagingRoot = Join-Path -Path $WorkingDirectory -ChildPath ('{0}-{1}' -f $Template.templateId, [guid]::NewGuid().ToString('N'))
+    $contentRoot = Join-Path -Path $stagingRoot -ChildPath 'content'
+    $uploadRoot = Join-Path -Path $stagingRoot -ChildPath 'upload'
+    $createdAppId = $null
+    $currentStep = 'Resolve package metadata'
+    Write-Debug "Processing WinGet template '$($Template.templateId)' for package '$($Template.packageIdentifier)'. TemplatePath='$($Template.TemplatePath)', DisplayName='$DisplayName', StagingRoot='$stagingRoot', ContentRoot='$contentRoot', UploadRoot='$uploadRoot'."
+
+    try {
+        $packageMetadata = New-WinGetPackageMetadataFromTemplate -Template $Template
+        Write-Debug "Resolved WinGet package metadata for template '$($Template.templateId)': PackageIdentifier='$($packageMetadata.PackageIdentifier)', PackageVersion='$($packageMetadata.PackageVersion)', ManifestPath='$($packageMetadata.ManifestPath)', SelectedInstaller=$(Format-WinGetInstallerSummary -Installer $packageMetadata.SelectedInstaller)."
+
+        $currentStep = 'Create wrapper files'
+        $wrapperFiles = New-WinGetWrapperFiles -Path $contentRoot -Template $Template
+        Write-Debug "Created WinGet wrapper files for template '$($Template.templateId)': InstallScriptPath='$($wrapperFiles.InstallScriptPath)', UninstallScriptPath='$($wrapperFiles.UninstallScriptPath)'."
+
+        $packagePath = Join-Path -Path $stagingRoot -ChildPath ('{0}.intunewin' -f $Template.templateId)
+        $currentStep = 'Create packaging context'
+        $installCommandLine = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File .\Install-WinGetPackage.ps1'
+        $uninstallCommandLine = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File .\Uninstall-WinGetPackage.ps1'
+        $packageContext = New-IntuneWinPackagingContext -PackageMetadata $packageMetadata -SourcePath $contentRoot -SetupFile ([System.IO.Path]::GetFileName($wrapperFiles.InstallScriptPath)) -OutputPath $packagePath -InstallCommandLine $installCommandLine -UninstallCommandLine $uninstallCommandLine
+        Write-Debug "Created WinGet packaging context for template '$($Template.templateId)' with OutputPath='$packagePath'."
+
+        $currentStep = 'Create .intunewin package'
+        $packagedContent = New-IntuneWinPackage -PackagingContext $packageContext
+        Write-Debug "Created .intunewin package for template '$($Template.templateId)' at '$($packagedContent.OutputPath)' (SetupFile='$($packagedContent.SetupFile)', UnencryptedSize=$($packagedContent.UnencryptedSize))."
+
+        $iconAsset = $null
+        $currentStep = 'Resolve app icon'
+        try {
+            $iconAsset = Resolve-WinGetAppIcon -Template $Template
+            if ($iconAsset) {
+                Write-Debug "Resolved icon for '$DisplayName' from '$($iconAsset.Source)' with MimeType='$($iconAsset.MimeType)'."
+            }
+        } catch {
+            Write-Debug "Icon resolution failed for '$DisplayName'. Proceeding without icon. Error='$($_.Exception.Message)'."
+            Write-HydrationLog -Message "  Warning: Icon resolution failed for $DisplayName - $($_.Exception.Message)" -Level Warning
+        }
+
+        $configuration = @{
+            PackageInformation    = @{
+                SetupFile = 'Install-WinGetPackage.ps1'
+            }
+            Information           = @{
+                DisplayName     = $DisplayName
+                Description     = New-HydrationDescription -ExistingText ([string]$Template.description)
+                Publisher       = if ($packageMetadata.Publisher) { $packageMetadata.Publisher } else { [string]$Template.publisher }
+                Developer       = [string]$Template.publisher
+                Owner           = [string]$Template.metadata.placeholders.owner
+                Notes           = New-WinGetOwnershipNotes -Template $Template -PackageMetadata $packageMetadata
+                AppVersion      = [string]$packageMetadata.PackageVersion
+                RoleScopeTagIds = @($Template.metadata.placeholders.scopeTagIds)
+            }
+            Program               = @{
+                InstallCommand          = $installCommandLine
+                UninstallCommand        = $uninstallCommandLine
+                InstallExperience       = [string]$Template.install.experience
+                DeviceRestartBehavior   = [string]$Template.install.restartBehavior
+                AllowAvailableUninstall = ($Template.uninstall.behavior -eq 'allow')
+            }
+            RequirementRule       = @{
+                MinimumSupportedWindowsRelease = [string]$Template.requirements.minimumSupportedWindowsRelease
+                Architecture                   = Get-RequirementArchitecture -Architecture $Template.requirements.architectures
+                MinimumFreeDiskSpaceInMB       = $Template.requirements.minimumFreeDiskSpaceInMB
+                MinimumMemoryInMB              = $Template.requirements.minimumMemoryInMB
+            }
+            DetectionRule         = @(Get-WinGetDetectionRules -Template $Template -PackageMetadata $packageMetadata)
+            CustomRequirementRule = @()
+        }
+
+        $currentStep = 'Create Win32 app payload'
+        $payload = New-IntuneWin32AppPayload -Configuration $configuration -PackageFileName ([System.IO.Path]::GetFileName($packagePath)) -SetupFilePath 'Install-WinGetPackage.ps1' -ScriptRootPath $contentRoot -IconBase64 $iconAsset.Base64 -IconMimeType $iconAsset.MimeType
+        Write-Debug "Created Win32 app payload for '$DisplayName' with AppVersion='$($payload.appVersion)', DetectionRules=$(@($payload.detectionRules).Count), RequirementRules=$(@($payload.requirementRules).Count), ScopeTags=$(@($payload.roleScopeTagIds).Count)."
+
+        $currentStep = 'Create Graph mobile app'
+        $createdApp = Invoke-HydrationGraphRequest -Method POST -Uri 'beta/deviceAppManagement/mobileApps' -Body $payload
+        $createdAppId = $createdApp.id
+        Write-Debug "Created WinGet Win32 app '$DisplayName' in Graph with AppId='$createdAppId'."
+
+        $currentStep = 'Publish Win32 app content'
+        $publishResult = Publish-IntuneWin32AppContent -AppId $createdAppId -IntuneWinPath $packagePath -WorkingDirectory $uploadRoot
+        Write-Debug "Published Win32 app content for '$DisplayName'. ContentVersionId='$($publishResult.ContentVersionId)', ContentFileId='$($publishResult.ContentFileId)', UploadedChunkCount=$($publishResult.UploadedChunkCount), PackagePath='$($publishResult.PackagePath)'."
+        Write-HydrationLog -Message "  Created: $DisplayName" -Level Info
+        return New-HydrationResult -Name $DisplayName -Id $createdAppId -Path $Template.TemplatePath -Type 'WinGetWin32App' -Action 'Created' -Status ([string]$packageMetadata.PackageVersion)
+    } catch {
+        Write-Debug "WinGet import failed for '$DisplayName' during step '$currentStep'. Error='$($_.Exception.Message)'."
+        $errorMessage = Get-GraphErrorMessage -ErrorRecord $_
+        if ($createdAppId) {
+            try {
+                Invoke-HydrationGraphRequest -Method DELETE -Uri "beta/deviceAppManagement/mobileApps/$createdAppId" | Out-Null
+                Write-Debug "Deleted partially created WinGet Win32 app '$DisplayName' with AppId='$createdAppId' during cleanup."
+                Write-HydrationLog -Message "  CleanupDeleted: $DisplayName" -Level Warning
+            } catch {
+                Write-Debug "Failed to delete partially created WinGet Win32 app '$DisplayName' with AppId='$createdAppId' during cleanup. Error='$($_.Exception.Message)'."
+                Write-HydrationLog -Message "  CleanupFailed: $DisplayName - $($_.Exception.Message)" -Level Warning
+            }
+        }
+
+        Write-HydrationLog -Message "  Failed: $DisplayName - $errorMessage" -Level Warning
+        return New-HydrationResult -Name $DisplayName -Path $Template.TemplatePath -Type 'WinGetWin32App' -Action 'Failed' -Status $errorMessage
+    } finally {
+        if (Test-Path -Path $stagingRoot) {
+            Write-Debug "Removing WinGet staging directory '$stagingRoot' for template '$($Template.templateId)'."
+            Remove-Item -Path $stagingRoot -Recurse -Force
+        }
+    }
+}

--- a/Private/WinGet/Invoke-IntuneWinGetAppTemplate.ps1
+++ b/Private/WinGet/Invoke-IntuneWinGetAppTemplate.ps1
@@ -126,7 +126,11 @@ function Invoke-IntuneWinGetAppTemplate {
     } finally {
         if (Test-Path -Path $stagingRoot) {
             Write-Debug "Removing WinGet staging directory '$stagingRoot' for template '$($Template.templateId)'."
-            Remove-Item -Path $stagingRoot -Recurse -Force
+            try {
+                Remove-Item -Path $stagingRoot -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Debug "Failed to remove WinGet staging directory '$stagingRoot'. Error='$($_.Exception.Message)'."
+            }
         }
     }
 }

--- a/Private/WinGet/Invoke-IntuneWinGetAppTemplate.ps1
+++ b/Private/WinGet/Invoke-IntuneWinGetAppTemplate.ps1
@@ -95,7 +95,7 @@ function Invoke-IntuneWinGetAppTemplate {
 
         $currentStep = 'Create Win32 app payload'
         $payload = New-IntuneWin32AppPayload -Configuration $configuration -PackageFileName ([System.IO.Path]::GetFileName($packagePath)) -SetupFilePath 'Install-WinGetPackage.ps1' -ScriptRootPath $contentRoot -IconBase64 $iconAsset.Base64 -IconMimeType $iconAsset.MimeType
-        Write-Debug "Created Win32 app payload for '$DisplayName' with AppVersion='$($payload.appVersion)', DetectionRules=$(@($payload.detectionRules).Count), RequirementRules=$(@($payload.requirementRules).Count), ScopeTags=$(@($payload.roleScopeTagIds).Count)."
+        Write-Debug "Created Win32 app payload for '$DisplayName' with AppVersion='$($payload.appVersion)', Rules=$(@($payload.rules).Count), ScopeTags=$(@($payload.roleScopeTagIds).Count)."
 
         $currentStep = 'Create Graph mobile app'
         $createdApp = Invoke-HydrationGraphRequest -Method POST -Uri 'beta/deviceAppManagement/mobileApps' -Body $payload

--- a/Private/WinGet/New-IntuneWin32AppPayload.ps1
+++ b/Private/WinGet/New-IntuneWin32AppPayload.ps1
@@ -1,0 +1,118 @@
+function New-IntuneWin32AppPayload {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Configuration,
+
+        [Parameter()]
+        [string]$PackageFileName,
+
+        [Parameter()]
+        [string]$SetupFilePath,
+
+        [Parameter()]
+        [string]$IconBase64,
+
+        [Parameter()]
+        [string]$IconMimeType = 'image/png',
+
+        [Parameter()]
+        [string]$ScriptRootPath
+    )
+
+    $packageInformation = Get-ConfigurationSection -InputObject $Configuration -Name 'PackageInformation'
+    $information = Get-ConfigurationSection -InputObject $Configuration -Name 'Information'
+    $program = Get-ConfigurationSection -InputObject $Configuration -Name 'Program'
+    $requirementConfig = Get-ConfigurationSection -InputObject $Configuration -Name 'RequirementRule'
+
+    $detectionRules = @(foreach ($rule in @($Configuration.DetectionRule)) {
+            if ($null -ne $rule) {
+                ConvertTo-IntuneWinDetectionRule -Rule $rule -ScriptRootPath $ScriptRootPath
+            }
+        })
+
+    $requirementRules = @(foreach ($rule in @($Configuration.CustomRequirementRule)) {
+            if ($null -ne $rule) {
+                ConvertTo-IntuneWinRequirementRule -Rule $rule -ScriptRootPath $ScriptRootPath
+            }
+        })
+
+    $packageName = if ($PackageFileName) {
+        $PackageFileName
+    } elseif ($packageInformation.SetupFile) {
+        $packageInformation.SetupFile
+    } else {
+        $null
+    }
+
+    $setupFile = if ($SetupFilePath) {
+        $SetupFilePath
+    } elseif ($packageInformation.SetupFile) {
+        $packageInformation.SetupFile
+    } else {
+        $null
+    }
+
+    $payload = @{
+        '@odata.type'                   = '#microsoft.graph.win32LobApp'
+        displayName                     = $information.DisplayName
+        description                     = ($information.Description ?? '')
+        publisher                       = ($information.Publisher ?? '')
+        developer                       = ($information.Developer ?? '')
+        owner                           = ($information.Owner ?? '')
+        notes                           = ($information.Notes ?? '')
+        appVersion                      = ($information.AppVersion ?? '')
+        informationUrl                  = if ([string]::IsNullOrWhiteSpace($information.InformationURL)) { $null } else { $information.InformationURL }
+        privacyInformationUrl           = if ([string]::IsNullOrWhiteSpace($information.PrivacyURL)) { $null } else { $information.PrivacyURL }
+        fileName                        = $packageName
+        setupFilePath                   = $setupFile
+        installCommandLine              = $program.InstallCommand
+        uninstallCommandLine            = $program.UninstallCommand
+        minimumSupportedOperatingSystem = Resolve-MinimumSupportedOperatingSystem -Release ($requirementConfig.MinimumSupportedWindowsRelease ?? $requirementConfig.MinimumRequiredOperatingSystem)
+        installExperience               = @{ runAsAccount = ($program.InstallExperience ?? 'system') }
+        minimumFreeDiskSpaceInMB        = ($requirementConfig.MinimumFreeDiskSpaceInMB ?? $null)
+        minimumMemoryInMB               = ($requirementConfig.MinimumMemoryInMB ?? $null)
+        returnCodes                     = @(
+            @{ returnCode = 0; type = 'success' }
+            @{ returnCode = 1707; type = 'success' }
+            @{ returnCode = 3010; type = 'softReboot' }
+            @{ returnCode = 1641; type = 'hardReboot' }
+            @{ returnCode = 1618; type = 'retry' }
+        )
+    }
+
+    $applicableArchitecture = Resolve-ApplicableArchitecture -Architecture $requirementConfig.Architecture
+    if ($applicableArchitecture) {
+        $payload.applicableArchitectures = $applicableArchitecture
+    }
+
+    if ($program.DeviceRestartBehavior) {
+        $payload.deviceRestartBehavior = $program.DeviceRestartBehavior
+    }
+
+    if ($program.ContainsKey('AllowAvailableUninstall')) {
+        $payload.allowAvailableUninstall = ConvertTo-HydrationBoolValue -Value $program.AllowAvailableUninstall
+    }
+
+    if ($information.ContainsKey('RoleScopeTagIds') -and @($information.RoleScopeTagIds).Count -gt 0) {
+        $payload.roleScopeTagIds = @($information.RoleScopeTagIds)
+    }
+
+    if ($IconBase64) {
+        $payload.largeIcon = @{
+            '@odata.type' = '#microsoft.graph.mimeContent'
+            type          = $IconMimeType
+            value         = $IconBase64
+        }
+    }
+
+    $combinedRules = @($detectionRules + $requirementRules)
+    if ($combinedRules.Count -gt 0) {
+        $payload.rules = $combinedRules
+    }
+
+    Write-Debug "Created Win32 app payload for '$($payload.displayName)' with FileName='$($payload.fileName)', SetupFilePath='$($payload.setupFilePath)', AppVersion='$($payload.appVersion)', DetectionRules=$($detectionRules.Count), RequirementRules=$($requirementRules.Count), CombinedRules=$($combinedRules.Count), RoleScopeTags=$(@($payload.roleScopeTagIds).Count), HasIcon=$([bool]$IconBase64)."
+
+    return $payload
+}

--- a/Private/WinGet/New-IntuneWinPackage.ps1
+++ b/Private/WinGet/New-IntuneWinPackage.ps1
@@ -256,7 +256,9 @@ function New-IntuneWinPackage {
         throw 'PackagingContext.OutputPath is required.'
     }
 
-    $outputDirectory = Split-Path -Path $PackagingContext.OutputPath -Parent
+    $outputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PackagingContext.OutputPath)
+    $outputDirectory = Split-Path -Path $outputPath -Parent
+
     if (-not [string]::IsNullOrWhiteSpace($outputDirectory) -and -not (Test-Path -Path $outputDirectory)) {
         $null = New-Item -Path $outputDirectory -ItemType Directory -Force -ErrorAction Stop
     }
@@ -270,19 +272,19 @@ function New-IntuneWinPackage {
     Write-Debug "Creating .intunewin package for '$($PackagingContext.PackageIdentifier)' version '$($PackagingContext.PackageVersion)'. SourcePath='$($PackagingContext.SourcePath)', SetupFile='$($PackagingContext.SetupFile)', OutputPath='$($PackagingContext.OutputPath)', WorkingRoot='$workingRoot'."
 
     try {
-        if (Test-Path -Path $PackagingContext.OutputPath) {
-            if (-not $PSCmdlet.ShouldProcess($PackagingContext.OutputPath, 'Overwrite existing .intunewin package')) {
+        if (Test-Path -Path $outputPath) {
+            if (-not $PSCmdlet.ShouldProcess($outputPath, 'Overwrite existing .intunewin package')) {
                 $errorRecord = [System.Management.Automation.ErrorRecord]::new(
                     [System.OperationCanceledException]::new("Refused to overwrite existing package '$($PackagingContext.OutputPath)'."),
                     'IntuneWinPackageOverwriteDeclined',
                     [System.Management.Automation.ErrorCategory]::OperationStopped,
-                    $PackagingContext.OutputPath
+                    $outputPath
                 )
                 $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
 
             Write-Debug "Removing existing .intunewin output at '$($PackagingContext.OutputPath)'."
-            Remove-Item -Path $PackagingContext.OutputPath -Force -ErrorAction Stop
+            Remove-Item -Path $outputPath -Force -ErrorAction Stop
         }
 
         [System.IO.Compression.ZipFile]::CreateFromDirectory(
@@ -306,7 +308,7 @@ function New-IntuneWinPackage {
         }
         $detectionXml = Format-DetectionXml -DisplayName $displayName -InnerFileName $innerFileName -SetupFile $PackagingContext.SetupFile -UnencryptedContentSize $unencryptedContentSize -EncryptionInfo $encryptionInfo
 
-        $fileStream = [System.IO.File]::Open($PackagingContext.OutputPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        $fileStream = [System.IO.File]::Open($outputPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
         try {
             $archive = [System.IO.Compression.ZipArchive]::new($fileStream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
             try {
@@ -319,7 +321,7 @@ function New-IntuneWinPackage {
             $fileStream.Dispose()
         }
 
-        $outputSize = (Get-Item -Path $PackagingContext.OutputPath).Length
+        $outputSize = (Get-Item -Path $outputPath).Length
         Write-Debug "Created final .intunewin package at '$($PackagingContext.OutputPath)' ($outputSize bytes)."
 
         return [PSCustomObject]@{

--- a/Private/WinGet/New-IntuneWinPackage.ps1
+++ b/Private/WinGet/New-IntuneWinPackage.ps1
@@ -258,11 +258,11 @@ function New-IntuneWinPackage {
 
     $outputDirectory = Split-Path -Path $PackagingContext.OutputPath -Parent
     if (-not [string]::IsNullOrWhiteSpace($outputDirectory) -and -not (Test-Path -Path $outputDirectory)) {
-        $null = New-Item -Path $outputDirectory -ItemType Directory -Force
+        $null = New-Item -Path $outputDirectory -ItemType Directory -Force -ErrorAction Stop
     }
 
     $workingRoot = Join-Path -Path $outputDirectory -ChildPath ('.winget-packaging-{0}' -f [guid]::NewGuid().ToString('N'))
-    $null = New-Item -Path $workingRoot -ItemType Directory -Force
+    $null = New-Item -Path $workingRoot -ItemType Directory -Force -ErrorAction Stop
 
     $sourceArchivePath = Join-Path -Path $workingRoot -ChildPath 'source-content.zip'
     $encryptedArchivePath = Join-Path -Path $workingRoot -ChildPath 'IntunePackage.intunewin'
@@ -282,7 +282,7 @@ function New-IntuneWinPackage {
             }
 
             Write-Debug "Removing existing .intunewin output at '$($PackagingContext.OutputPath)'."
-            Remove-Item -Path $PackagingContext.OutputPath -Force
+            Remove-Item -Path $PackagingContext.OutputPath -Force -ErrorAction Stop
         }
 
         [System.IO.Compression.ZipFile]::CreateFromDirectory(

--- a/Private/WinGet/New-IntuneWinPackage.ps1
+++ b/Private/WinGet/New-IntuneWinPackage.ps1
@@ -333,7 +333,11 @@ function New-IntuneWinPackage {
     } finally {
         if (Test-Path -Path $workingRoot) {
             Write-Debug "Removing packaging working directory '$workingRoot'."
-            Remove-Item -Path $workingRoot -Recurse -Force
+            try {
+                Remove-Item -Path $workingRoot -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Debug "Failed to remove packaging working directory '$workingRoot'. Error='$($_.Exception.Message)'."
+            }
         }
     }
 }

--- a/Private/WinGet/New-IntuneWinPackage.ps1
+++ b/Private/WinGet/New-IntuneWinPackage.ps1
@@ -1,0 +1,339 @@
+function New-IntuneWinPackage {
+    <#
+    .SYNOPSIS
+        Builds a repo-owned .intunewin package.
+    .DESCRIPTION
+        Packages a source directory into the Intune portal-compatible .intunewin
+        structure by zipping the source, encrypting the inner archive, generating a
+        Detection.xml manifest, and producing the final outer package.
+    .PARAMETER PackagingContext
+        Packaging context returned by New-IntuneWinPackagingContext.
+    .OUTPUTS
+        PSCustomObject describing the generated package.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        [psobject]$PackagingContext
+    )
+
+    function ConvertTo-Base64 {
+        param(
+            [Parameter(Mandatory)]
+            [byte[]]$Value
+        )
+
+        return [Convert]::ToBase64String($Value)
+    }
+
+    function Format-DetectionXml {
+        param(
+            [Parameter(Mandatory)]
+            [string]$DisplayName,
+
+            [Parameter(Mandatory)]
+            [string]$InnerFileName,
+
+            [Parameter(Mandatory)]
+            [string]$SetupFile,
+
+            [Parameter(Mandatory)]
+            [int64]$UnencryptedContentSize,
+
+            [Parameter(Mandatory)]
+            [hashtable]$EncryptionInfo
+        )
+
+        $xml = [System.Xml.XmlDocument]::new()
+        $applicationInfo = $xml.CreateElement('ApplicationInfo')
+        $applicationInfo.SetAttribute('ToolVersion', '1.4.0.0')
+        [void]$xml.AppendChild($applicationInfo)
+
+        foreach ($node in @(
+                @{ Name = 'Name'; Value = $DisplayName },
+                @{ Name = 'UnencryptedContentSize'; Value = $UnencryptedContentSize },
+                @{ Name = 'FileName'; Value = $InnerFileName },
+                @{ Name = 'SetupFile'; Value = $SetupFile }
+            )) {
+            $element = $xml.CreateElement($node.Name)
+            $element.InnerText = [string]$node.Value
+            [void]$applicationInfo.AppendChild($element)
+        }
+
+        $encryptionElement = $xml.CreateElement('EncryptionInfo')
+        foreach ($node in @(
+                @{ Name = 'EncryptionKey'; Value = $EncryptionInfo.EncryptionKey },
+                @{ Name = 'MacKey'; Value = $EncryptionInfo.MacKey },
+                @{ Name = 'InitializationVector'; Value = $EncryptionInfo.InitializationVector },
+                @{ Name = 'Mac'; Value = $EncryptionInfo.Mac },
+                @{ Name = 'ProfileIdentifier'; Value = $EncryptionInfo.ProfileIdentifier },
+                @{ Name = 'FileDigest'; Value = $EncryptionInfo.FileDigest },
+                @{ Name = 'FileDigestAlgorithm'; Value = $EncryptionInfo.FileDigestAlgorithm }
+            )) {
+            $element = $xml.CreateElement($node.Name)
+            $element.InnerText = [string]$node.Value
+            [void]$encryptionElement.AppendChild($element)
+        }
+        [void]$applicationInfo.AppendChild($encryptionElement)
+
+        $builder = [System.Text.StringBuilder]::new()
+        $settings = [System.Xml.XmlWriterSettings]::new()
+        $settings.Indent = $true
+        $settings.IndentChars = '  '
+        $settings.NewLineChars = "`r`n"
+        $settings.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+        $settings.OmitXmlDeclaration = $true
+
+        $writer = [System.Xml.XmlWriter]::Create($builder, $settings)
+        try {
+            $xml.Save($writer)
+        } finally {
+            $writer.Dispose()
+        }
+
+        return $builder.ToString()
+    }
+
+    function Protect-ArchiveFile {
+        param(
+            [Parameter(Mandatory)]
+            [string]$SourcePath,
+
+            [Parameter(Mandatory)]
+            [string]$DestinationPath
+        )
+
+        $encryptionAlgorithm = [System.Security.Cryptography.Aes]::Create()
+        $macAlgorithm = [System.Security.Cryptography.Aes]::Create()
+        $hashAlgorithm = [System.Security.Cryptography.SHA256]::Create()
+        $macLength = 32
+        $sourceHashStream = $null
+        $outputStream = $null
+        $sourceStream = $null
+        $cryptoStream = $null
+        $hmac = $null
+
+        try {
+            $encryptionAlgorithm.GenerateKey()
+            $macAlgorithm.GenerateKey()
+            $initializationVector = $encryptionAlgorithm.IV
+
+            $sourceHashStream = [System.IO.File]::OpenRead($SourcePath)
+            $fileDigest = $hashAlgorithm.ComputeHash($sourceHashStream)
+            $sourceHashStream.Dispose()
+            $sourceHashStream = $null
+
+            $outputStream = [System.IO.File]::Open($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+            $placeholderBytes = [byte[]]::new($macLength + $initializationVector.Length)
+            $outputStream.Write($placeholderBytes, 0, $placeholderBytes.Length)
+
+            $sourceStream = [System.IO.File]::OpenRead($SourcePath)
+            $encryptor = $encryptionAlgorithm.CreateEncryptor($encryptionAlgorithm.Key, $initializationVector)
+            $cryptoStream = [System.Security.Cryptography.CryptoStream]::new($outputStream, $encryptor, [System.Security.Cryptography.CryptoStreamMode]::Write, $true)
+            $sourceStream.CopyTo($cryptoStream)
+            $cryptoStream.FlushFinalBlock()
+            $cryptoStream.Dispose()
+            $cryptoStream = $null
+            $sourceStream.Dispose()
+            $sourceStream = $null
+
+            $outputStream.Position = $macLength
+            $outputStream.Write($initializationVector, 0, $initializationVector.Length)
+            $outputStream.Flush()
+
+            $hmac = [System.Security.Cryptography.HMACSHA256]::new($macAlgorithm.Key)
+            $outputStream.Position = $macLength
+            $mac = $hmac.ComputeHash($outputStream)
+            $hmac.Dispose()
+            $hmac = $null
+
+            $outputStream.Position = 0
+            $outputStream.Write($mac, 0, $mac.Length)
+            $outputStream.Flush()
+
+            return @{
+                EncryptionKey        = ConvertTo-Base64 -Value $encryptionAlgorithm.Key
+                MacKey               = ConvertTo-Base64 -Value $macAlgorithm.Key
+                InitializationVector = ConvertTo-Base64 -Value $initializationVector
+                Mac                  = ConvertTo-Base64 -Value $mac
+                ProfileIdentifier    = 'ProfileVersion1'
+                FileDigest           = ConvertTo-Base64 -Value $fileDigest
+                FileDigestAlgorithm  = 'SHA256'
+            }
+        } finally {
+            if ($null -ne $hmac) {
+                $hmac.Dispose()
+            }
+
+            if ($null -ne $cryptoStream) {
+                $cryptoStream.Dispose()
+            }
+
+            if ($null -ne $sourceStream) {
+                $sourceStream.Dispose()
+            }
+
+            if ($null -ne $sourceHashStream) {
+                $sourceHashStream.Dispose()
+            }
+
+            if ($null -ne $outputStream) {
+                $outputStream.Dispose()
+            }
+
+            $encryptionAlgorithm.Dispose()
+            $macAlgorithm.Dispose()
+            $hashAlgorithm.Dispose()
+        }
+    }
+
+    function Add-ZipEntryFromFile {
+        param(
+            [Parameter(Mandatory)]
+            [System.IO.Compression.ZipArchive]$Archive,
+
+            [Parameter(Mandatory)]
+            [string]$EntryName,
+
+            [Parameter(Mandatory)]
+            [string]$SourcePath
+        )
+
+        $entry = $Archive.CreateEntry($EntryName, [System.IO.Compression.CompressionLevel]::NoCompression)
+        $entryStream = $entry.Open()
+        try {
+            $sourceStream = [System.IO.File]::OpenRead($SourcePath)
+            try {
+                $sourceStream.CopyTo($entryStream)
+            } finally {
+                $sourceStream.Dispose()
+            }
+        } finally {
+            $entryStream.Dispose()
+        }
+    }
+
+    function Add-ZipEntryFromText {
+        param(
+            [Parameter(Mandatory)]
+            [System.IO.Compression.ZipArchive]$Archive,
+
+            [Parameter(Mandatory)]
+            [string]$EntryName,
+
+            [Parameter(Mandatory)]
+            [string]$Content
+        )
+
+        $entry = $Archive.CreateEntry($EntryName, [System.IO.Compression.CompressionLevel]::NoCompression)
+        $entryStream = $entry.Open()
+        $writer = [System.IO.StreamWriter]::new($entryStream, [System.Text.Encoding]::UTF8)
+        try {
+            $writer.Write($Content)
+        } finally {
+            $writer.Dispose()
+            $entryStream.Dispose()
+        }
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    if (-not $PackagingContext.PackagingCapability -or -not $PackagingContext.PackagingCapability.SupportsCrossPlatformIntuneWin) {
+        throw 'The current platform does not support repo-owned .intunewin packaging.'
+    }
+
+    if (-not (Test-Path -Path $PackagingContext.SourcePath -PathType Container)) {
+        throw "Packaging source path not found: $($PackagingContext.SourcePath)"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($PackagingContext.SetupFile)) {
+        throw 'PackagingContext.SetupFile is required.'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($PackagingContext.OutputPath)) {
+        throw 'PackagingContext.OutputPath is required.'
+    }
+
+    $outputDirectory = Split-Path -Path $PackagingContext.OutputPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory) -and -not (Test-Path -Path $outputDirectory)) {
+        $null = New-Item -Path $outputDirectory -ItemType Directory -Force
+    }
+
+    $workingRoot = Join-Path -Path $outputDirectory -ChildPath ('.winget-packaging-{0}' -f [guid]::NewGuid().ToString('N'))
+    $null = New-Item -Path $workingRoot -ItemType Directory -Force
+
+    $sourceArchivePath = Join-Path -Path $workingRoot -ChildPath 'source-content.zip'
+    $encryptedArchivePath = Join-Path -Path $workingRoot -ChildPath 'IntunePackage.intunewin'
+    $innerFileName = 'IntunePackage.intunewin'
+    Write-Debug "Creating .intunewin package for '$($PackagingContext.PackageIdentifier)' version '$($PackagingContext.PackageVersion)'. SourcePath='$($PackagingContext.SourcePath)', SetupFile='$($PackagingContext.SetupFile)', OutputPath='$($PackagingContext.OutputPath)', WorkingRoot='$workingRoot'."
+
+    try {
+        if (Test-Path -Path $PackagingContext.OutputPath) {
+            if (-not $PSCmdlet.ShouldProcess($PackagingContext.OutputPath, 'Overwrite existing .intunewin package')) {
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.OperationCanceledException]::new("Refused to overwrite existing package '$($PackagingContext.OutputPath)'."),
+                    'IntuneWinPackageOverwriteDeclined',
+                    [System.Management.Automation.ErrorCategory]::OperationStopped,
+                    $PackagingContext.OutputPath
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
+            }
+
+            Write-Debug "Removing existing .intunewin output at '$($PackagingContext.OutputPath)'."
+            Remove-Item -Path $PackagingContext.OutputPath -Force
+        }
+
+        [System.IO.Compression.ZipFile]::CreateFromDirectory(
+            $PackagingContext.SourcePath,
+            $sourceArchivePath,
+            [System.IO.Compression.CompressionLevel]::Optimal,
+            $false
+        )
+
+        $unencryptedContentSize = (Get-Item -Path $sourceArchivePath).Length
+        Write-Debug "Created source archive '$sourceArchivePath' ($unencryptedContentSize bytes)."
+        $encryptionInfo = Protect-ArchiveFile -SourcePath $sourceArchivePath -DestinationPath $encryptedArchivePath
+        $encryptedContentSize = (Get-Item -Path $encryptedArchivePath).Length
+        Write-Debug "Encrypted WinGet package payload to '$encryptedArchivePath' ($encryptedContentSize bytes)."
+        $displayName = if ($PackagingContext.DisplayName) {
+            $PackagingContext.DisplayName
+        } elseif ($PackagingContext.PackageIdentifier) {
+            $PackagingContext.PackageIdentifier
+        } else {
+            $PackagingContext.SetupFile
+        }
+        $detectionXml = Format-DetectionXml -DisplayName $displayName -InnerFileName $innerFileName -SetupFile $PackagingContext.SetupFile -UnencryptedContentSize $unencryptedContentSize -EncryptionInfo $encryptionInfo
+
+        $fileStream = [System.IO.File]::Open($PackagingContext.OutputPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        try {
+            $archive = [System.IO.Compression.ZipArchive]::new($fileStream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
+            try {
+                Add-ZipEntryFromFile -Archive $archive -EntryName 'IntuneWinPackage/Contents/IntunePackage.intunewin' -SourcePath $encryptedArchivePath
+                Add-ZipEntryFromText -Archive $archive -EntryName 'IntuneWinPackage/Metadata/Detection.xml' -Content $detectionXml
+            } finally {
+                $archive.Dispose()
+            }
+        } finally {
+            $fileStream.Dispose()
+        }
+
+        $outputSize = (Get-Item -Path $PackagingContext.OutputPath).Length
+        Write-Debug "Created final .intunewin package at '$($PackagingContext.OutputPath)' ($outputSize bytes)."
+
+        return [PSCustomObject]@{
+            OutputPath       = $PackagingContext.OutputPath
+            FileName         = [System.IO.Path]::GetFileName($PackagingContext.OutputPath)
+            SetupFile        = $PackagingContext.SetupFile
+            UnencryptedSize  = $unencryptedContentSize
+            EncryptionInfo   = [PSCustomObject]$encryptionInfo
+            PackagingContext = $PackagingContext
+        }
+    } finally {
+        if (Test-Path -Path $workingRoot) {
+            Write-Debug "Removing packaging working directory '$workingRoot'."
+            Remove-Item -Path $workingRoot -Recurse -Force
+        }
+    }
+}

--- a/Private/WinGet/New-IntuneWinPackagingContext.ps1
+++ b/Private/WinGet/New-IntuneWinPackagingContext.ps1
@@ -1,0 +1,95 @@
+function New-IntuneWinPackagingContext {
+    <#
+    .SYNOPSIS
+        Creates a standardized context object for future .intunewin packaging.
+    .DESCRIPTION
+        Normalizes the inputs needed by a repo-owned packager so WinGet resolution,
+        staging, and Intune upload code can evolve independently.
+    .PARAMETER PackageMetadata
+        Metadata loaded from the bundled WinGet template resolvedPackage node.
+    .PARAMETER SourcePath
+        Directory containing files to package.
+    .PARAMETER SetupFile
+        Setup file to execute from the packaged content. Defaults to the selected
+        installer file name from PackageMetadata.
+    .PARAMETER OutputPath
+        Destination .intunewin path.
+    .PARAMETER InstallCommandLine
+        Command line Intune should run to install the app.
+    .PARAMETER UninstallCommandLine
+        Command line Intune should run to uninstall the app.
+    .PARAMETER DetectionRule
+        Detection rules to carry forward to Win32 app publishing.
+    .PARAMETER RequirementRule
+        Requirement rules to carry forward to Win32 app publishing.
+    .OUTPUTS
+        PSCustomObject describing a packaging request.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNull()]
+        [PSCustomObject]$PackageMetadata,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourcePath,
+
+        [Parameter()]
+        [string]$SetupFile,
+
+        [Parameter()]
+        [string]$OutputPath,
+
+        [Parameter()]
+        [string]$InstallCommandLine,
+
+        [Parameter()]
+        [string]$UninstallCommandLine,
+
+        [Parameter()]
+        [object[]]$DetectionRule = @(),
+
+        [Parameter()]
+        [object[]]$RequirementRule = @()
+    )
+
+    process {
+        $resolvedSetupFile = if ($SetupFile) {
+            $SetupFile
+        } elseif ($PackageMetadata.SelectedInstaller -and $PackageMetadata.SelectedInstaller.InstallerUrl) {
+            [System.IO.Path]::GetFileName(([System.Uri]$PackageMetadata.SelectedInstaller.InstallerUrl).AbsolutePath)
+        } else {
+            $null
+        }
+
+        if ([string]::IsNullOrWhiteSpace($resolvedSetupFile)) {
+            throw 'SetupFile could not be inferred from the selected installer. Provide -SetupFile explicitly.'
+        }
+
+        $packagingCapability = Get-IntuneWinPackagingCapability
+        Write-Debug "Creating WinGet packaging context for package '$($PackageMetadata.PackageIdentifier)' version '$($PackageMetadata.PackageVersion)'. SourcePath='$SourcePath', SetupFile='$resolvedSetupFile', OutputPath='$OutputPath'."
+        Write-Debug "Packaging context selected installer: $(Format-WinGetInstallerSummary -Installer $PackageMetadata.SelectedInstaller)."
+        Write-Debug "Packaging capability SupportsCrossPlatformIntuneWin=$($packagingCapability.SupportsCrossPlatformIntuneWin); ZipArchive=$($packagingCapability.Capabilities.ZipArchive); Aes=$($packagingCapability.Capabilities.Aes)."
+
+        return [PSCustomObject]@{
+            PackageFormat        = 'intunewin'
+            Source               = 'WinGet'
+            PackageIdentifier    = $PackageMetadata.PackageIdentifier
+            PackageVersion       = $PackageMetadata.PackageVersion
+            DisplayName          = $PackageMetadata.DisplayName
+            Publisher            = $PackageMetadata.Publisher
+            SourcePath           = $SourcePath
+            SetupFile            = $resolvedSetupFile
+            OutputPath           = $OutputPath
+            InstallCommandLine   = $InstallCommandLine
+            UninstallCommandLine = $UninstallCommandLine
+            DetectionRule        = @($DetectionRule)
+            RequirementRule      = @($RequirementRule)
+            SelectedInstaller    = $PackageMetadata.SelectedInstaller
+            ManifestSource       = $PackageMetadata.ManifestSource
+            PackagingCapability  = $packagingCapability
+        }
+    }
+}

--- a/Private/WinGet/New-WinGetOwnershipNotes.ps1
+++ b/Private/WinGet/New-WinGetOwnershipNotes.ps1
@@ -10,17 +10,30 @@ function New-WinGetOwnershipNotes {
     )
 
     $lines = [System.Collections.Generic.List[string]]::new()
+    $seenLines = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 
-    foreach ($noteLine in @($Template.metadata.notes)) {
-        if (-not [string]::IsNullOrWhiteSpace($noteLine)) {
-            $lines.Add([string]$noteLine)
+    function Add-OwnershipNoteLine {
+        param(
+            [Parameter()]
+            [AllowNull()]
+            [string]$Line
+        )
+
+        if ([string]::IsNullOrWhiteSpace($Line)) {
+            return
+        }
+
+        if ($seenLines.Add($Line)) {
+            $lines.Add($Line)
         }
     }
 
+    foreach ($noteLine in @($Template.metadata.notes)) {
+        Add-OwnershipNoteLine -Line ([string]$noteLine)
+    }
+
     foreach ($customNote in @($Template.metadata.placeholders.customNotes)) {
-        if (-not [string]::IsNullOrWhiteSpace($customNote)) {
-            $lines.Add([string]$customNote)
-        }
+        Add-OwnershipNoteLine -Line ([string]$customNote)
     }
 
     $sourceMarker = if ($Template.metadata.markers.source) {
@@ -37,10 +50,8 @@ function New-WinGetOwnershipNotes {
             ('WinGetManifestRepository: {0}' -f $PackageMetadata.ManifestSource.Repository),
             ('WinGetManifestPath: {0}' -f $PackageMetadata.ManifestPath)
         )) {
-        if (-not [string]::IsNullOrWhiteSpace($metadataLine)) {
-            $lines.Add($metadataLine)
-        }
+        Add-OwnershipNoteLine -Line $metadataLine
     }
 
-    return ($lines | Select-Object -Unique) -join [Environment]::NewLine
+    return $lines -join [Environment]::NewLine
 }

--- a/Private/WinGet/New-WinGetOwnershipNotes.ps1
+++ b/Private/WinGet/New-WinGetOwnershipNotes.ps1
@@ -1,0 +1,46 @@
+function New-WinGetOwnershipNotes {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Template,
+
+        [Parameter(Mandatory)]
+        [psobject]$PackageMetadata
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($noteLine in @($Template.metadata.notes)) {
+        if (-not [string]::IsNullOrWhiteSpace($noteLine)) {
+            $lines.Add([string]$noteLine)
+        }
+    }
+
+    foreach ($customNote in @($Template.metadata.placeholders.customNotes)) {
+        if (-not [string]::IsNullOrWhiteSpace($customNote)) {
+            $lines.Add([string]$customNote)
+        }
+    }
+
+    $sourceMarker = if ($Template.metadata.markers.source) {
+        [string]$Template.metadata.markers.source
+    } else {
+        'Imported from WinGet'
+    }
+
+    foreach ($metadataLine in @(
+            $sourceMarker,
+            ('WinGetPackageIdentifier: {0}' -f $PackageMetadata.PackageIdentifier),
+            ('WinGetPackageVersion: {0}' -f $PackageMetadata.PackageVersion),
+            ('WinGetTemplateId: {0}' -f $Template.templateId),
+            ('WinGetManifestRepository: {0}' -f $PackageMetadata.ManifestSource.Repository),
+            ('WinGetManifestPath: {0}' -f $PackageMetadata.ManifestPath)
+        )) {
+        if (-not [string]::IsNullOrWhiteSpace($metadataLine)) {
+            $lines.Add($metadataLine)
+        }
+    }
+
+    return ($lines | Select-Object -Unique) -join [Environment]::NewLine
+}

--- a/Private/WinGet/New-WinGetPackageMetadataFromTemplate.ps1
+++ b/Private/WinGet/New-WinGetPackageMetadataFromTemplate.ps1
@@ -1,0 +1,64 @@
+function New-WinGetPackageMetadataFromTemplate {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Template
+    )
+
+    if (-not $Template.PSObject.Properties.Name.Contains('resolvedPackage') -or $null -eq $Template.resolvedPackage) {
+        throw "Unsupported WinGet template '$($Template.templateId)'. Open an issue requesting this app or submit a PR that adds bundled resolvedPackage metadata."
+    }
+
+    $resolvedPackage = $Template.resolvedPackage
+    $match = $Template.package.match
+    $manifestSource = $resolvedPackage.manifestSource
+    $selectedInstaller = $resolvedPackage.selectedInstaller
+
+    if ($null -eq $manifestSource -or $null -eq $selectedInstaller) {
+        throw "WinGet template '$($Template.templateId)' resolvedPackage metadata is incomplete."
+    }
+
+    $packageVersion = [string]$resolvedPackage.packageVersion
+    $packagePath = [string]$manifestSource.packagePath
+    $versionPath = [string]$manifestSource.versionPath
+    $repository = [string]$manifestSource.repository
+
+    return [PSCustomObject]@{
+        PackageIdentifier = [string]$Template.packageIdentifier
+        PackageVersion    = $packageVersion
+        PackageLocale     = [string]$match.locale
+        DisplayName       = [string]$Template.displayName
+        Publisher         = [string]$Template.publisher
+        Description       = [string]$Template.description
+        LocaleManifest    = [PSCustomObject]@{
+            PackageLocale    = [string]$match.locale
+            PackageName      = [string]$Template.displayName
+            Publisher        = [string]$Template.publisher
+            ShortDescription = [string]$Template.description
+            Icons            = @()
+        }
+        InstallerManifest = [PSCustomObject]@{
+            PackageIdentifier = [string]$Template.packageIdentifier
+            PackageVersion    = $packageVersion
+            InstallerType     = $selectedInstaller.InstallerType
+            Installers        = @($selectedInstaller)
+        }
+        VersionManifest   = [PSCustomObject]@{
+            PackageIdentifier = [string]$Template.packageIdentifier
+            PackageVersion    = $packageVersion
+        }
+        ManifestPath      = $versionPath
+        ManifestSource    = [PSCustomObject]@{
+            Type          = 'Template'
+            Repository    = $repository
+            Ref           = [string]$manifestSource.ref
+            PackagePath   = $packagePath
+            VersionPath   = $versionPath
+            InstallerFile = if ($manifestSource.installerFile) { [string]$manifestSource.installerFile } else { $null }
+            LocaleFile    = if ($manifestSource.localeFile) { [string]$manifestSource.localeFile } else { $null }
+        }
+        Installers        = @($selectedInstaller)
+        SelectedInstaller = $selectedInstaller
+    }
+}

--- a/Private/WinGet/New-WinGetRemediationBody.ps1
+++ b/Private/WinGet/New-WinGetRemediationBody.ps1
@@ -1,0 +1,38 @@
+function New-WinGetRemediationBody {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Definition,
+
+        [Parameter(Mandatory)]
+        [bool]$IncludeCreateOnlyProperties
+    )
+
+    $detectionScriptContent = New-WinGetRemediationScriptContent -PackageIdentifiers $Definition.PackageIdentifiers -Scope $Definition.Scope -ScriptType 'Detection'
+    $remediationScriptContent = New-WinGetRemediationScriptContent -PackageIdentifiers $Definition.PackageIdentifiers -Scope $Definition.Scope -ScriptType 'Remediation'
+    $scopeFolderName = [cultureinfo]::InvariantCulture.TextInfo.ToTitleCase($Definition.Scope)
+    $null = Save-HydrationGeneratedScript -RelativePath "WinGetRemediations/$scopeFolderName/Detect-WinGetAppUpdates.ps1" -Content $detectionScriptContent
+    $null = Save-HydrationGeneratedScript -RelativePath "WinGetRemediations/$scopeFolderName/Remediate-WinGetAppUpdates.ps1" -Content $remediationScriptContent
+
+    $body = @{
+        publisher                   = 'WinGet'
+        displayName                 = $Definition.DisplayName
+        description                 = $Definition.Description
+        detectionScriptContent      = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($detectionScriptContent))
+        remediationScriptContent    = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($remediationScriptContent))
+        runAs32Bit                  = $false
+        runAsAccount                = $Definition.RunAsAccount
+        enforceSignatureCheck       = $false
+        roleScopeTagIds             = @('0')
+        detectionScriptParameters   = @()
+        remediationScriptParameters = @()
+    }
+
+    if ($IncludeCreateOnlyProperties) {
+        $body['@odata.type'] = '#microsoft.graph.deviceHealthScript'
+        $body['isGlobalScript'] = $false
+    }
+
+    return $body
+}

--- a/Private/WinGet/New-WinGetRemediationDescription.ps1
+++ b/Private/WinGet/New-WinGetRemediationDescription.ps1
@@ -1,0 +1,23 @@
+function New-WinGetRemediationDescription {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Scope,
+
+        [Parameter(Mandatory)]
+        [string[]]$PackageIdentifiers
+    )
+
+    $scopeLabel = if ($Scope -eq 'system') { 'system' } else { 'user' }
+    $fingerprint = Get-WinGetRemediationFingerprint -PackageIdentifiers $PackageIdentifiers
+
+    return @(
+        "Auto-update remediation for WinGet apps ($scopeLabel scope)."
+        $script:HydrationMarker
+        'Imported from WinGet'
+        "WinGetRemediationScope: $scopeLabel"
+        "WinGetPackageCount: $(@($PackageIdentifiers | Sort-Object -Unique).Count)"
+        "WinGetPackageFingerprint: $fingerprint"
+    ) -join [Environment]::NewLine
+}

--- a/Private/WinGet/New-WinGetRemediationScriptContent.ps1
+++ b/Private/WinGet/New-WinGetRemediationScriptContent.ps1
@@ -1,0 +1,148 @@
+function New-WinGetRemediationScriptContent {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$PackageIdentifiers,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('system', 'user')]
+        [string]$Scope,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Detection', 'Remediation')]
+        [string]$ScriptType
+    )
+
+    $escapedPackageIdentifiers = @(
+        $PackageIdentifiers |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique |
+            ForEach-Object { "'{0}'" -f (($_ -replace "'", "''")) }
+    )
+
+    $allowListLiteral = if ($escapedPackageIdentifiers.Count -gt 0) {
+        "@({0})" -f ($escapedPackageIdentifiers -join ', ')
+    } else {
+        '@()'
+    }
+
+    $wingetScope = if ($Scope -eq 'system') { 'machine' } else { 'user' }
+    $scopeLabel = if ($Scope -eq 'system') { 'System' } else { 'User' }
+    $logOperation = if ($ScriptType -eq 'Detection') { 'Detect' } else { 'Remediate' }
+    $bootstrapFragment = Get-WinGetBootstrapScriptFragment -LogFunctionName 'Write-RemediationLog' -BootstrapMessage 'Bootstrapping WinGet for proactive remediation.'
+    $scriptSuffix = if ($ScriptType -eq 'Detection') {
+        @"
+`$pendingUpgrades = [System.Collections.Generic.List[string]]::new()
+foreach (`$packageIdentifier in `$packageIdentifiers) {
+    `$escapedPackageIdentifier = [regex]::Escape(`$packageIdentifier)
+    if (`$upgradeOutput -match `$escapedPackageIdentifier) {
+        Write-RemediationLog -Message "Upgrade available for `$packageIdentifier."
+        `$pendingUpgrades.Add(`$packageIdentifier)
+    }
+}
+
+if (`$pendingUpgrades.Count -gt 0) {
+    Write-RemediationLog -Message "Pending upgrades: `$(`$pendingUpgrades -join ', ')"
+    exit 1
+}
+
+Write-RemediationLog -Message 'No upgrades needed.'
+exit 0
+"@
+    } else {
+        @"
+`$completedUpgrades = [System.Collections.Generic.List[string]]::new()
+`$failedUpgrades = [System.Collections.Generic.List[string]]::new()
+foreach (`$packageIdentifier in `$packageIdentifiers) {
+    `$escapedPackageIdentifier = [regex]::Escape(`$packageIdentifier)
+    if (`$upgradeOutput -notmatch `$escapedPackageIdentifier) {
+        continue
+    }
+
+    Write-RemediationLog -Message "Upgrade available for `$packageIdentifier. Starting remediation."
+    & `$wingetPath upgrade --id "`$packageIdentifier" --exact --silent --force --scope `$scope --accept-package-agreements --accept-source-agreements 2>&1 | Out-String | ForEach-Object {
+        if (-not [string]::IsNullOrWhiteSpace(`$_)) {
+            Write-RemediationLog -Message `$_
+        }
+    }
+
+    `$exitCode = `$LASTEXITCODE
+    if (`$exitCode -eq 0 -or `$exitCode -eq -1978335189) {
+        `$completedUpgrades.Add(`$packageIdentifier)
+        Write-RemediationLog -Message "Upgrade completed for `$packageIdentifier with exit code `$exitCode."
+    } else {
+        `$failedUpgrades.Add("`$packageIdentifier (`$exitCode)")
+        Write-RemediationLog -Message "Upgrade failed for `$packageIdentifier with exit code `$exitCode." -Level 'WARN'
+    }
+}
+
+if (`$failedUpgrades.Count -gt 0) {
+    Write-RemediationLog -Message "Failed upgrades: `$(`$failedUpgrades -join ', ')" -Level 'ERROR'
+    exit 1
+}
+
+if (`$completedUpgrades.Count -gt 0) {
+    Write-RemediationLog -Message "Completed upgrades: `$(`$completedUpgrades -join ', ')"
+} else {
+    Write-RemediationLog -Message 'No upgrades were applicable during remediation.'
+}
+
+exit 0
+"@
+    }
+
+    return @"
+`$ErrorActionPreference = 'Stop'
+`$packageIdentifiers = $allowListLiteral
+`$scope = '$wingetScope'
+`$scopeLabel = '$scopeLabel'
+
+function Get-IntuneManagementExtensionLogDirectory {
+    [CmdletBinding()]
+    param()
+
+    `$programDataPath = if (-not [string]::IsNullOrWhiteSpace(`$env:ProgramData)) {
+        `$env:ProgramData
+    } else {
+        'C:\ProgramData'
+    }
+
+    `$logDirectory = Join-Path -Path `$programDataPath -ChildPath 'Microsoft\IntuneManagementExtension\Logs'
+    if (-not (Test-Path -Path `$logDirectory)) {
+        `$null = New-Item -Path `$logDirectory -ItemType Directory -Force
+    }
+
+    return `$logDirectory
+}
+
+function Write-RemediationLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]`$Message,
+
+        [Parameter()]
+        [ValidateSet('INFO', 'WARN', 'ERROR')]
+        [string]`$Level = 'INFO'
+    )
+
+    `$timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
+    `$entry = "[`$timestamp] [`$Level] `$Message"
+    Add-Content -Path `$script:logPath -Value `$entry
+    Write-Output `$entry
+}
+
+`$logDirectory = Get-IntuneManagementExtensionLogDirectory
+`$script:logPath = Join-Path -Path `$logDirectory -ChildPath "IntuneHydrationKit-WinGet-Remediation-$scopeLabel-$logOperation.log"
+
+Write-RemediationLog -Message "Starting WinGet proactive remediation $ScriptType for `$scopeLabel scope."
+Write-RemediationLog -Message "Allowlist contains `$(`$packageIdentifiers.Count) package identifier(s)."
+
+$bootstrapFragment
+
+`$wingetPath = Get-WinGetExecutablePath
+Write-RemediationLog -Message "Resolved winget executable: `$wingetPath"
+
+`$upgradeOutput = & `$wingetPath upgrade --scope `$scope --accept-source-agreements 2>&1 | Out-String
+Write-RemediationLog -Message "Upgrade scan completed for `$scopeLabel scope."
+"@ + [Environment]::NewLine + $scriptSuffix
+}

--- a/Private/WinGet/New-WinGetWrapperFiles.ps1
+++ b/Private/WinGet/New-WinGetWrapperFiles.ps1
@@ -1,0 +1,32 @@
+function New-WinGetWrapperFiles {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [psobject]$Template
+    )
+
+    if (-not (Test-Path -Path $Path)) {
+        $null = New-Item -Path $Path -ItemType Directory -Force
+    }
+
+    $installScriptPath = Join-Path -Path $Path -ChildPath 'Install-WinGetPackage.ps1'
+    $uninstallScriptPath = Join-Path -Path $Path -ChildPath 'Uninstall-WinGetPackage.ps1'
+    $detectionScriptPath = Join-Path -Path $Path -ChildPath 'Detect-WinGetPackage.ps1'
+
+    Set-Content -Path $installScriptPath -Value (Get-WinGetWrapperScriptContent -WingetCommand $Template.install.command -PackageIdentifier $Template.packageIdentifier -Operation Install) -Encoding utf8
+    Set-Content -Path $uninstallScriptPath -Value (Get-WinGetWrapperScriptContent -WingetCommand $Template.uninstall.command -PackageIdentifier $Template.packageIdentifier -Operation Uninstall) -Encoding utf8
+    Set-Content -Path $detectionScriptPath -Value (Get-WinGetDetectionScriptContent -PackageIdentifier $Template.packageIdentifier -DisplayName $Template.displayName -Publisher $Template.publisher) -Encoding utf8
+    $null = Save-HydrationGeneratedScript -RelativePath (Join-Path -Path "WinGetApps/$($Template.templateId)" -ChildPath 'Install-WinGetPackage.ps1') -SourcePath $installScriptPath
+    $null = Save-HydrationGeneratedScript -RelativePath (Join-Path -Path "WinGetApps/$($Template.templateId)" -ChildPath 'Uninstall-WinGetPackage.ps1') -SourcePath $uninstallScriptPath
+    $null = Save-HydrationGeneratedScript -RelativePath (Join-Path -Path "WinGetApps/$($Template.templateId)/Detection" -ChildPath 'Detect-WinGetPackage.ps1') -SourcePath $detectionScriptPath
+
+    return [PSCustomObject]@{
+        InstallScriptPath   = $installScriptPath
+        UninstallScriptPath = $uninstallScriptPath
+        DetectionScriptPath = $detectionScriptPath
+    }
+}

--- a/Private/WinGet/New-WinGetWrapperFiles.ps1
+++ b/Private/WinGet/New-WinGetWrapperFiles.ps1
@@ -10,16 +10,16 @@ function New-WinGetWrapperFiles {
     )
 
     if (-not (Test-Path -Path $Path)) {
-        $null = New-Item -Path $Path -ItemType Directory -Force
+        $null = New-Item -Path $Path -ItemType Directory -Force -ErrorAction Stop
     }
 
     $installScriptPath = Join-Path -Path $Path -ChildPath 'Install-WinGetPackage.ps1'
     $uninstallScriptPath = Join-Path -Path $Path -ChildPath 'Uninstall-WinGetPackage.ps1'
     $detectionScriptPath = Join-Path -Path $Path -ChildPath 'Detect-WinGetPackage.ps1'
 
-    Set-Content -Path $installScriptPath -Value (Get-WinGetWrapperScriptContent -WingetCommand $Template.install.command -PackageIdentifier $Template.packageIdentifier -Operation Install) -Encoding utf8
-    Set-Content -Path $uninstallScriptPath -Value (Get-WinGetWrapperScriptContent -WingetCommand $Template.uninstall.command -PackageIdentifier $Template.packageIdentifier -Operation Uninstall) -Encoding utf8
-    Set-Content -Path $detectionScriptPath -Value (Get-WinGetDetectionScriptContent -PackageIdentifier $Template.packageIdentifier -DisplayName $Template.displayName -Publisher $Template.publisher) -Encoding utf8
+    Set-Content -Path $installScriptPath -Value (Get-WinGetWrapperScriptContent -WingetCommand $Template.install.command -PackageIdentifier $Template.packageIdentifier -Operation Install) -Encoding utf8 -ErrorAction Stop
+    Set-Content -Path $uninstallScriptPath -Value (Get-WinGetWrapperScriptContent -WingetCommand $Template.uninstall.command -PackageIdentifier $Template.packageIdentifier -Operation Uninstall) -Encoding utf8 -ErrorAction Stop
+    Set-Content -Path $detectionScriptPath -Value (Get-WinGetDetectionScriptContent -PackageIdentifier $Template.packageIdentifier -DisplayName $Template.displayName -Publisher $Template.publisher) -Encoding utf8 -ErrorAction Stop
     $null = Save-HydrationGeneratedScript -RelativePath (Join-Path -Path "WinGetApps/$($Template.templateId)" -ChildPath 'Install-WinGetPackage.ps1') -SourcePath $installScriptPath
     $null = Save-HydrationGeneratedScript -RelativePath (Join-Path -Path "WinGetApps/$($Template.templateId)" -ChildPath 'Uninstall-WinGetPackage.ps1') -SourcePath $uninstallScriptPath
     $null = Save-HydrationGeneratedScript -RelativePath (Join-Path -Path "WinGetApps/$($Template.templateId)/Detection" -ChildPath 'Detect-WinGetPackage.ps1') -SourcePath $detectionScriptPath

--- a/Private/WinGet/Publish-IntuneWin32AppContent.ps1
+++ b/Private/WinGet/Publish-IntuneWin32AppContent.ps1
@@ -35,7 +35,7 @@ function Publish-IntuneWin32AppContent {
     }
 
     if (-not (Test-Path -Path $WorkingDirectory)) {
-        $null = New-Item -Path $WorkingDirectory -ItemType Directory -Force
+        $null = New-Item -Path $WorkingDirectory -ItemType Directory -Force -ErrorAction Stop
     }
 
     $encryptedContentPath = Join-Path -Path $WorkingDirectory -ChildPath $Metadata.FileName

--- a/Private/WinGet/Publish-IntuneWin32AppContent.ps1
+++ b/Private/WinGet/Publish-IntuneWin32AppContent.ps1
@@ -107,7 +107,11 @@ function Publish-IntuneWin32AppContent {
     } finally {
         if (Test-Path -Path $encryptedContentPath) {
             Write-Debug "Removing temporary encrypted content file '$encryptedContentPath'."
-            Remove-Item -Path $encryptedContentPath -Force
+            try {
+                Remove-Item -Path $encryptedContentPath -Force -ErrorAction Stop
+            } catch {
+                Write-Debug "Failed to remove temporary encrypted content file '$encryptedContentPath'. Error='$($_.Exception.Message)'."
+            }
         }
     }
 }

--- a/Private/WinGet/Publish-IntuneWin32AppContent.ps1
+++ b/Private/WinGet/Publish-IntuneWin32AppContent.ps1
@@ -1,0 +1,113 @@
+function Publish-IntuneWin32AppContent {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AppId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IntuneWinPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$WorkingDirectory,
+
+        [Parameter()]
+        [psobject]$Metadata,
+
+        [Parameter()]
+        [int]$TimeoutSeconds = 180
+    )
+
+    function Get-UploadUriForLogging {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Uri
+        )
+
+        return ($Uri -split '\?', 2)[0]
+    }
+
+    if (-not $Metadata) {
+        $Metadata = Get-IntuneWinPackageMetadata -IntuneWinPath $IntuneWinPath
+    }
+
+    if (-not (Test-Path -Path $WorkingDirectory)) {
+        $null = New-Item -Path $WorkingDirectory -ItemType Directory -Force
+    }
+
+    $encryptedContentPath = Join-Path -Path $WorkingDirectory -ChildPath $Metadata.FileName
+    $contentVersionUri = "beta/deviceAppManagement/mobileApps/$AppId/microsoft.graph.win32LobApp/contentVersions"
+    $appUri = "beta/deviceAppManagement/mobileApps/$AppId"
+    Write-Debug "Publishing Win32 app content for AppId='$AppId'. IntuneWinPath='$IntuneWinPath', WorkingDirectory='$WorkingDirectory', PackageFileName='$($Metadata.FileName)'."
+
+    $null = Expand-IntuneWinPackageEncryptedContent -IntuneWinPath $IntuneWinPath -FileName $Metadata.FileName -DestinationPath $encryptedContentPath
+    try {
+        Write-Debug "Expanded encrypted Win32 content to '$encryptedContentPath'."
+        $contentVersionId = (Invoke-HydrationGraphRequest -Method POST -Uri $contentVersionUri -Body @{}).id
+        Write-Debug "Created Win32 content version '$contentVersionId' for app '$AppId'."
+        $encryptedSize = (Get-Item -Path $encryptedContentPath).Length
+        $contentFileUri = "$contentVersionUri/$contentVersionId/files"
+        $contentFile = Invoke-HydrationGraphRequest -Method POST -Uri $contentFileUri -Body @{
+            '@odata.type' = '#microsoft.graph.mobileAppContentFile'
+            name          = $Metadata.FileName
+            size          = [int64]$Metadata.UnencryptedSize
+            sizeEncrypted = [int64]$encryptedSize
+            manifest      = $null
+            isDependency  = $false
+        }
+
+        $contentFileId = $contentFile.id
+        Write-Debug "Created Win32 content file '$contentFileId' for app '$AppId' (UnencryptedSize=$([int64]$Metadata.UnencryptedSize), EncryptedSize=$encryptedSize)."
+        $fileInfo = Wait-IntuneWin32ContentState -AppId $AppId -ContentVersionId $contentVersionId -FileId $contentFileId -DesiredState 'azureStorageUriRequestSuccess' -TimeoutSeconds $TimeoutSeconds
+        Write-Debug "Received Azure Storage upload target for content file '$contentFileId': '$(Get-UploadUriForLogging -Uri $fileInfo.azureStorageUri)'."
+
+        $renewUploadAction = ${function:Get-IntuneWin32RenewedUploadUri}
+        $renewUploadUri = {
+            $renewedUploadUri = & $renewUploadAction -AppId $AppId -ContentVersionId $contentVersionId -ContentFileId $contentFileId -ContentFileUri $contentFileUri -TimeoutSeconds $TimeoutSeconds
+            Write-Debug "Received renewed Azure Storage upload target for content file '$contentFileId': '$(Get-UploadUriForLogging -Uri $renewedUploadUri)'."
+            return $renewedUploadUri
+        }
+
+        $uploadResult = Send-IntuneWinAzureStorageChunkedUpload -FilePath $encryptedContentPath -UploadUri $fileInfo.azureStorageUri -RenewUploadUri $renewUploadUri
+        Write-Debug "Uploaded encrypted content for app '$AppId' using $($uploadResult.ChunkCount) chunk(s)."
+
+        Invoke-HydrationGraphRequest -Method POST -Uri "$contentFileUri/$contentFileId/commit" -Body @{
+            fileEncryptionInfo = @{
+                encryptionKey        = $Metadata.EncryptionKey
+                macKey               = $Metadata.MacKey
+                initializationVector = $Metadata.InitializationVector
+                mac                  = $Metadata.Mac
+                profileIdentifier    = $Metadata.ProfileIdentifier
+                fileDigest           = $Metadata.FileDigest
+                fileDigestAlgorithm  = $Metadata.FileDigestAlgorithm
+            }
+        } | Out-Null
+        Write-Debug "Submitted commit for content file '$contentFileId' in content version '$contentVersionId'."
+
+        Wait-IntuneWin32ContentState -AppId $AppId -ContentVersionId $contentVersionId -FileId $contentFileId -DesiredState 'commitFileSuccess' -TimeoutSeconds $TimeoutSeconds | Out-Null
+        Write-Debug "Win32 content file '$contentFileId' committed successfully."
+        Invoke-HydrationGraphRequest -Method PATCH -Uri $appUri -Body @{
+            '@odata.type'           = '#microsoft.graph.win32LobApp'
+            committedContentVersion = $contentVersionId
+        } | Out-Null
+        Write-Debug "Marked app '$AppId' committedContentVersion as '$contentVersionId'."
+
+        return [PSCustomObject]@{
+            AppId              = $AppId
+            ContentVersionId   = $contentVersionId
+            ContentFileId      = $contentFileId
+            PackagePath        = $encryptedContentPath
+            EncryptedSize      = $encryptedSize
+            UnencryptedSize    = [int64]$Metadata.UnencryptedSize
+            UploadedChunkCount = $uploadResult.ChunkCount
+        }
+    } finally {
+        if (Test-Path -Path $encryptedContentPath) {
+            Write-Debug "Removing temporary encrypted content file '$encryptedContentPath'."
+            Remove-Item -Path $encryptedContentPath -Force
+        }
+    }
+}

--- a/Private/WinGet/Remove-IntuneWinGetApps.ps1
+++ b/Private/WinGet/Remove-IntuneWinGetApps.ps1
@@ -1,0 +1,78 @@
+function Remove-IntuneWinGetApps {
+    <#
+    .SYNOPSIS
+        Removes WinGet hydration-owned Win32 apps that match the current template set.
+    .DESCRIPTION
+        Filters the supplied existing apps to those owned by the WinGet hydration importer
+        and whose displayName is in the known template name set, then batch-deletes them.
+        Supports WhatIf via the caller's ShouldProcess and WhatIfPreference state.
+    .PARAMETER ExistingApps
+        PSCustomObject with Items (array of app records) and Lookup (hashtable by name).
+    .PARAMETER KnownTemplateNames
+        HashSet of displayNames that are in scope for this operation.
+    .PARAMETER PSCmdlet
+        The calling cmdlet's $PSCmdlet so ShouldProcess decisions match the caller.
+    .PARAMETER WhatIfPreference
+        The caller's $WhatIfPreference value.
+    .OUTPUTS
+        PSCustomObject[] - Hydration results for each deleted or would-delete app.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$ExistingApps,
+
+        [Parameter(Mandatory)]
+        [System.Collections.Generic.HashSet[string]]$KnownTemplateNames,
+
+        [Parameter(Mandatory)]
+        [System.Management.Automation.PSCmdlet]$PSCmdlet,
+
+        [Parameter()]
+        [bool]$WhatIfPreference = $false
+    )
+
+    $appsToDelete = [System.Collections.Generic.List[hashtable]]::new()
+
+    foreach ($existingApp in $ExistingApps.Items) {
+        if (-not $existingApp.IsOwned) {
+            continue
+        }
+
+        if (-not $KnownTemplateNames.Contains($existingApp.DisplayName)) {
+            Write-Verbose "Skipping '$($existingApp.DisplayName)' - not in current WinGet templates"
+            Write-Debug "Delete decision: skipping '$($existingApp.DisplayName)' because it is WinGet-owned but not in the current template set."
+            continue
+        }
+
+        Write-Debug "Delete decision: queued '$($existingApp.DisplayName)' (AppId='$($existingApp.Id)') for deletion."
+        $appsToDelete.Add(@{
+                Name = $existingApp.DisplayName
+                Id   = $existingApp.Id
+                Url  = "/deviceAppManagement/mobileApps/$($existingApp.Id)"
+            })
+    }
+
+    if ($appsToDelete.Count -eq 0) {
+        Write-Verbose 'No WinGet hydration-owned apps found to delete'
+        return @()
+    }
+
+    $results = @()
+
+    if (-not $PSCmdlet.ShouldProcess("$($appsToDelete.Count) WinGet Win32 app(s)", 'Delete')) {
+        if ($WhatIfPreference) {
+            foreach ($app in $appsToDelete) {
+                $results += Add-HydrationDryRunResult -Action 'WouldDelete' -Name $app.Name -Type 'WinGetWin32App'
+            }
+        }
+
+        return $results
+    }
+
+    $appNames = (@($appsToDelete.Name)) -join "', '"
+    Write-Debug "Deleting $($appsToDelete.Count) WinGet-owned app(s): '$appNames'."
+    $results += Invoke-GraphBatchOperation -Items @($appsToDelete) -Operation 'DELETE' -ResultType 'WinGetWin32App'
+    return $results
+}

--- a/Private/WinGet/Resolve-WinGetAppIcon.ps1
+++ b/Private/WinGet/Resolve-WinGetAppIcon.ps1
@@ -87,6 +87,9 @@ function Resolve-WinGetAppIcon {
     }
 
     $iconResult = switch ($sourceType) {
+        'none' {
+            $null
+        }
         'file' {
             $filePath = [string]$iconConfig.fileName
 

--- a/Private/WinGet/Resolve-WinGetAppIcon.ps1
+++ b/Private/WinGet/Resolve-WinGetAppIcon.ps1
@@ -1,0 +1,125 @@
+function Resolve-WinGetAppIcon {
+    [CmdletBinding()]
+    [OutputType([psobject])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Template
+    )
+
+    function Get-IconMimeType {
+        param(
+            [Parameter()]
+            [string]$Path
+        )
+
+        $extension = [System.IO.Path]::GetExtension($Path)
+        switch ($extension.ToLowerInvariant()) {
+            '.png' { return 'image/png' }
+            '.jpg' { return 'image/jpeg' }
+            '.jpeg' { return 'image/jpeg' }
+            '.gif' { return 'image/gif' }
+            '.bmp' { return 'image/bmp' }
+            '.ico' { return 'image/x-icon' }
+            '.svg' { return 'image/svg+xml' }
+            default { return 'image/png' }
+        }
+    }
+
+    function Get-BytesFromFile {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path
+        )
+
+        $resolvedPath = $Path
+        if (-not [System.IO.Path]::IsPathRooted($resolvedPath)) {
+            $templateDirectory = Split-Path -Path ([string]$Template.TemplatePath) -Parent
+            if (-not [string]::IsNullOrWhiteSpace($templateDirectory)) {
+                $resolvedPath = Join-Path -Path $templateDirectory -ChildPath $resolvedPath
+            }
+        }
+
+        if (-not (Test-Path -Path $resolvedPath -PathType Leaf)) {
+            throw "Icon file not found: $resolvedPath"
+        }
+
+        return [PSCustomObject]@{
+            Bytes    = [System.IO.File]::ReadAllBytes($resolvedPath)
+            MimeType = Get-IconMimeType -Path $resolvedPath
+            Source   = $resolvedPath
+        }
+    }
+
+    function Get-BundledFallbackIcon {
+        $fallbackIconPath = $null
+        foreach ($candidateIconPath in @('media/IHKLogoClearLight.png', 'media/IHTLogoClearLight.png')) {
+            $candidatePath = Join-Path -Path $script:ModuleRoot -ChildPath $candidateIconPath
+            if (Test-Path -Path $candidatePath -PathType Leaf) {
+                $fallbackIconPath = $candidatePath
+                break
+            }
+        }
+
+        if (-not $fallbackIconPath) {
+            Write-Debug "Bundled fallback icon not found."
+            return $null
+        }
+
+        Write-Debug "Using bundled fallback icon at '$fallbackIconPath'."
+        return [PSCustomObject]@{
+            Bytes    = [System.IO.File]::ReadAllBytes($fallbackIconPath)
+            MimeType = Get-IconMimeType -Path $fallbackIconPath
+            Source   = $fallbackIconPath
+        }
+    }
+
+    if (-not $Template.PSObject.Properties.Name.Contains('icon') -or $null -eq $Template.icon) {
+        Write-Debug "No icon property was configured for WinGet template '$($Template.templateId)'. Falling back to bundled icon."
+        $iconConfig = [pscustomobject]@{}
+        $sourceType = 'none'
+    } else {
+        $iconConfig = $Template.icon
+        $sourceType = [string]$iconConfig.sourceType
+    }
+    if ([string]::IsNullOrWhiteSpace($sourceType) -or $sourceType -eq 'none') {
+        Write-Debug "No icon configured for WinGet template '$($Template.templateId)'. Falling back to bundled icon."
+        $sourceType = 'none'
+    }
+
+    $iconResult = switch ($sourceType) {
+        'file' {
+            $filePath = [string]$iconConfig.fileName
+
+            if ([string]::IsNullOrWhiteSpace($filePath)) {
+                Write-Debug "Template '$($Template.templateId)' specifies icon.sourceType='file' but icon.fileName is not set."
+                $null
+            } else {
+                try {
+                    Get-BytesFromFile -Path $filePath
+                } catch {
+                    Write-Debug "Failed to resolve template icon file for '$($Template.templateId)': $($_.Exception.Message)"
+                    $null
+                }
+            }
+        }
+        default {
+            Write-Debug "Unsupported icon source type '$sourceType' for template '$($Template.templateId)'."
+            $null
+        }
+    }
+
+    if ($null -eq $iconResult) {
+        $iconResult = Get-BundledFallbackIcon
+    }
+
+    if ($null -eq $iconResult -or $null -eq $iconResult.Bytes -or $iconResult.Bytes.Length -eq 0) {
+        return $null
+    }
+
+    Write-Debug "Resolved icon for WinGet template '$($Template.templateId)' from '$($iconResult.Source)' with MimeType='$($iconResult.MimeType)'."
+    return [PSCustomObject]@{
+        Base64   = [System.Convert]::ToBase64String($iconResult.Bytes)
+        MimeType = $iconResult.MimeType
+        Source   = $iconResult.Source
+    }
+}

--- a/Private/WinGet/Select-WinGetPackageInstaller.ps1
+++ b/Private/WinGet/Select-WinGetPackageInstaller.ps1
@@ -1,0 +1,127 @@
+function Select-WinGetPackageInstaller {
+    <#
+    .SYNOPSIS
+        Selects the best installer from resolved WinGet package metadata.
+    .DESCRIPTION
+        Applies deterministic scoring so future Win32 packaging can resolve the same
+        installer on any PowerShell 7 platform without shelling out to winget.
+    .PARAMETER Installer
+        Installer entries from a resolved WinGet package manifest.
+    .PARAMETER Architecture
+        Preferred architecture.
+    .PARAMETER Scope
+        Preferred install scope.
+    .PARAMETER InstallerLocale
+        Preferred installer locale.
+    .PARAMETER InstallerType
+        Preferred installer type.
+    .OUTPUTS
+        PSCustomObject representing the selected installer.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [object[]]$Installer,
+
+        [Parameter()]
+        [string]$Architecture = 'x64',
+
+        [Parameter()]
+        [string]$Scope = 'machine',
+
+        [Parameter()]
+        [string]$InstallerLocale,
+
+        [Parameter()]
+        [string]$InstallerType
+    )
+
+    $scoredInstallers = foreach ($currentInstaller in $Installer) {
+        $score = 0
+
+        if ($Architecture) {
+            if ($currentInstaller.Architecture -eq $Architecture) {
+                $score += 100
+            } elseif ($currentInstaller.Architecture -eq 'neutral') {
+                $score += 50
+            } else {
+                $score -= 25
+            }
+        }
+
+        if ($Scope) {
+            if ([string]::IsNullOrWhiteSpace($currentInstaller.Scope)) {
+                $score += 5
+            } elseif ($currentInstaller.Scope -eq $Scope) {
+                $score += 40
+            } else {
+                $score -= 10
+            }
+        }
+
+        if ($InstallerLocale) {
+            if ($currentInstaller.InstallerLocale -eq $InstallerLocale) {
+                $score += 20
+            } elseif ([string]::IsNullOrWhiteSpace($currentInstaller.InstallerLocale)) {
+                $score += 5
+            }
+        }
+
+        if ($InstallerType) {
+            if ($currentInstaller.InstallerType -eq $InstallerType) {
+                $score += 15
+            } elseif ([string]::IsNullOrWhiteSpace($currentInstaller.InstallerType)) {
+                $score += 5
+            }
+        }
+
+        Write-Debug "WinGet installer candidate scored $score with preferences Architecture='$Architecture', Scope='$Scope', InstallerLocale='$InstallerLocale', InstallerType='$InstallerType': $(Format-WinGetInstallerSummary -Installer $currentInstaller)."
+
+        [PSCustomObject]@{
+            Score     = $score
+            Installer = $currentInstaller
+        }
+    }
+
+    $selectedInstaller = $scoredInstallers |
+        Sort-Object -Property @{ Expression = 'Score'; Descending = $true }, @{
+            Expression = {
+                if ($_.Installer.Architecture -eq $Architecture) {
+                    0
+                } elseif ($_.Installer.Architecture -eq 'neutral') {
+                    1
+                } else {
+                    2
+                }
+            }
+        }, @{
+            Expression = {
+                if ($_.Installer.Scope -eq $Scope) {
+                    0
+                } elseif ([string]::IsNullOrWhiteSpace($_.Installer.Scope)) {
+                    1
+                } else {
+                    2
+                }
+            }
+        }, @{
+            Expression = {
+                if ($_.Installer.InstallerType) {
+                    0
+                } else {
+                    1
+                }
+            }
+        } |
+        Select-Object -First 1 -ExpandProperty Installer
+
+    if (-not $selectedInstaller) {
+        throw 'No WinGet installers were available for selection.'
+    }
+
+    Write-Debug "Selected WinGet installer: $(Format-WinGetInstallerSummary -Installer $selectedInstaller)."
+
+    return $selectedInstaller
+}

--- a/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
+++ b/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
@@ -11,6 +11,7 @@ function Send-IntuneWinAzureStorageChunkedUpload {
         [string]$UploadUri,
 
         [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]$ChunkSizeBytes = 6MB,
 
         [Parameter()]
@@ -38,8 +39,9 @@ function Send-IntuneWinAzureStorageChunkedUpload {
         return ($Uri -split '\?', 2)[0]
     }
 
-    $fileSize = (Get-Item -Path $FilePath).Length
-    $chunkCount = [Math]::Ceiling($fileSize / $ChunkSizeBytes)
+    $fileSize = [int64](Get-Item -Path $FilePath).Length
+    $chunkSize = [int64]$ChunkSizeBytes
+    $chunkCount = [int][Math]::Ceiling($fileSize / $chunkSize)
     $currentUploadUri = $UploadUri
     $isoEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
     $chunkIds = @()
@@ -51,7 +53,7 @@ function Send-IntuneWinAzureStorageChunkedUpload {
             $chunkId = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($index.ToString('0000')))
             $chunkIds += $chunkId
 
-            $chunkLength = [Math]::Min($ChunkSizeBytes, $fileSize - ($index * $ChunkSizeBytes))
+            $chunkLength = Get-IntuneWinUploadChunkLength -FileSize $fileSize -ChunkIndex $index -ChunkSizeBytes $ChunkSizeBytes
             $chunkBytes = $reader.ReadBytes($chunkLength)
             $requestBody = $isoEncoding.GetString($chunkBytes)
             $chunkUri = "$currentUploadUri&comp=block&blockid=$chunkId"

--- a/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
+++ b/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
@@ -43,14 +43,14 @@ function Send-IntuneWinAzureStorageChunkedUpload {
     $chunkSize = [int64]$ChunkSizeBytes
     $chunkCount = [int][Math]::Ceiling($fileSize / $chunkSize)
     $currentUploadUri = $UploadUri
-    $chunkIds = @()
+    $chunkIds = [System.Collections.Generic.List[string]]::new([Math]::Max($chunkCount, 0))
     Write-Debug "Starting Azure Storage chunked upload for '$FilePath' ($fileSize bytes) to '$(Get-UploadUriForLogging -Uri $UploadUri)' using ChunkSizeBytes=$ChunkSizeBytes across $chunkCount chunk(s)."
 
     $reader = [System.IO.BinaryReader]::new([System.IO.File]::Open($FilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read))
     try {
         for ($index = 0; $index -lt $chunkCount; $index++) {
             $chunkId = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($index.ToString('0000')))
-            $chunkIds += $chunkId
+            $chunkIds.Add($chunkId)
 
             $chunkLength = Get-IntuneWinUploadChunkLength -FileSize $fileSize -ChunkIndex $index -ChunkSizeBytes $ChunkSizeBytes
             $chunkBytes = $reader.ReadBytes($chunkLength)

--- a/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
+++ b/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
@@ -43,7 +43,6 @@ function Send-IntuneWinAzureStorageChunkedUpload {
     $chunkSize = [int64]$ChunkSizeBytes
     $chunkCount = [int][Math]::Ceiling($fileSize / $chunkSize)
     $currentUploadUri = $UploadUri
-    $isoEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
     $chunkIds = @()
     Write-Debug "Starting Azure Storage chunked upload for '$FilePath' ($fileSize bytes) to '$(Get-UploadUriForLogging -Uri $UploadUri)' using ChunkSizeBytes=$ChunkSizeBytes across $chunkCount chunk(s)."
 
@@ -55,16 +54,12 @@ function Send-IntuneWinAzureStorageChunkedUpload {
 
             $chunkLength = Get-IntuneWinUploadChunkLength -FileSize $fileSize -ChunkIndex $index -ChunkSizeBytes $ChunkSizeBytes
             $chunkBytes = $reader.ReadBytes($chunkLength)
-            $requestBody = $isoEncoding.GetString($chunkBytes)
             $chunkUri = "$currentUploadUri&comp=block&blockid=$chunkId"
             Write-Debug "Uploading Azure Storage chunk $($index + 1)/$chunkCount for '$FilePath' (ChunkId='$chunkId', Bytes=$chunkLength)."
 
             for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
                 try {
-                    Invoke-WebRequest -Method PUT -Uri $chunkUri -Body $requestBody -Headers @{
-                        'Content-Type'   = 'text/plain; charset=iso-8859-1'
-                        'x-ms-blob-type' = 'BlockBlob'
-                    } -TimeoutSec $ChunkUploadTimeoutSec -ErrorAction Stop | Out-Null
+                    Invoke-IntuneWinAzureStorageBlockUpload -Uri $chunkUri -Body $chunkBytes -TimeoutSec $ChunkUploadTimeoutSec
                     break
                 } catch {
                     $isAuthFailure = $_.Exception.Message -match 'AuthenticationFailed|403|authorized'

--- a/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
+++ b/Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
@@ -1,0 +1,129 @@
+function Send-IntuneWinAzureStorageChunkedUpload {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FilePath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UploadUri,
+
+        [Parameter()]
+        [int]$ChunkSizeBytes = 6MB,
+
+        [Parameter()]
+        [scriptblock]$RenewUploadUri,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$MaxRetries = 3,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$ChunkUploadTimeoutSec = 300,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$CommitTimeoutSec = 120
+    )
+
+    function Get-UploadUriForLogging {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Uri
+        )
+
+        return ($Uri -split '\?', 2)[0]
+    }
+
+    $fileSize = (Get-Item -Path $FilePath).Length
+    $chunkCount = [Math]::Ceiling($fileSize / $ChunkSizeBytes)
+    $currentUploadUri = $UploadUri
+    $isoEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
+    $chunkIds = @()
+    Write-Debug "Starting Azure Storage chunked upload for '$FilePath' ($fileSize bytes) to '$(Get-UploadUriForLogging -Uri $UploadUri)' using ChunkSizeBytes=$ChunkSizeBytes across $chunkCount chunk(s)."
+
+    $reader = [System.IO.BinaryReader]::new([System.IO.File]::Open($FilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read))
+    try {
+        for ($index = 0; $index -lt $chunkCount; $index++) {
+            $chunkId = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($index.ToString('0000')))
+            $chunkIds += $chunkId
+
+            $chunkLength = [Math]::Min($ChunkSizeBytes, $fileSize - ($index * $ChunkSizeBytes))
+            $chunkBytes = $reader.ReadBytes($chunkLength)
+            $requestBody = $isoEncoding.GetString($chunkBytes)
+            $chunkUri = "$currentUploadUri&comp=block&blockid=$chunkId"
+            Write-Debug "Uploading Azure Storage chunk $($index + 1)/$chunkCount for '$FilePath' (ChunkId='$chunkId', Bytes=$chunkLength)."
+
+            for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+                try {
+                    Invoke-WebRequest -Method PUT -Uri $chunkUri -Body $requestBody -Headers @{
+                        'Content-Type'   = 'text/plain; charset=iso-8859-1'
+                        'x-ms-blob-type' = 'BlockBlob'
+                    } -TimeoutSec $ChunkUploadTimeoutSec -ErrorAction Stop | Out-Null
+                    break
+                } catch {
+                    $isAuthFailure = $_.Exception.Message -match 'AuthenticationFailed|403|authorized'
+                    if ($isAuthFailure -and $RenewUploadUri -and $attempt -lt $MaxRetries) {
+                        Write-Debug "Azure Storage upload authorization expired for chunk $($index + 1)/$chunkCount. Renewing upload URI before retrying."
+                        $currentUploadUri = & $RenewUploadUri
+                        $chunkUri = "$currentUploadUri&comp=block&blockid=$chunkId"
+                        continue
+                    }
+
+                    if ($attempt -eq $MaxRetries) {
+                        throw
+                    }
+
+                    Write-Debug "Azure Storage upload retry for chunk $($index + 1)/$chunkCount after failure '$($_.Exception.Message)' (attempt $attempt of $MaxRetries)."
+                    Start-Sleep -Seconds (5 * $attempt)
+                }
+            }
+        }
+    } finally {
+        $reader.Close()
+        $reader.Dispose()
+    }
+
+    $blockListXml = [System.Text.StringBuilder]::new()
+    [void]$blockListXml.Append('<?xml version="1.0" encoding="utf-8"?><BlockList>')
+    foreach ($chunkId in $chunkIds) {
+        [void]$blockListXml.Append("<Latest>$chunkId</Latest>")
+    }
+    [void]$blockListXml.Append('</BlockList>')
+    $blockListBody = $blockListXml.ToString()
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            Write-Debug "Committing Azure Storage block list for '$FilePath' with $($chunkIds.Count) chunk(s)."
+            Invoke-RestMethod -Method PUT -Uri "$currentUploadUri&comp=blocklist" -Body $blockListBody -Headers @{
+                'Content-Type' = 'text/plain; charset=UTF-8'
+            } -TimeoutSec $CommitTimeoutSec -ErrorAction Stop | Out-Null
+            break
+        } catch {
+            $isAuthFailure = $_.Exception.Message -match 'AuthenticationFailed|403|authorized'
+            if ($isAuthFailure -and $RenewUploadUri -and $attempt -lt $MaxRetries) {
+                Write-Debug "Azure Storage block list commit authorization expired. Renewing upload URI before retrying."
+                $currentUploadUri = & $RenewUploadUri
+                continue
+            }
+
+            if ($attempt -eq $MaxRetries) {
+                throw
+            }
+
+            Write-Debug "Azure Storage block list commit retry after failure '$($_.Exception.Message)' (attempt $attempt of $MaxRetries)."
+            Start-Sleep -Seconds (5 * $attempt)
+        }
+    }
+
+    Write-Debug "Completed Azure Storage chunked upload for '$FilePath'. FinalUploadUri='$(Get-UploadUriForLogging -Uri $currentUploadUri)', ChunkCount=$chunkCount, FileSize=$fileSize."
+
+    return [PSCustomObject]@{
+        ChunkCount = $chunkCount
+        FileSize   = $fileSize
+        UploadUri  = $currentUploadUri
+    }
+}

--- a/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
+++ b/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
@@ -38,6 +38,36 @@ function Sync-IntuneWinGetProactiveRemediation {
         ([string]$ExistingRemediation.description -like "*WinGetRemediationScope: $Scope*")
     }
 
+    function Remove-OwnedWinGetRemediation {
+        param(
+            [Parameter(Mandatory)]
+            [psobject]$Definition,
+
+            [Parameter(Mandatory)]
+            [AllowEmptyCollection()]
+            [object[]]$OwnedExisting
+        )
+
+        if ($OwnedExisting.Count -eq 0) {
+            return $false
+        }
+
+        if ($WhatIfEnabled) {
+            foreach ($existingRemediation in $OwnedExisting) {
+                $results.Add((Add-HydrationDryRunResult -Action 'WouldDelete' -Name $Definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation'))
+            }
+            return $true
+        }
+
+        foreach ($existingRemediation in $OwnedExisting) {
+            Invoke-HydrationGraphRequest -Method DELETE -Uri "beta/deviceManagement/deviceHealthScripts/$($existingRemediation.id)" | Out-Null
+            Write-HydrationLog -Message "  Deleted: $($Definition.DisplayName)" -Level Info
+            $results.Add((New-HydrationResult -Name $Definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation' -Action 'Deleted' -Status 'Removed'))
+        }
+
+        return $true
+    }
+
     $results = [System.Collections.Generic.List[object]]::new()
     $definitions = @(
         Get-WinGetRemediationDefinition -Scope 'system' -TemplateSet $Templates
@@ -53,30 +83,24 @@ function Sync-IntuneWinGetProactiveRemediation {
     }
 
     foreach ($definition in $definitions) {
+        if ($definition.PackageIdentifiers.Count -eq 0 -and -not $RemoveExisting) {
+            $existingRemediations = Get-ExistingRemediation -DisplayName $definition.DisplayName
+            $ownedExisting = @($existingRemediations | Where-Object { Test-OwnedWinGetRemediation -ExistingRemediation $_ -Scope $definition.Scope })
+
+            if (Remove-OwnedWinGetRemediation -Definition $definition -OwnedExisting $ownedExisting) {
+                continue
+            }
+
+            Write-HydrationLog -Message "  Skipped: $($definition.DisplayName) - no packages for scope." -Level Info
+            $results.Add((New-HydrationResult -Name $definition.DisplayName -Type 'WinGetRemediation' -Action 'Skipped' -Status 'No packages'))
+            continue
+        }
+
         $existingRemediations = Get-ExistingRemediation -DisplayName $definition.DisplayName
         $ownedExisting = @($existingRemediations | Where-Object { Test-OwnedWinGetRemediation -ExistingRemediation $_ -Scope $definition.Scope })
 
         if ($RemoveExisting) {
-            if ($ownedExisting.Count -eq 0) {
-                continue
-            }
-
-            if ($WhatIfEnabled) {
-                foreach ($existingRemediation in $ownedExisting) {
-                    $results.Add((Add-HydrationDryRunResult -Action 'WouldDelete' -Name $definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation'))
-                }
-                continue
-            }
-
-            foreach ($existingRemediation in $ownedExisting) {
-                Invoke-HydrationGraphRequest -Method DELETE -Uri "beta/deviceManagement/deviceHealthScripts/$($existingRemediation.id)" | Out-Null
-                Write-HydrationLog -Message "  Deleted: $($definition.DisplayName)" -Level Info
-                $results.Add((New-HydrationResult -Name $definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation' -Action 'Deleted' -Status 'Removed'))
-            }
-            continue
-        }
-
-        if ($definition.PackageIdentifiers.Count -eq 0) {
+            $null = Remove-OwnedWinGetRemediation -Definition $definition -OwnedExisting $ownedExisting
             continue
         }
 

--- a/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
+++ b/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
@@ -1,0 +1,118 @@
+function Sync-IntuneWinGetProactiveRemediation {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        [psobject[]]$Templates,
+
+        [Parameter()]
+        [switch]$RemoveExisting,
+
+        [Parameter()]
+        [bool]$WhatIfEnabled = $false
+    )
+
+    function Get-ExistingRemediation {
+        param(
+            [Parameter(Mandatory)]
+            [string]$DisplayName
+        )
+
+        $escapedDisplayName = $DisplayName.Replace("'", "''")
+        $filter = [uri]::EscapeDataString("displayName eq '$escapedDisplayName'")
+        $response = Invoke-HydrationGraphRequest -Method GET -Uri "beta/deviceManagement/deviceHealthScripts?`$filter=$filter"
+        return @($response.value)
+    }
+
+    function Test-OwnedWinGetRemediation {
+        param(
+            [Parameter(Mandatory)]
+            [psobject]$ExistingRemediation,
+
+            [Parameter(Mandatory)]
+            [string]$Scope
+        )
+
+        return (Test-HydrationKitObject -Description ([string]$ExistingRemediation.description)) -and
+        ([string]$ExistingRemediation.description -like '*Imported from WinGet*') -and
+        ([string]$ExistingRemediation.description -like "*WinGetRemediationScope: $Scope*")
+    }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $definitions = @(
+        Get-WinGetRemediationDefinition -Scope 'system' -TemplateSet $Templates
+        Get-WinGetRemediationDefinition -Scope 'user' -TemplateSet $Templates
+    )
+
+    if (-not $WhatIfEnabled) {
+        $availability = Get-IntuneProactiveRemediationAvailability
+        if (-not $availability.IsAvailable) {
+            Write-HydrationLog -Message "  Skipped: WinGet proactive remediations - $($availability.Message)" -Level Warning
+            return @(
+                New-HydrationResult -Name 'WinGet proactive remediations' -Type 'WinGetRemediation' -Action 'Skipped' -Status $availability.Status
+            )
+        }
+    }
+
+    foreach ($definition in $definitions) {
+        $existingRemediations = Get-ExistingRemediation -DisplayName $definition.DisplayName
+        $ownedExisting = @($existingRemediations | Where-Object { Test-OwnedWinGetRemediation -ExistingRemediation $_ -Scope $definition.Scope })
+
+        if ($RemoveExisting) {
+            if ($ownedExisting.Count -eq 0) {
+                continue
+            }
+
+            if ($WhatIfEnabled) {
+                foreach ($existingRemediation in $ownedExisting) {
+                    $results.Add((Add-HydrationDryRunResult -Action 'WouldDelete' -Name $definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation'))
+                }
+                continue
+            }
+
+            foreach ($existingRemediation in $ownedExisting) {
+                Invoke-HydrationGraphRequest -Method DELETE -Uri "beta/deviceManagement/deviceHealthScripts/$($existingRemediation.id)" | Out-Null
+                Write-HydrationLog -Message "  Deleted: $($definition.DisplayName)" -Level Info
+                $results.Add((New-HydrationResult -Name $definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation' -Action 'Deleted' -Status 'Removed'))
+            }
+            continue
+        }
+
+        if ($definition.PackageIdentifiers.Count -eq 0) {
+            continue
+        }
+
+        $ownedExistingRemediation = $ownedExisting | Select-Object -First 1
+        if ($existingRemediations.Count -gt 0 -and -not $ownedExistingRemediation) {
+            Write-HydrationLog -Message "  Failed: $($definition.DisplayName) - A remediation with this name already exists but is not owned by Intune Hydration Kit." -Level Warning
+            $results.Add((New-HydrationResult -Name $definition.DisplayName -Type 'WinGetRemediation' -Action 'Failed' -Status 'Name collision'))
+            continue
+        }
+
+        $fingerprint = Get-WinGetRemediationFingerprint -PackageIdentifiers $definition.PackageIdentifiers
+        if ($ownedExistingRemediation -and [string]$ownedExistingRemediation.description -like "*WinGetPackageFingerprint: $fingerprint*") {
+            Write-HydrationLog -Message "  Skipped: $($definition.DisplayName)" -Level Info
+            $results.Add((New-HydrationResult -Name $definition.DisplayName -Id $ownedExistingRemediation.id -Type 'WinGetRemediation' -Action 'Skipped' -Status 'Already current'))
+            continue
+        }
+
+        if ($WhatIfEnabled) {
+            $action = if ($ownedExistingRemediation) { 'WouldUpdate' } else { 'WouldCreate' }
+            $results.Add((Add-HydrationDryRunResult -Action $action -Name $definition.DisplayName -Id $ownedExistingRemediation.id -Type 'WinGetRemediation'))
+            continue
+        }
+
+        $body = New-WinGetRemediationBody -Definition $definition -IncludeCreateOnlyProperties (-not $ownedExistingRemediation)
+        if ($ownedExistingRemediation) {
+            Invoke-HydrationGraphRequest -Method PATCH -Uri "beta/deviceManagement/deviceHealthScripts/$($ownedExistingRemediation.id)" -Body $body | Out-Null
+            Write-HydrationLog -Message "  Updated: $($definition.DisplayName)" -Level Info
+            $results.Add((New-HydrationResult -Name $definition.DisplayName -Id $ownedExistingRemediation.id -Type 'WinGetRemediation' -Action 'Updated' -Status "Packages=$($definition.PackageIdentifiers.Count)"))
+        } else {
+            $createdRemediation = Invoke-HydrationGraphRequest -Method POST -Uri 'beta/deviceManagement/deviceHealthScripts' -Body $body
+            Write-HydrationLog -Message "  Created: $($definition.DisplayName)" -Level Info
+            $results.Add((New-HydrationResult -Name $definition.DisplayName -Id $createdRemediation.id -Type 'WinGetRemediation' -Action 'Created' -Status "Packages=$($definition.PackageIdentifiers.Count)"))
+        }
+    }
+
+    return @($results)
+}

--- a/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
+++ b/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
@@ -44,14 +44,12 @@ function Sync-IntuneWinGetProactiveRemediation {
         Get-WinGetRemediationDefinition -Scope 'user' -TemplateSet $Templates
     )
 
-    if (-not $WhatIfEnabled) {
-        $availability = Get-IntuneProactiveRemediationAvailability
-        if (-not $availability.IsAvailable) {
-            Write-HydrationLog -Message "  Skipped: WinGet proactive remediations - $($availability.Message)" -Level Warning
-            return @(
-                New-HydrationResult -Name 'WinGet proactive remediations' -Type 'WinGetRemediation' -Action 'Skipped' -Status $availability.Status
-            )
-        }
+    $availability = Get-IntuneProactiveRemediationAvailability
+    if (-not $availability.IsAvailable) {
+        Write-HydrationLog -Message "  Skipped: WinGet proactive remediations - $($availability.Message)" -Level Warning
+        return @(
+            New-HydrationResult -Name 'WinGet proactive remediations' -Type 'WinGetRemediation' -Action 'Skipped' -Status $availability.Status
+        )
     }
 
     foreach ($definition in $definitions) {

--- a/Private/WinGet/Test-IntuneWinGetAppOwnership.ps1
+++ b/Private/WinGet/Test-IntuneWinGetAppOwnership.ps1
@@ -1,0 +1,66 @@
+function Test-IntuneWinGetAppOwnership {
+    <#
+    .SYNOPSIS
+        Tests whether a Win32 app is owned by the WinGet hydration importer.
+    .DESCRIPTION
+        Requires both the standard hydration marker and the WinGet source marker or
+        WinGet metadata block so delete operations only target apps created by the
+        WinGet Win32 hydration flow.
+    .PARAMETER Description
+        App description text.
+    .PARAMETER Notes
+        App notes text.
+    .PARAMETER ObjectName
+        Optional object name for verbose logging.
+    .OUTPUTS
+        System.Boolean
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Description,
+
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Notes,
+
+        [Parameter()]
+        [string]$ObjectName
+    )
+
+    $isHydrationKitObject = Test-HydrationKitObject -Description $Description -Notes $Notes -ObjectName $ObjectName
+    if (-not $isHydrationKitObject) {
+        return $false
+    }
+
+    $wingetMarkers = @(
+        'Imported from WinGet',
+        'WinGetPackageIdentifier:'
+    )
+
+    foreach ($field in @($Description, $Notes)) {
+        if ([string]::IsNullOrWhiteSpace($field)) {
+            continue
+        }
+
+        foreach ($marker in $wingetMarkers) {
+            if ($field -like "*$marker*") {
+                if ($ObjectName) {
+                    Write-Verbose "Object '$ObjectName' is owned by the WinGet hydration importer"
+                }
+
+                return $true
+            }
+        }
+    }
+
+    if ($ObjectName) {
+        Write-Verbose "Object '$ObjectName' is not owned by the WinGet hydration importer"
+    }
+
+    return $false
+}

--- a/Private/WinGet/Wait-IntuneWin32ContentState.ps1
+++ b/Private/WinGet/Wait-IntuneWin32ContentState.ps1
@@ -1,0 +1,60 @@
+function Wait-IntuneWin32ContentState {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AppId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ContentVersionId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FileId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DesiredState,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$PollIntervalSeconds = 5,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$TimeoutSeconds = 180
+    )
+
+    $fileUri = "beta/deviceAppManagement/mobileApps/$AppId/microsoft.graph.win32LobApp/contentVersions/$ContentVersionId/files/$FileId"
+    Write-Debug "Waiting for Win32 content file '$FileId' for app '$AppId' to reach upload state '$DesiredState' (PollIntervalSeconds=$PollIntervalSeconds, TimeoutSeconds=$TimeoutSeconds)."
+
+    $elapsedSeconds = 0
+    while ($elapsedSeconds -le $TimeoutSeconds) {
+        $file = Invoke-HydrationGraphRequest -Method GET -Uri $fileUri
+        Write-Debug "Win32 content file '$FileId' current upload state is '$($file.uploadState)' after $elapsedSeconds second(s)."
+
+        if ($file.uploadState -eq $DesiredState) {
+            Write-Debug "Win32 content file '$FileId' reached desired upload state '$DesiredState'."
+            return $file
+        }
+
+        if ($file.uploadState -eq 'commitFileFailed') {
+            throw "Win32 content file commit failed for file '$FileId'."
+        }
+
+        $remainingSeconds = $TimeoutSeconds - $elapsedSeconds
+        if ($remainingSeconds -le 0) {
+            break
+        }
+
+        $sleepSeconds = [Math]::Min($PollIntervalSeconds, $remainingSeconds)
+        Start-Sleep -Seconds $sleepSeconds
+        $elapsedSeconds += $sleepSeconds
+    }
+
+    $timeoutMessage = "Timed out waiting for upload state '$DesiredState' for file '$FileId'."
+    Write-Debug "Timed out waiting for Win32 content file '$FileId' to reach upload state '$DesiredState'."
+    throw $timeoutMessage
+}

--- a/Public/Imports/Import-IntuneWinGetApp.ps1
+++ b/Public/Imports/Import-IntuneWinGetApp.ps1
@@ -49,7 +49,7 @@ function Import-IntuneWinGetApp {
     }
 
     if (-not (Test-Path -Path $WorkingDirectory)) {
-        $null = New-Item -Path $WorkingDirectory -ItemType Directory -Force
+        $null = New-Item -Path $WorkingDirectory -ItemType Directory -Force -ErrorAction Stop
     }
 
     Write-Debug "Starting WinGet Win32 import. RemoveExisting=$($RemoveExisting.IsPresent), WorkingDirectory='$WorkingDirectory', PresetId='$PresetId', TemplateIdCount=$(@($TemplateId).Count)."
@@ -109,12 +109,6 @@ function Import-IntuneWinGetApp {
         }
 
         $displayName = Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName
-        if ([string]::IsNullOrWhiteSpace($template.packageIdentifier)) {
-            Write-HydrationLog -Message "  Failed: $displayName - Missing or blank packageIdentifier for template '$($template.templateId)'" -Level Warning
-            $results += New-HydrationResult -Name $displayName -Path $template.TemplatePath -Type 'WinGetWin32App' -Action 'Failed' -Status "Missing or blank packageIdentifier for template '$($template.templateId)'"
-            continue
-        }
-
         if ($existingApps.Lookup.ContainsKey($displayName) -and $existingApps.Lookup[$displayName].IsOwned) {
             $matchedApp = $existingApps.Lookup[$displayName]
             Write-Debug "Create decision: skipping '$displayName' because matching WinGet-owned app '$($matchedApp.DisplayName)' already exists with AppId='$($matchedApp.Id)'."

--- a/Public/Imports/Import-IntuneWinGetApp.ps1
+++ b/Public/Imports/Import-IntuneWinGetApp.ps1
@@ -1,0 +1,148 @@
+function Import-IntuneWinGetApp {
+    <#
+    .SYNOPSIS
+        Imports WinGet-backed Win32 apps from bundled catalog or preset templates.
+    .DESCRIPTION
+        Creates Intune Win32 apps that wrap WinGet install and uninstall commands,
+        publishes the generated .intunewin content, and tags created apps with both
+        the hydration marker and WinGet ownership metadata so future deletes are safe.
+    .PARAMETER TemplateId
+        One or more specific bundled WinGet template IDs to import.
+    .PARAMETER PresetId
+        Optional preset ID to resolve from Templates/MobileApps/Windows/WinGet/Presets.
+    .PARAMETER RemoveExisting
+        Deletes matching WinGet hydration-owned Win32 apps instead of creating them.
+    .PARAMETER WorkingDirectory
+        Directory used to stage wrapper scripts, packages, and upload artifacts.
+    .PARAMETER RemediationEnabled
+        When enabled, creates or updates proactive remediation scripts for the selected
+        WinGet app set. A system-scoped script is generated for machine apps and a
+        user-scoped script is generated for user apps. No assignments are created.
+    .EXAMPLE
+        Import-IntuneWinGetApp -PresetId 'starter-pack'
+    .EXAMPLE
+        Import-IntuneWinGetApp -TemplateId 'google-chrome'
+    .EXAMPLE
+        Import-IntuneWinGetApp -RemoveExisting -PresetId 'starter-pack'
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter()]
+        [string[]]$TemplateId,
+
+        [Parameter()]
+        [string]$PresetId,
+
+        [Parameter()]
+        [switch]$RemoveExisting,
+
+        [Parameter()]
+        [string]$WorkingDirectory,
+
+        [Parameter()]
+        [switch]$RemediationEnabled
+    )
+
+    if (-not $WorkingDirectory) {
+        $WorkingDirectory = Join-Path -Path (Get-Location).Path -ChildPath '.intunehydrationkit/winget-apps'
+    }
+
+    if (-not (Test-Path -Path $WorkingDirectory)) {
+        $null = New-Item -Path $WorkingDirectory -ItemType Directory -Force
+    }
+
+    Write-Debug "Starting WinGet Win32 import. RemoveExisting=$($RemoveExisting.IsPresent), WorkingDirectory='$WorkingDirectory', PresetId='$PresetId', TemplateIdCount=$(@($TemplateId).Count)."
+
+    $templates = @(Get-HydrationWinGetAppTemplates -TemplateId $TemplateId -PresetId $PresetId)
+    if ($templates.Count -eq 0) {
+        Write-Verbose 'No WinGet app templates found to process'
+        return @()
+    }
+
+    $templateIds = (@($templates.templateId)) -join "', '"
+    Write-Debug "Loaded $($templates.Count) WinGet template(s): '$templateIds'."
+
+    $knownTemplateNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($template in $templates) {
+        if (-not [string]::IsNullOrWhiteSpace($template.displayName)) {
+            $templateDisplayName = [string]$template.displayName
+            [void]$knownTemplateNames.Add((Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName))
+        }
+    }
+
+    $existingApps = Get-ExistingWinGetApps -KnownTemplateNames $knownTemplateNames
+    Write-Debug "Resolved $($existingApps.Items.Count) existing app(s) from Graph for WinGet ownership evaluation. LookupEntries=$($existingApps.Lookup.Count)."
+    $results = @()
+
+    $validTemplates = [System.Collections.Generic.List[psobject]]::new()
+    foreach ($template in $templates) {
+        if ([string]::IsNullOrWhiteSpace($template.packageIdentifier)) {
+            $templateDisplayName = [string]$template.displayName
+            $displayName = if ([string]::IsNullOrWhiteSpace($templateDisplayName)) {
+                $template.templateId ?? 'UnknownTemplate'
+            } else {
+                Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName
+            }
+            Write-HydrationLog -Message "  Failed: $displayName - Missing or blank packageIdentifier for template '$($template.templateId)'" -Level Warning
+            $results += New-HydrationResult -Name $displayName -Path $template.TemplatePath -Type 'WinGetWin32App' -Action 'Failed' -Status "Missing or blank packageIdentifier for template '$($template.templateId)'"
+            continue
+        }
+        $validTemplates.Add($template)
+    }
+    $templates = $validTemplates
+
+    if ($RemoveExisting) {
+        $results += Remove-IntuneWinGetApps -ExistingApps $existingApps -KnownTemplateNames $knownTemplateNames -PSCmdlet $PSCmdlet -WhatIfPreference:$WhatIfPreference
+
+        if ($RemediationEnabled.IsPresent) {
+            $results += Sync-IntuneWinGetProactiveRemediation -Templates $templates -RemoveExisting -WhatIfEnabled:$WhatIfPreference
+        }
+        return $results
+    }
+
+    foreach ($template in $templates) {
+        $templateDisplayName = [string]$template.displayName
+        if ([string]::IsNullOrWhiteSpace($templateDisplayName)) {
+            $results += New-HydrationResult -Name ($template.templateId ?? 'UnknownTemplate') -Path $template.TemplatePath -Type 'WinGetWin32App' -Action 'Failed' -Status 'Missing displayName'
+            continue
+        }
+
+        $displayName = Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName
+        if ([string]::IsNullOrWhiteSpace($template.packageIdentifier)) {
+            Write-HydrationLog -Message "  Failed: $displayName - Missing or blank packageIdentifier for template '$($template.templateId)'" -Level Warning
+            $results += New-HydrationResult -Name $displayName -Path $template.TemplatePath -Type 'WinGetWin32App' -Action 'Failed' -Status "Missing or blank packageIdentifier for template '$($template.templateId)'"
+            continue
+        }
+
+        if ($existingApps.Lookup.ContainsKey($displayName) -and $existingApps.Lookup[$displayName].IsOwned) {
+            $matchedApp = $existingApps.Lookup[$displayName]
+            Write-Debug "Create decision: skipping '$displayName' because matching WinGet-owned app '$($matchedApp.DisplayName)' already exists with AppId='$($matchedApp.Id)'."
+            Write-HydrationLog -Message "  Skipped: $displayName" -Level Info
+            $results += New-HydrationResult -Name $displayName -Id $matchedApp.Id -Path $template.TemplatePath -Type 'WinGetWin32App' -Action 'Skipped' -Status 'Already exists'
+            continue
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($displayName, 'Create WinGet Win32 app')) {
+            if ($WhatIfPreference) {
+                Write-Debug "Create decision: WhatIf prevented creation for '$displayName'."
+                $results += Add-HydrationDryRunResult -Action 'WouldCreate' -Name $displayName -Path $template.TemplatePath -Type 'WinGetWin32App'
+            }
+
+            continue
+        }
+
+        $importParams = @{
+            Template         = $template
+            DisplayName      = $displayName
+            WorkingDirectory = $WorkingDirectory
+        }
+        $results += Invoke-IntuneWinGetAppTemplate @importParams
+    }
+
+    if ($RemediationEnabled.IsPresent) {
+        $results += Sync-IntuneWinGetProactiveRemediation -Templates $templates -WhatIfEnabled:$WhatIfPreference
+    }
+
+    return $results
+}

--- a/Tests/Private/ConvertFrom-GraphEscapedString.Tests.ps1
+++ b/Tests/Private/ConvertFrom-GraphEscapedString.Tests.ps1
@@ -1,0 +1,19 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Graph/ConvertFrom-GraphEscapedString.ps1
+}
+
+Describe 'ConvertFrom-GraphEscapedString' {
+    It 'Should collapse escaped backslashes in non-nested messages' {
+        $result = ConvertFrom-GraphEscapedString -Value 'Path C:\\Temp\\App'
+
+        $result | Should -Be 'Path C:\Temp\App'
+    }
+
+    It 'Should preserve escaped backslashes for nested messages' {
+        $result = ConvertFrom-GraphEscapedString -Value 'Path C:\\Temp\\App' -NestedMessage
+
+        $result | Should -Be 'Path C:\\Temp\\App'
+    }
+}

--- a/Tests/Private/ConvertTo-IntuneWinDetectionRule.Tests.ps1
+++ b/Tests/Private/ConvertTo-IntuneWinDetectionRule.Tests.ps1
@@ -1,0 +1,93 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Utilities/ConvertTo-HydrationBoolValue.ps1
+    . $PSScriptRoot/../../Private/WinGet/ConvertTo-IntuneWinDetectionRule.ps1
+}
+
+Describe 'ConvertTo-IntuneWinDetectionRule' {
+    BeforeAll {
+        $script:artifactRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/ConvertTo-IntuneWinDetectionRule'
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:artifactRoot -ItemType Directory -Force
+        'Write-Output ''detected''' | Set-Content -Path (Join-Path $script:artifactRoot 'detection.ps1')
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+    }
+
+    It 'Should map MSI product code rules' {
+        $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                DetectionType          = 'MSI'
+                ProductCode            = '{1234-5678}'
+                ProductVersionOperator = 'greaterThanOrEqual'
+                ProductVersion         = '1.2.3'
+            })
+
+        $result['@odata.type'] | Should -Be '#microsoft.graph.win32LobAppProductCodeRule'
+        $result.productCode | Should -Be '{1234-5678}'
+        $result.productVersion | Should -Be '1.2.3'
+    }
+
+    It 'Should map registry comparison rules' {
+        $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                DetectionType        = 'Registry'
+                DetectionMethod      = 'VersionComparison'
+                KeyPath              = 'HKLM:\Software\Contoso'
+                ValueName            = 'DisplayVersion'
+                Operator             = 'greaterThanOrEqual'
+                Value                = '2.0'
+                Check32BitOn64System = 'true'
+            })
+
+        $result.operationType | Should -Be 'version'
+        $result.comparisonValue | Should -Be '2.0'
+        $result.check32BitOn64System | Should -BeTrue
+    }
+
+    It 'Should map file existence rules' {
+        $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                DetectionType     = 'File'
+                FileDetectionType = 'exists'
+                Path              = 'C:\Program Files\Contoso'
+                FileOrFolderName  = 'Contoso.exe'
+            })
+
+        $result['@odata.type'] | Should -Be '#microsoft.graph.win32LobAppFileSystemRule'
+        $result.operationType | Should -Be 'exists'
+        $result.operator | Should -Be 'notConfigured'
+    }
+
+    It 'Should base64 encode detection scripts' {
+        $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                DetectionType         = 'Script'
+                ScriptFile            = 'detection.ps1'
+                EnforceSignatureCheck = 'false'
+                RunAs32Bit            = 'true'
+            }) -ScriptRootPath $script:artifactRoot
+
+        $decodedScript = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($result.scriptContent))
+        $decodedScript | Should -Match 'detected'
+        $result.runAs32Bit | Should -BeTrue
+        $result.ContainsKey('runAsAccount') | Should -BeFalse
+    }
+
+    It 'Should throw for unsupported rule types' {
+        { ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{ DetectionType = 'Unsupported' }) } | Should -Throw '*Unsupported detection rule type*'
+    }
+
+    It 'Should throw a clear error when script root path is missing for script rules' {
+        {
+            ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                    DetectionType = 'Script'
+                    ScriptFile    = 'detection.ps1'
+                })
+        } | Should -Throw "*ScriptRootPath is required for script detection rule 'detection.ps1'*"
+    }
+}

--- a/Tests/Private/ConvertTo-IntuneWinDetectionRule.Tests.ps1
+++ b/Tests/Private/ConvertTo-IntuneWinDetectionRule.Tests.ps1
@@ -51,6 +51,16 @@ Describe 'ConvertTo-IntuneWinDetectionRule' {
         $result.check32BitOn64System | Should -BeTrue
     }
 
+    It 'Should default registry rules to existence when no operation is specified' {
+        $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                DetectionType = 'Registry'
+                KeyPath       = 'HKLM:\Software\Contoso'
+            })
+
+        $result.operationType | Should -Be 'exists'
+        $result.operator | Should -Be 'notConfigured'
+    }
+
     It 'Should map file existence rules' {
         $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
                 DetectionType     = 'File'
@@ -60,6 +70,17 @@ Describe 'ConvertTo-IntuneWinDetectionRule' {
             })
 
         $result['@odata.type'] | Should -Be '#microsoft.graph.win32LobAppFileSystemRule'
+        $result.operationType | Should -Be 'exists'
+        $result.operator | Should -Be 'notConfigured'
+    }
+
+    It 'Should default file rules to existence when no operation is specified' {
+        $result = ConvertTo-IntuneWinDetectionRule -Rule ([pscustomobject]@{
+                DetectionType    = 'File'
+                Path             = 'C:\Program Files\Contoso'
+                FileOrFolderName = 'Contoso.exe'
+            })
+
         $result.operationType | Should -Be 'exists'
         $result.operator | Should -Be 'notConfigured'
     }

--- a/Tests/Private/ConvertTo-IntuneWinRequirementRule.Tests.ps1
+++ b/Tests/Private/ConvertTo-IntuneWinRequirementRule.Tests.ps1
@@ -1,0 +1,77 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Utilities/ConvertTo-HydrationBoolValue.ps1
+    . $PSScriptRoot/../../Private/WinGet/ConvertTo-IntuneWinRequirementRule.ps1
+}
+
+Describe 'ConvertTo-IntuneWinRequirementRule' {
+    BeforeAll {
+        $script:artifactRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/ConvertTo-IntuneWinRequirementRule'
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:artifactRoot -ItemType Directory -Force
+        'Write-Output 1' | Set-Content -Path (Join-Path $script:artifactRoot 'requirement.ps1')
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+    }
+
+    It 'Should map registry requirement rules' {
+        $result = ConvertTo-IntuneWinRequirementRule -Rule ([pscustomobject]@{
+                RequirementType = 'Registry'
+                KeyPath         = 'HKLM:\Software\Contoso'
+                ValueName       = 'DisplayVersion'
+                Value           = '2.0'
+            })
+
+        $result['@odata.type'] | Should -Be '#microsoft.graph.win32LobAppRegistryRequirement'
+        $result.operationType | Should -Be 'version'
+        $result.detectionValue | Should -Be '2.0'
+    }
+
+    It 'Should map script requirement rules' {
+        $result = ConvertTo-IntuneWinRequirementRule -Rule ([pscustomobject]@{
+                RequirementType       = 'Script'
+                ScriptFile            = 'requirement.ps1'
+                Value                 = '1'
+                EnforceSignatureCheck = 'false'
+                RunAs32Bit            = 'false'
+            }) -ScriptRootPath $script:artifactRoot
+
+        $decodedScript = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($result.scriptContent))
+        $decodedScript | Should -Match 'Write-Output 1'
+        $result.detectionValue | Should -Be '1'
+    }
+
+    It 'Should throw for unsupported requirement rules' {
+        { ConvertTo-IntuneWinRequirementRule -Rule ([pscustomobject]@{ RequirementType = 'Unsupported' }) } | Should -Throw '*Unsupported requirement rule type*'
+    }
+
+    It 'Should throw for unrecognized boolean strings' {
+        {
+            ConvertTo-IntuneWinRequirementRule -Rule ([pscustomobject]@{
+                    RequirementType       = 'Script'
+                    ScriptFile            = 'requirement.ps1'
+                    Value                 = '1'
+                    EnforceSignatureCheck = 'maybe'
+                    RunAs32Bit            = 'false'
+                }) -ScriptRootPath $script:artifactRoot
+        } | Should -Throw "*Unsupported boolean string value: 'maybe'*"
+    }
+
+    It 'Should throw a clear error when script root path is missing for script rules' {
+        {
+            ConvertTo-IntuneWinRequirementRule -Rule ([pscustomobject]@{
+                    RequirementType = 'Script'
+                    ScriptFile      = 'requirement.ps1'
+                    Value           = '1'
+                })
+        } | Should -Throw "*ScriptRootPath is required for script requirement rule 'requirement.ps1'*"
+    }
+}

--- a/Tests/Private/Deduplicate-HydrationDeleteCandidates.Tests.ps1
+++ b/Tests/Private/Deduplicate-HydrationDeleteCandidates.Tests.ps1
@@ -1,0 +1,20 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Hydration/Deduplicate-HydrationDeleteCandidates.ps1
+}
+
+Describe 'Deduplicate-HydrationDeleteCandidates' {
+    It 'Should return a flat array of unique candidates' {
+        $result = Deduplicate-HydrationDeleteCandidates -Candidates @(
+            @{ Name = 'Policy A'; Id = '1'; Url = '/one' }
+            @{ Name = 'Policy A'; Id = '2'; Url = '/two' }
+            @{ Name = 'Policy B'; Id = '3'; Url = '/three' }
+        )
+
+        $result | Should -HaveCount 2
+        $result[0] | Should -BeOfType ([hashtable])
+        $result.Name | Should -Contain 'Policy A'
+        $result.Name | Should -Contain 'Policy B'
+    }
+}

--- a/Tests/Private/Deduplicate-HydrationDeleteCandidates.Tests.ps1
+++ b/Tests/Private/Deduplicate-HydrationDeleteCandidates.Tests.ps1
@@ -14,7 +14,18 @@ Describe 'Deduplicate-HydrationDeleteCandidates' {
 
         $result | Should -HaveCount 2
         $result[0] | Should -BeOfType ([hashtable])
-        $result.Name | Should -Contain 'Policy A'
-        $result.Name | Should -Contain 'Policy B'
+        $result.Name | Should -Be @('Policy A', 'Policy B')
+        $result.Id | Should -Be @('1', '3')
+    }
+
+    It 'Should treat names as case-insensitive duplicates' {
+        $result = @(Deduplicate-HydrationDeleteCandidates -Candidates @(
+            @{ Name = 'Policy A'; Id = '1'; Url = '/one' }
+            @{ Name = 'policy a'; Id = '2'; Url = '/two' }
+        ))
+
+        $result | Should -HaveCount 1
+        $result[0].Name | Should -Be 'Policy A'
+        $result[0].Id | Should -Be '1'
     }
 }

--- a/Tests/Private/Get-ConfigurationSection.Tests.ps1
+++ b/Tests/Private/Get-ConfigurationSection.Tests.ps1
@@ -1,0 +1,28 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Utilities/Get-ConfigurationSection.ps1
+}
+
+Describe 'Get-ConfigurationSection' {
+    It 'Should return an existing non-null section' {
+        $section = @{ Name = 'Contoso' }
+        $result = Get-ConfigurationSection -InputObject @{ Information = $section } -Name 'Information'
+
+        $result | Should -Be $section
+    }
+
+    It 'Should return an empty hashtable when the section is missing' {
+        $result = Get-ConfigurationSection -InputObject @{} -Name 'Information'
+
+        $result | Should -BeOfType ([hashtable])
+        $result.Count | Should -Be 0
+    }
+
+    It 'Should return an empty hashtable when the section is explicitly null' {
+        $result = Get-ConfigurationSection -InputObject @{ Information = $null } -Name 'Information'
+
+        $result | Should -BeOfType ([hashtable])
+        $result.Count | Should -Be 0
+    }
+}

--- a/Tests/Private/Get-HydrationWinGetAppTemplates.Tests.ps1
+++ b/Tests/Private/Get-HydrationWinGetAppTemplates.Tests.ps1
@@ -1,0 +1,111 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $functionPath = Join-Path $PSScriptRoot '..\..\Private\WinGet\Get-HydrationWinGetAppTemplates.ps1'
+    . $functionPath
+}
+
+Describe 'Get-HydrationWinGetAppTemplates' {
+    BeforeEach {
+        $script:WinGetTemplatePath = Join-Path ([System.IO.Path]::GetTempPath()) "WinGetTemplates-$([guid]::NewGuid().ToString('N'))"
+        $appsPath = Join-Path $script:WinGetTemplatePath 'Apps'
+        $presetsPath = Join-Path $script:WinGetTemplatePath 'Presets'
+        $schemasPath = Join-Path $script:WinGetTemplatePath 'Schemas'
+        $null = New-Item -Path $appsPath, $presetsPath, $schemasPath -ItemType Directory -Force
+
+        @{
+            '$schema'              = 'https://json-schema.org/draft/2020-12/schema'
+            type                   = 'object'
+            required               = @('templateId', 'displayName', 'packageIdentifier')
+            additionalProperties   = $true
+            properties             = @{
+                templateId        = @{ type = 'string' }
+                displayName       = @{ type = 'string' }
+                packageIdentifier = @{ type = 'string' }
+            }
+        } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $schemasPath 'winGetAppTemplate.schema.json') -Encoding utf8
+
+        @{
+            '$schema'              = 'https://json-schema.org/draft/2020-12/schema'
+            type                   = 'object'
+            required               = @('appIds')
+            additionalProperties   = $true
+            properties             = @{
+                appIds = @{
+                    type  = 'array'
+                    items = @{ type = 'string' }
+                }
+            }
+        } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $schemasPath 'winGetAppPreset.schema.json') -Encoding utf8
+
+        foreach ($templateId in @('7-zip', 'notepad-plus-plus', 'vlc-media-player', 'google-chrome', 'putty', 'microsoft-edge', 'visual-studio-code', 'windows-terminal')) {
+            @{
+                templateId        = $templateId
+                displayName       = $templateId
+                packageIdentifier = "Contoso.$templateId"
+            } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $appsPath "$templateId.json") -Encoding utf8
+        }
+
+        @{
+            appIds = @('7-zip', 'notepad-plus-plus', 'vlc-media-player', 'google-chrome', 'putty', 'microsoft-edge')
+        } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $presetsPath 'starter-pack.json') -Encoding utf8
+
+        @{
+            appIds = @('microsoft-edge', 'visual-studio-code', 'windows-terminal', 'google-chrome', 'putty', '7-zip')
+        } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $presetsPath 'mobile-apps.json') -Encoding utf8
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:WinGetTemplatePath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'Should load the starter pack preset templates' {
+        $result = Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -PresetId 'starter-pack'
+
+        $result.Count | Should -BeGreaterThan 5
+        $result.templateId | Should -Contain '7-zip'
+        $result.templateId | Should -Contain 'notepad-plus-plus'
+        $result.templateId | Should -Contain 'vlc-media-player'
+        $result | Where-Object { $_.PresetId -eq 'starter-pack' } | Should -HaveCount $result.Count
+    }
+
+    It 'Should load the mobile app preset templates' {
+        $result = Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -PresetId 'mobile-apps'
+
+        $result.Count | Should -BeGreaterThan 5
+        $result.templateId | Should -Not -Contain 'adobe-acrobat-reader-dc'
+        $result.templateId | Should -Not -Contain 'powershell'
+        $result.templateId | Should -Contain 'microsoft-edge'
+        $result.templateId | Should -Contain 'visual-studio-code'
+        $result.templateId | Should -Contain 'windows-terminal'
+        $result | Where-Object { $_.PresetId -eq 'mobile-apps' } | Should -HaveCount $result.Count
+    }
+
+    It 'Should load specific template IDs without a preset' {
+        $result = Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -TemplateId @('google-chrome', 'putty')
+
+        $result | Should -HaveCount 2
+        @($result.templateId) | Should -Contain 'google-chrome'
+        @($result.templateId) | Should -Contain 'putty'
+    }
+
+    It 'Should throw when the preset does not exist' {
+        {
+            Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -PresetId 'missing-preset'
+        } | Should -Throw '*missing-preset*'
+    }
+
+    It 'Should throw when a requested template does not exist' {
+        {
+            Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -TemplateId 'does-not-exist'
+        } | Should -Throw '*does-not-exist*'
+    }
+
+    It 'Should return no templates when the default bundled catalog is not present' {
+        $script:TemplatesPath = Join-Path ([System.IO.Path]::GetTempPath()) "MissingTemplates-$([guid]::NewGuid().ToString('N'))"
+
+        $result = Get-HydrationWinGetAppTemplates
+
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Private/Get-HydrationWinGetAppTemplates.Tests.ps1
+++ b/Tests/Private/Get-HydrationWinGetAppTemplates.Tests.ps1
@@ -89,6 +89,14 @@ Describe 'Get-HydrationWinGetAppTemplates' {
         @($result.templateId) | Should -Contain 'putty'
     }
 
+    It 'Should resolve requested template IDs case-insensitively' {
+        $result = Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -TemplateId @('Google-Chrome', 'PuTTY')
+
+        $result | Should -HaveCount 2
+        @($result.templateId) | Should -Contain 'google-chrome'
+        @($result.templateId) | Should -Contain 'putty'
+    }
+
     It 'Should throw when the preset does not exist' {
         {
             Get-HydrationWinGetAppTemplates -TemplatePath $script:WinGetTemplatePath -PresetId 'missing-preset'

--- a/Tests/Private/Get-IntuneProactiveRemediationAvailability.Tests.ps1
+++ b/Tests/Private/Get-IntuneProactiveRemediationAvailability.Tests.ps1
@@ -1,0 +1,47 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    Get-Module -Name IntuneHydrationKit | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+    $script:TestModule = Get-Module -Name IntuneHydrationKit | Select-Object -First 1
+}
+
+Describe 'Get-IntuneProactiveRemediationAvailability' {
+    It 'Should return Available when the Graph probe succeeds' {
+        Mock Invoke-HydrationGraphRequest { @{ value = @() } } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            Get-IntuneProactiveRemediationAvailability
+        }
+
+        $result.IsAvailable | Should -BeTrue
+        $result.Status | Should -Be 'Available'
+    }
+
+    It 'Should return FeatureUnavailable for tenant capability failures' {
+        Mock Invoke-HydrationGraphRequest { throw 'probe failed' } -ModuleName IntuneHydrationKit
+        Mock Get-GraphStatusCode { 404 } -ModuleName IntuneHydrationKit
+        Mock Get-GraphErrorMessage { 'HTTP 404 - Resource not found' } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            Get-IntuneProactiveRemediationAvailability
+        }
+
+        $result.IsAvailable | Should -BeFalse
+        $result.Status | Should -Be 'FeatureUnavailable'
+    }
+
+    It 'Should return InsufficientPermissions for permission failures' {
+        Mock Invoke-HydrationGraphRequest { throw 'probe failed' } -ModuleName IntuneHydrationKit
+        Mock Get-GraphStatusCode { 403 } -ModuleName IntuneHydrationKit
+        Mock Get-GraphErrorMessage { 'HTTP 403 - Access denied - check permissions' } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            Get-IntuneProactiveRemediationAvailability
+        }
+
+        $result.IsAvailable | Should -BeFalse
+        $result.Status | Should -Be 'InsufficientPermissions'
+    }
+}

--- a/Tests/Private/Get-IntuneWinPackageMetadata.Tests.ps1
+++ b/Tests/Private/Get-IntuneWinPackageMetadata.Tests.ps1
@@ -1,0 +1,67 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinPackageMetadata.ps1
+}
+
+Describe 'Get-IntuneWinPackageMetadata' {
+    BeforeAll {
+        $script:artifactRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/Get-IntuneWinPackageMetadata'
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:artifactRoot -ItemType Directory -Force
+        $packageRoot = Join-Path $script:artifactRoot 'source'
+        $metadataRoot = Join-Path $packageRoot 'Metadata'
+        $contentsRoot = Join-Path $packageRoot 'Contents'
+        $null = New-Item -Path $metadataRoot -ItemType Directory -Force
+        $null = New-Item -Path $contentsRoot -ItemType Directory -Force
+
+        @'
+<ApplicationInfo>
+  <FileName>app.bin</FileName>
+  <SetupFile>setup.exe</SetupFile>
+  <UnencryptedContentSize>12345</UnencryptedContentSize>
+  <EncryptionInfo>
+    <EncryptionKey>enc-key</EncryptionKey>
+    <MacKey>mac-key</MacKey>
+    <InitializationVector>iv</InitializationVector>
+    <Mac>mac</Mac>
+    <ProfileIdentifier>profile</ProfileIdentifier>
+    <FileDigest>digest</FileDigest>
+    <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+  </EncryptionInfo>
+</ApplicationInfo>
+'@ | Set-Content -Path (Join-Path $metadataRoot 'Detection.xml')
+        'encrypted-content' | Set-Content -Path (Join-Path $contentsRoot 'app.bin')
+
+        $script:packagePath = Join-Path $script:artifactRoot 'sample.intunewin'
+        Compress-Archive -Path (Join-Path $packageRoot '*') -DestinationPath $script:packagePath -Force
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+    }
+
+    It 'Should parse Detection.xml metadata from the package' {
+        $result = Get-IntuneWinPackageMetadata -IntuneWinPath $script:packagePath
+
+        $result.FileName | Should -Be 'app.bin'
+        $result.SetupFile | Should -Be 'setup.exe'
+        $result.UnencryptedSize | Should -Be 12345
+        $result.FileDigestAlgorithm | Should -Be 'SHA256'
+    }
+
+    It 'Should throw when Detection.xml is missing' {
+        $emptyRoot = Join-Path $script:artifactRoot 'missing-detection'
+        $null = New-Item -Path $emptyRoot -ItemType Directory -Force
+        'content' | Set-Content -Path (Join-Path $emptyRoot 'app.bin')
+        $missingDetectionPath = Join-Path $script:artifactRoot 'missing.intunewin'
+        Compress-Archive -Path (Join-Path $emptyRoot '*') -DestinationPath $missingDetectionPath -Force
+
+        { Get-IntuneWinPackageMetadata -IntuneWinPath $missingDetectionPath } | Should -Throw '*Detection.xml*'
+    }
+}

--- a/Tests/Private/Get-IntuneWinUploadChunkLength.Tests.ps1
+++ b/Tests/Private/Get-IntuneWinUploadChunkLength.Tests.ps1
@@ -1,0 +1,25 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinUploadChunkLength.ps1
+}
+
+Describe 'Get-IntuneWinUploadChunkLength' {
+    It 'Should return a full chunk for non-final chunks' {
+        Get-IntuneWinUploadChunkLength -FileSize 25 -ChunkIndex 1 -ChunkSizeBytes 10 | Should -Be 10
+    }
+
+    It 'Should return the remaining byte count for the final chunk' {
+        Get-IntuneWinUploadChunkLength -FileSize 25 -ChunkIndex 2 -ChunkSizeBytes 10 | Should -Be 5
+    }
+
+    It 'Should use 64-bit offsets for large packages' {
+        $fileSize = [int64]3GB + 123
+
+        Get-IntuneWinUploadChunkLength -FileSize $fileSize -ChunkIndex 512 -ChunkSizeBytes 6MB | Should -Be 123
+    }
+
+    It 'Should return zero when the chunk index starts beyond the file' {
+        Get-IntuneWinUploadChunkLength -FileSize 25 -ChunkIndex 3 -ChunkSizeBytes 10 | Should -Be 0
+    }
+}

--- a/Tests/Private/Get-MobileAppImportConfiguration.Tests.ps1
+++ b/Tests/Private/Get-MobileAppImportConfiguration.Tests.ps1
@@ -1,0 +1,88 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' '..' 'Private' 'Utilities' 'Get-ConfigurationSection.ps1')
+    $modulePath = Join-Path $PSScriptRoot '..' '..' 'Private' 'MobileApps' 'Get-MobileAppImportConfiguration.ps1'
+    . $modulePath
+}
+
+Describe 'Get-MobileAppImportConfiguration' {
+    It 'Should return defaults when mobileApps section is absent' {
+        $settings = @{}
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.presetId | Should -Be $null
+        $result.templateIds | Should -BeNullOrEmpty
+        $result.remediationEnabled | Should -Be $true
+    }
+
+    It 'Should return defaults when mobileApps section is null' {
+        $settings = @{ mobileApps = $null }
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.presetId | Should -Be $null
+        $result.templateIds | Should -BeNullOrEmpty
+        $result.remediationEnabled | Should -Be $true
+    }
+
+    It 'Should extract presetId and templateIds' {
+        $settings = @{
+            mobileApps = @{
+                presetId    = 'starter-pack'
+                templateIds = @('google-chrome', 'vscode')
+                remediation = @{ enabled = $true }
+            }
+        }
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.presetId | Should -Be 'starter-pack'
+        $result.templateIds | Should -Be @('google-chrome', 'vscode')
+        $result.remediationEnabled | Should -Be $true
+    }
+
+    It 'Should drop blank template IDs and presetId' {
+        $settings = @{
+            mobileApps = @{
+                presetId    = ' '
+                templateIds = @('', '   ', $null, 'valid-app')
+            }
+        }
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.presetId | Should -Be $null
+        $result.templateIds | Should -Be @('valid-app')
+    }
+
+    It 'Should parse remediation enabled false' {
+        $settings = @{
+            mobileApps = @{
+                remediation = @{ enabled = $false }
+            }
+        }
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.remediationEnabled | Should -Be $false
+    }
+
+    It 'Should keep remediation enabled when remediation section omits enabled' {
+        $settings = @{
+            mobileApps = @{
+                remediation = @{}
+            }
+        }
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.remediationEnabled | Should -Be $true
+    }
+
+    It 'Should keep remediation enabled when remediation enabled is null' {
+        $settings = @{
+            mobileApps = @{
+                remediation = @{ enabled = $null }
+            }
+        }
+        $result = Get-MobileAppImportConfiguration -Settings $settings
+
+        $result.remediationEnabled | Should -Be $true
+    }
+}

--- a/Tests/Private/Get-MobileAppTemplateNameSet.Tests.ps1
+++ b/Tests/Private/Get-MobileAppTemplateNameSet.Tests.ps1
@@ -1,0 +1,67 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..'
+    Get-Module -Name IntuneHydrationKit | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $moduleRoot 'IntuneHydrationKit.psd1') -Force
+    $modulePath = Join-Path $PSScriptRoot '..' '..' 'Private' 'MobileApps' 'Get-MobileAppTemplateNameSet.ps1'
+    . $modulePath
+}
+
+Describe 'Get-MobileAppTemplateNameSet' {
+    It 'Should extract display names from valid template files' {
+        $tempDir = Join-Path $TestDrive 'mobile-app-templates'
+        $null = New-Item -Path $tempDir -ItemType Directory -Force
+        @'
+{
+    "displayName": "Company Portal"
+}
+'@ | Set-Content -Path (Join-Path $tempDir 'CompanyPortal.json') -Encoding utf8
+        @'
+{
+    "displayName": "WhatsApp"
+}
+'@ | Set-Content -Path (Join-Path $tempDir 'WhatsApp.json') -Encoding utf8
+
+        $files = Get-ChildItem -Path $tempDir -Filter '*.json' -File
+
+        InModuleScope IntuneHydrationKit -Parameters @{ TemplateFiles = $files } {
+            $result = Get-MobileAppTemplateNameSet -TemplateFiles $TemplateFiles
+
+            $result | Should -Contain 'Company Portal - [IHD]'
+            $result | Should -Contain 'WhatsApp - [IHD]'
+        }
+    }
+
+    It 'Should skip templates with missing displayName' {
+        $tempDir = Join-Path $TestDrive 'mobile-app-templates-missing'
+        $null = New-Item -Path $tempDir -ItemType Directory -Force
+        @'
+{
+    "publisher": "Test"
+}
+'@ | Set-Content -Path (Join-Path $tempDir 'NoName.json') -Encoding utf8
+
+        $files = Get-ChildItem -Path $tempDir -Filter '*.json' -File
+
+        InModuleScope IntuneHydrationKit -Parameters @{ TemplateFiles = $files } {
+            $result = Get-MobileAppTemplateNameSet -TemplateFiles $TemplateFiles
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Should skip invalid JSON files' {
+        $tempDir = Join-Path $TestDrive 'mobile-app-templates-invalid'
+        $null = New-Item -Path $tempDir -ItemType Directory -Force
+        'not json' | Set-Content -Path (Join-Path $tempDir 'Bad.json') -Encoding utf8
+
+        $files = Get-ChildItem -Path $tempDir -Filter '*.json' -File
+
+        InModuleScope IntuneHydrationKit -Parameters @{ TemplateFiles = $files } {
+            $result = Get-MobileAppTemplateNameSet -TemplateFiles $TemplateFiles
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Private/Get-WinGetBootstrapScriptFragment.Tests.ps1
+++ b/Tests/Private/Get-WinGetBootstrapScriptFragment.Tests.ps1
@@ -14,6 +14,9 @@ Describe 'Get-WinGetBootstrapScriptFragment' {
         $result | Should -Match "Write-TestLog -Message 'Bootstrapping WinGet for tests\.'"
         $result.Contains('$programDataRoot = if ([string]::IsNullOrWhiteSpace($env:ProgramData)) { ''C:\ProgramData'' } else { $env:ProgramData }') | Should -BeTrue
         $result.Contains('$programDataWingetRoot = Join-Path -Path $programDataRoot -ChildPath ''Microsoft.DesktopAppInstaller''') | Should -BeTrue
+        $result.Contains('$tempRoot = [System.IO.Path]::GetTempPath()') | Should -BeTrue
+        $result.Contains('$tempRoot = if ([string]::IsNullOrWhiteSpace($env:TEMP)) { ''C:\Windows\Temp'' } else { $env:TEMP }') | Should -BeTrue
+        $result.Contains('$stagingRoot = Join-Path -Path $tempRoot -ChildPath ''IntuneHydrationKit-WinGetBootstrap''') | Should -BeTrue
         $result | Should -Not -Match '7zip|7za|Install-WingetWith7Zip'
     }
 }

--- a/Tests/Private/Get-WinGetBootstrapScriptFragment.Tests.ps1
+++ b/Tests/Private/Get-WinGetBootstrapScriptFragment.Tests.ps1
@@ -1,0 +1,17 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
+}
+
+Describe 'Get-WinGetBootstrapScriptFragment' {
+    It 'Should generate a reusable ZipFile-based WinGet bootstrap fragment' {
+        $result = Get-WinGetBootstrapScriptFragment -LogFunctionName 'Write-TestLog' -BootstrapMessage 'Bootstrapping WinGet for tests.'
+
+        $result | Should -Match 'function Get-WinGetExecutablePath'
+        $result | Should -Match 'function Install-WinGetSystemBootstrap'
+        $result | Should -Match 'System\.IO\.Compression\.ZipFile'
+        $result | Should -Match "Write-TestLog -Message 'Bootstrapping WinGet for tests\.'"
+        $result | Should -Not -Match '7zip|7za|Install-WingetWith7Zip'
+    }
+}

--- a/Tests/Private/Get-WinGetBootstrapScriptFragment.Tests.ps1
+++ b/Tests/Private/Get-WinGetBootstrapScriptFragment.Tests.ps1
@@ -12,6 +12,8 @@ Describe 'Get-WinGetBootstrapScriptFragment' {
         $result | Should -Match 'function Install-WinGetSystemBootstrap'
         $result | Should -Match 'System\.IO\.Compression\.ZipFile'
         $result | Should -Match "Write-TestLog -Message 'Bootstrapping WinGet for tests\.'"
+        $result.Contains('$programDataRoot = if ([string]::IsNullOrWhiteSpace($env:ProgramData)) { ''C:\ProgramData'' } else { $env:ProgramData }') | Should -BeTrue
+        $result.Contains('$programDataWingetRoot = Join-Path -Path $programDataRoot -ChildPath ''Microsoft.DesktopAppInstaller''') | Should -BeTrue
         $result | Should -Not -Match '7zip|7za|Install-WingetWith7Zip'
     }
 }

--- a/Tests/Private/Get-WinGetDetectionRules.Tests.ps1
+++ b/Tests/Private/Get-WinGetDetectionRules.Tests.ps1
@@ -1,0 +1,41 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-WinGetDetectionRules.ps1
+}
+
+Describe 'Get-WinGetDetectionRules' {
+    It 'Should use generated script detection even when WinGet manifest metadata has an MSI product code' {
+        $template = [pscustomobject]@{
+            templateId = 'google-chrome'
+            detection  = [pscustomobject]@{
+                strategy = 'generated'
+            }
+        }
+
+        $packageMetadata = [pscustomobject]@{
+            SelectedInstaller = [pscustomobject]@{
+                InstallerType = 'msi'
+                ProductCode   = '{042C29DE-2EAE-34E1-A978-C2BE5AB65557}'
+            }
+        }
+
+        $result = Get-WinGetDetectionRules -Template $template -PackageMetadata $packageMetadata
+
+        $rules = @($result)
+        $rules | Should -HaveCount 1
+        $rules[0].DetectionType | Should -Be 'Script'
+        $rules[0].ScriptFile | Should -Be 'Detect-WinGetPackage.ps1'
+    }
+
+    It 'Should reject unsupported WinGet detection strategies' {
+        $template = [pscustomobject]@{
+            templateId = 'contoso-app'
+            detection  = [pscustomobject]@{
+                strategy = 'msi'
+            }
+        }
+
+        { Get-WinGetDetectionRules -Template $template } | Should -Throw "*Detection strategy 'msi' is not supported*"
+    }
+}

--- a/Tests/Private/Get-WinGetDetectionScriptContent.Tests.ps1
+++ b/Tests/Private/Get-WinGetDetectionScriptContent.Tests.ps1
@@ -17,6 +17,10 @@ Describe 'Get-WinGetDetectionScriptContent' {
         $scriptContent | Should -Match 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\*'
         $scriptContent | Should -Match 'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\*'
         $scriptContent | Should -Match 'Test-InstalledApplicationRegistry'
+        $scriptContent | Should -Match ([regex]::Escape('Write-Output "[$Level] $Message"'))
+        $scriptContent | Should -Match ([regex]::Escape('Write-Output "$PackageIdentifier is installed"'))
+        $scriptContent | Should -Match ([regex]::Escape('Write-Output "$PackageIdentifier is not installed"'))
+        $scriptContent | Should -Not -Match 'Write-Host'
 
         $parseErrors = $null
         $null = [System.Management.Automation.Language.Parser]::ParseInput($scriptContent, [ref]$null, [ref]$parseErrors)

--- a/Tests/Private/Get-WinGetDetectionScriptContent.Tests.ps1
+++ b/Tests/Private/Get-WinGetDetectionScriptContent.Tests.ps1
@@ -1,0 +1,25 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-WinGetBootstrapScriptFragment.ps1
+    . $PSScriptRoot/../../Private/WinGet/Get-WinGetDetectionScriptContent.ps1
+}
+
+Describe 'Get-WinGetDetectionScriptContent' {
+    It 'Should generate WinGet detection with exact ID matching and uninstall registry fallback' {
+        $scriptContent = Get-WinGetDetectionScriptContent -PackageIdentifier 'Adobe.Acrobat.Reader.64-bit' -DisplayName 'Adobe Acrobat Reader DC' -Publisher 'ADOBE INC.'
+
+        $scriptContent | Should -Match ([regex]::Escape('$PackageIdentifier = ''Adobe.Acrobat.Reader.64-bit'''))
+        $scriptContent | Should -Match ([regex]::Escape('$DisplayName = ''Adobe Acrobat Reader DC'''))
+        $scriptContent | Should -Match ([regex]::Escape('$Publisher = ''ADOBE INC.'''))
+        $scriptContent | Should -Match ([regex]::Escape('winget list --id "$PackageIdentifier" --exact --accept-source-agreements'))
+        $scriptContent | Should -Not -Match ([regex]::Escape('--source winget'))
+        $scriptContent | Should -Match 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\*'
+        $scriptContent | Should -Match 'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\*'
+        $scriptContent | Should -Match 'Test-InstalledApplicationRegistry'
+
+        $parseErrors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseInput($scriptContent, [ref]$null, [ref]$parseErrors)
+        $parseErrors | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Private/Get-WinGetRemediationFingerprint.Tests.ps1
+++ b/Tests/Private/Get-WinGetRemediationFingerprint.Tests.ps1
@@ -1,0 +1,25 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-WinGetRemediationFingerprint.ps1
+}
+
+Describe 'Get-WinGetRemediationFingerprint' {
+    It 'Should produce a stable 16-character fingerprint from sorted unique package identifiers' {
+        $result = Get-WinGetRemediationFingerprint -PackageIdentifiers @(
+            'Contoso.User',
+            'Contoso.Machine',
+            'Contoso.User',
+            ' '
+        )
+
+        $result | Should -Be '9154625C4EF3E6D6'
+    }
+
+    It 'Should use PowerShell 7.0 compatible SHA256 APIs' {
+        $source = Get-Content -Path "$PSScriptRoot/../../Private/WinGet/Get-WinGetRemediationFingerprint.ps1" -Raw
+
+        $source | Should -Match 'ComputeHash'
+        $source | Should -Not -Match 'HashData'
+    }
+}

--- a/Tests/Private/Invoke-HydrationGraphRequest.Tests.ps1
+++ b/Tests/Private/Invoke-HydrationGraphRequest.Tests.ps1
@@ -1,0 +1,102 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Graph/Get-GraphStatusCode.ps1
+    . $PSScriptRoot/../../Private/Graph/Invoke-HydrationGraphRequest.ps1
+}
+
+Describe 'Invoke-HydrationGraphRequest' {
+    BeforeAll {
+        $script:GraphEndpoint = 'https://graph.microsoft.us'
+        Mock Start-Sleep {}
+    }
+
+    Context 'URI normalization' {
+        It 'Should trim the configured Graph endpoint from absolute URIs' {
+            Mock Invoke-MgGraphRequest { @{ ok = $true } }
+
+            $null = Invoke-HydrationGraphRequest -Method GET -Uri 'https://graph.microsoft.us/beta/deviceAppManagement/mobileApps'
+
+            Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+                $Uri -eq 'beta/deviceAppManagement/mobileApps'
+            }
+        }
+
+        It 'Should preserve relative URIs' {
+            Mock Invoke-MgGraphRequest { @{ ok = $true } }
+
+            $null = Invoke-HydrationGraphRequest -Method GET -Uri 'beta/deviceAppManagement/mobileApps'
+
+            Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+                $Uri -eq 'beta/deviceAppManagement/mobileApps'
+            }
+        }
+    }
+
+    Context 'Body handling' {
+        It 'Should pass JSON strings with content type through unchanged' {
+            Mock Invoke-MgGraphRequest { @{ ok = $true } }
+
+            $null = Invoke-HydrationGraphRequest -Method POST -Uri 'beta/deviceAppManagement/mobileApps' -Body '{"displayName":"Test"}'
+
+            Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+                $Body -eq '{"displayName":"Test"}' -and $ContentType -eq 'application/json'
+            }
+        }
+    }
+
+    Context 'Retry behavior' {
+        It 'Should retry transient server failures' {
+            $script:attemptCount = 0
+            Mock Invoke-MgGraphRequest {
+                $script:attemptCount++
+                if ($script:attemptCount -eq 1) {
+                    $exception = [System.Exception]::new('Transient failure')
+                    $exception | Add-Member -NotePropertyName 'ResponseStatusCode' -NotePropertyValue 503 -Force
+                    $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'TransientFailure', [System.Management.Automation.ErrorCategory]::InvalidOperation, $null)
+                    throw $errorRecord
+                }
+
+                return @{ id = 'success' }
+            }
+
+            $result = Invoke-HydrationGraphRequest -Method GET -Uri 'beta/deviceAppManagement/mobileApps' -RetryDelaySeconds 1
+
+            $result.id | Should -Be 'success'
+            $script:attemptCount | Should -Be 2
+            Should -Invoke Start-Sleep -Exactly 1 -ParameterFilter { $Seconds -eq 1 }
+        }
+
+        It 'Should honor Retry-After headers when present' {
+            $script:attemptCount = 0
+            Mock Invoke-MgGraphRequest {
+                $script:attemptCount++
+                if ($script:attemptCount -eq 1) {
+                    $exception = [System.Exception]::new('Too many requests')
+                    $exception | Add-Member -NotePropertyName 'ResponseStatusCode' -NotePropertyValue 429 -Force
+                    $exception | Add-Member -NotePropertyName 'ResponseHeaders' -NotePropertyValue @{ 'Retry-After' = '7' } -Force
+                    $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'Throttle', [System.Management.Automation.ErrorCategory]::LimitsExceeded, $null)
+                    throw $errorRecord
+                }
+
+                return @{ id = 'success' }
+            }
+
+            $null = Invoke-HydrationGraphRequest -Method GET -Uri 'beta/deviceAppManagement/mobileApps'
+
+            Should -Invoke Start-Sleep -Exactly 1 -ParameterFilter { $Seconds -eq 7 }
+        }
+
+        It 'Should rethrow non-retryable failures' {
+            Mock Invoke-MgGraphRequest {
+                $exception = [System.Exception]::new('Forbidden')
+                $exception | Add-Member -NotePropertyName 'ResponseStatusCode' -NotePropertyValue 403 -Force
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'Forbidden', [System.Management.Automation.ErrorCategory]::PermissionDenied, $null)
+                throw $errorRecord
+            }
+
+            { Invoke-HydrationGraphRequest -Method GET -Uri 'beta/deviceAppManagement/mobileApps' } | Should -Throw
+            Should -Invoke Start-Sleep -Exactly 0 -Scope It
+        }
+    }
+}

--- a/Tests/Private/Invoke-IntuneWinGetAppTemplate.Tests.ps1
+++ b/Tests/Private/Invoke-IntuneWinGetAppTemplate.Tests.ps1
@@ -1,0 +1,273 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..'
+    Get-Module -Name IntuneHydrationKit | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+}
+
+Describe 'Invoke-IntuneWinGetAppTemplate' {
+    BeforeAll {
+        $script:testWorkingRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/Invoke-IntuneWinGetAppTemplate'
+        if (Test-Path -Path $script:testWorkingRoot) {
+            Remove-Item -Path $script:testWorkingRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:testWorkingRoot -ItemType Directory -Force
+    }
+
+    Context 'packageIdentifier validation' {
+        It 'throws terminating error when packageIdentifier is missing' {
+            InModuleScope IntuneHydrationKit -Parameters @{ WorkingRoot = $script:testWorkingRoot } {
+                param($WorkingRoot)
+
+                $template = [pscustomobject]@{
+                    templateId = 'test-app'
+                }
+
+                { Invoke-IntuneWinGetAppTemplate -Template $template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot } |
+                    Should -Throw '*missing or blank packageIdentifier*'
+            }
+        }
+
+        It 'throws terminating error when packageIdentifier is blank' {
+            InModuleScope IntuneHydrationKit -Parameters @{ WorkingRoot = $script:testWorkingRoot } {
+                param($WorkingRoot)
+
+                $template = [pscustomobject]@{
+                    templateId        = 'test-app'
+                    packageIdentifier = ''
+                }
+
+                { Invoke-IntuneWinGetAppTemplate -Template $template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot } |
+                    Should -Throw '*missing or blank packageIdentifier*'
+            }
+        }
+
+        It 'throws terminating error when packageIdentifier is whitespace-only' {
+            InModuleScope IntuneHydrationKit -Parameters @{ WorkingRoot = $script:testWorkingRoot } {
+                param($WorkingRoot)
+
+                $template = [pscustomobject]@{
+                    templateId        = 'test-app'
+                    packageIdentifier = '   '
+                }
+
+                { Invoke-IntuneWinGetAppTemplate -Template $template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot } |
+                    Should -Throw '*missing or blank packageIdentifier*'
+            }
+        }
+
+        It 'does not throw when packageIdentifier is valid' {
+            InModuleScope IntuneHydrationKit -Parameters @{ WorkingRoot = $script:testWorkingRoot } {
+                param($WorkingRoot)
+
+                Mock New-WinGetWrapperFiles {
+                    [pscustomobject]@{
+                        InstallScriptPath   = Join-Path $WorkingRoot 'content\Install-WinGetPackage.ps1'
+                        UninstallScriptPath = Join-Path $WorkingRoot 'content\Uninstall-WinGetPackage.ps1'
+                    }
+                } -ParameterFilter { $Path -and $Template }
+
+                Mock New-IntuneWinPackagingContext { } -ParameterFilter { $SourcePath -and $OutputPath }
+                Mock New-IntuneWinPackage { } -ParameterFilter { $PackagingContext }
+                Mock New-WinGetOwnershipNotes { '' }
+                Mock Get-WinGetDetectionRules { @() }
+                Mock Get-PrimaryArchitecture { 'x64' }
+                Mock Get-RequirementArchitecture { 'x64' }
+                Mock New-IntuneWin32AppPayload { [pscustomobject]@{ appVersion = '1.0.0' } }
+                Mock Invoke-HydrationGraphRequest { [pscustomobject]@{ id = '00000000-0000-0000-0000-000000000001' } }
+                Mock Publish-IntuneWin32AppContent { [pscustomobject]@{ ContentVersionId = '1' } }
+                Mock Write-HydrationLog { }
+
+                $template = [pscustomobject]@{
+                    templateId        = 'test-app'
+                    packageIdentifier = 'Test.App'
+                    publisher         = 'Test Publisher'
+                    description       = 'Test app description'
+                    TemplatePath      = Join-Path $WorkingRoot 'test-app.json'
+                    resolvedPackage   = [pscustomobject]@{
+                        packageVersion    = '1.0.0'
+                        manifestSource    = [pscustomobject]@{
+                            repository  = 'microsoft/winget-pkgs'
+                            ref         = 'master'
+                            packagePath = 'manifests/t/Test/App'
+                            versionPath = 'manifests/t/Test/App/1.0.0'
+                        }
+                        selectedInstaller = [pscustomobject]@{
+                            Architecture    = 'x64'
+                            Scope           = 'machine'
+                            InstallerLocale = 'en-US'
+                            InstallerType   = 'exe'
+                            InstallerUrl    = 'https://example.test/app.exe'
+                        }
+                    }
+                    package           = [pscustomobject]@{
+                        match = [pscustomobject]@{
+                            architectures = @('x64')
+                            scope         = 'machine'
+                            locale        = 'en-US'
+                        }
+                    }
+                    install           = [pscustomobject]@{
+                        experience      = 'system'
+                        restartBehavior = 'suppress'
+                    }
+                    uninstall         = [pscustomobject]@{
+                        behavior = 'allow'
+                    }
+                    requirements      = [pscustomobject]@{
+                        minimumSupportedWindowsRelease = 'W10_22H2'
+                        architectures                  = @('x64')
+                        minimumFreeDiskSpaceInMB       = 1024
+                        minimumMemoryInMB              = 2048
+                    }
+                    metadata          = [pscustomobject]@{
+                        placeholders = [pscustomobject]@{
+                            owner       = 'Test Owner'
+                            scopeTagIds = @('1')
+                        }
+                    }
+                    icon              = [pscustomobject]@{
+                        sourceType = 'none'
+                        fileName   = $null
+                    }
+                }
+
+                { Invoke-IntuneWinGetAppTemplate -Template $template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot } |
+                    Should -Not -Throw
+            }
+        }
+
+        It 'returns a failed result when a template lacks bundled resolvedPackage metadata' {
+            InModuleScope IntuneHydrationKit -Parameters @{ WorkingRoot = $script:testWorkingRoot } {
+                param($WorkingRoot)
+
+                $template = [pscustomobject]@{
+                    templateId        = 'test-app'
+                    packageIdentifier = 'Test.App'
+                }
+
+                $result = Invoke-IntuneWinGetAppTemplate -Template $template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot
+
+                $result.Action | Should -Be 'Failed'
+                $result.Status | Should -BeLike '*Open an issue requesting this app or submit a PR*'
+            }
+        }
+
+        It 'uses resolved template metadata instead of live GitHub manifest resolution' {
+            InModuleScope IntuneHydrationKit -Parameters @{ WorkingRoot = $script:testWorkingRoot } {
+                param($WorkingRoot)
+
+                Mock New-WinGetWrapperFiles {
+                    [pscustomobject]@{
+                        InstallScriptPath   = Join-Path $WorkingRoot 'content\Install-WinGetPackage.ps1'
+                        UninstallScriptPath = Join-Path $WorkingRoot 'content\Uninstall-WinGetPackage.ps1'
+                    }
+                } -ParameterFilter { $Path -and $Template }
+                Mock New-IntuneWinPackagingContext { } -ParameterFilter { $PackageMetadata.PackageVersion -eq 'latest' }
+                Mock New-IntuneWinPackage { } -ParameterFilter { $PackagingContext }
+                Mock New-WinGetOwnershipNotes { '' }
+                Mock Get-WinGetDetectionRules { @() }
+                Mock Get-RequirementArchitecture { 'x64' }
+                Mock New-IntuneWin32AppPayload { [pscustomobject]@{ appVersion = 'latest' } }
+                Mock Invoke-HydrationGraphRequest { [pscustomobject]@{ id = '00000000-0000-0000-0000-000000000001' } }
+                Mock Publish-IntuneWin32AppContent { [pscustomobject]@{ ContentVersionId = '1' } }
+                Mock Write-HydrationLog { }
+
+                $template = [pscustomobject]@{
+                    templateId        = 'test-app'
+                    packageIdentifier = 'Test.App'
+                    displayName       = 'Test App'
+                    publisher         = 'Test Publisher'
+                    description       = 'Test app description'
+                    TemplatePath      = Join-Path $WorkingRoot 'test-app.json'
+                    package           = [pscustomobject]@{
+                        match = [pscustomobject]@{
+                            architectures  = @('x64')
+                            installerTypes = @('exe')
+                            scope          = 'machine'
+                            locale         = 'en-US'
+                        }
+                    }
+                    resolvedPackage   = [pscustomobject]@{
+                        packageVersion    = 'latest'
+                        manifestSource    = [pscustomobject]@{
+                            repository  = 'microsoft/winget-pkgs'
+                            ref         = 'master'
+                            packagePath = 'manifests/t/Test/App'
+                            versionPath = 'manifests/t/Test/App'
+                        }
+                        selectedInstaller = [pscustomobject]@{
+                            Architecture         = 'x64'
+                            Scope                = 'machine'
+                            InstallerLocale      = 'en-US'
+                            InstallerType        = 'exe'
+                            InstallerUrl         = $null
+                            InstallerSha256      = $null
+                            ProductCode          = $null
+                            PackageFamilyName    = $null
+                            NestedInstallerType  = $null
+                            AppsAndFeaturesEntry = @()
+                        }
+                    }
+                    install           = [pscustomobject]@{
+                        experience      = 'system'
+                        restartBehavior = 'suppress'
+                    }
+                    uninstall         = [pscustomobject]@{
+                        behavior = 'allow'
+                    }
+                    requirements      = [pscustomobject]@{
+                        minimumSupportedWindowsRelease = 'W10_22H2'
+                        architectures                  = @('x64')
+                    }
+                    metadata          = [pscustomobject]@{
+                        placeholders = [pscustomobject]@{
+                            owner       = ''
+                            scopeTagIds = @()
+                        }
+                    }
+                    icon              = [pscustomobject]@{
+                        sourceType = 'none'
+                        fileName   = $null
+                    }
+                }
+
+                { Invoke-IntuneWinGetAppTemplate -Template $template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot } |
+                    Should -Not -Throw
+            }
+        }
+
+        It 'fails fast when resolved template metadata is missing core nodes' {
+            InModuleScope IntuneHydrationKit {
+                $template = [pscustomobject]@{
+                    templateId        = 'test-app'
+                    packageIdentifier = 'Test.App'
+                    displayName       = 'Test App'
+                    publisher         = 'Test Publisher'
+                    description       = 'Test app description'
+                    package           = [pscustomobject]@{
+                        match = [pscustomobject]@{
+                            locale = 'en-US'
+                        }
+                    }
+                    resolvedPackage   = [pscustomobject]@{
+                        packageVersion = 'latest'
+                        manifestSource = [pscustomobject]@{
+                            repository  = 'microsoft/winget-pkgs'
+                            ref         = 'master'
+                            packagePath = 'manifests/t/Test/App'
+                            versionPath = 'manifests/t/Test/App'
+                            installerFile = $null
+                            localeFile    = $null
+                        }
+                    }
+                }
+
+                { New-WinGetPackageMetadataFromTemplate -Template $template } |
+                    Should -Throw '*resolvedPackage metadata is incomplete*'
+            }
+        }
+    }
+}

--- a/Tests/Private/Invoke-IntuneWinGetAppTemplate.Tests.ps1
+++ b/Tests/Private/Invoke-IntuneWinGetAppTemplate.Tests.ps1
@@ -14,6 +14,45 @@ Describe 'Invoke-IntuneWinGetAppTemplate' {
         }
 
         $null = New-Item -Path $script:testWorkingRoot -ItemType Directory -Force
+
+        function New-TestWinGetTemplate {
+            param(
+                [Parameter(Mandatory)]
+                [string]$WorkingRoot
+            )
+
+            return [pscustomobject]@{
+                templateId        = 'test-app'
+                packageIdentifier = 'Test.App'
+                displayName       = 'Test App'
+                publisher         = 'Test Publisher'
+                description       = 'Test app description'
+                TemplatePath      = Join-Path $WorkingRoot 'test-app.json'
+                install           = [pscustomobject]@{
+                    experience      = 'system'
+                    restartBehavior = 'suppress'
+                }
+                uninstall         = [pscustomobject]@{
+                    behavior = 'allow'
+                }
+                requirements      = [pscustomobject]@{
+                    minimumSupportedWindowsRelease = 'W10_22H2'
+                    architectures                  = @('x64')
+                    minimumFreeDiskSpaceInMB       = 1024
+                    minimumMemoryInMB              = 2048
+                }
+                metadata          = [pscustomobject]@{
+                    placeholders = [pscustomobject]@{
+                        owner       = 'Test Owner'
+                        scopeTagIds = @('1')
+                    }
+                }
+                icon              = [pscustomobject]@{
+                    sourceType = 'none'
+                    fileName   = $null
+                }
+            }
+        }
     }
 
     Context 'packageIdentifier validation' {
@@ -267,6 +306,75 @@ Describe 'Invoke-IntuneWinGetAppTemplate' {
 
                 { New-WinGetPackageMetadataFromTemplate -Template $template } |
                     Should -Throw '*resolvedPackage metadata is incomplete*'
+            }
+        }
+
+        It 'does not fail a successful import when staging cleanup fails' {
+            $template = New-TestWinGetTemplate -WorkingRoot $script:testWorkingRoot
+
+            InModuleScope IntuneHydrationKit -Parameters @{
+                WorkingRoot = $script:testWorkingRoot
+                Template    = $template
+            } {
+                param($WorkingRoot, $Template)
+
+                Mock New-WinGetPackageMetadataFromTemplate {
+                    [pscustomobject]@{
+                        PackageIdentifier = 'Test.App'
+                        PackageVersion    = '1.0.0'
+                        Publisher         = 'Test Publisher'
+                        ManifestPath      = 'manifests/t/Test/App/1.0.0'
+                        SelectedInstaller = [pscustomobject]@{
+                            Architecture    = 'x64'
+                            Scope           = 'machine'
+                            InstallerLocale = 'en-US'
+                            InstallerType   = 'exe'
+                            InstallerUrl    = 'https://example.test/app.exe'
+                        }
+                    }
+                }
+                Mock New-WinGetWrapperFiles {
+                    [pscustomobject]@{
+                        InstallScriptPath   = Join-Path $WorkingRoot 'content\Install-WinGetPackage.ps1'
+                        UninstallScriptPath = Join-Path $WorkingRoot 'content\Uninstall-WinGetPackage.ps1'
+                    }
+                } -ParameterFilter { $Path -and $Template }
+
+                Mock New-IntuneWinPackagingContext {
+                    [pscustomobject]@{
+                        SourcePath = $SourcePath
+                        OutputPath = $OutputPath
+                    }
+                }
+                Mock New-IntuneWinPackage {
+                    [pscustomobject]@{
+                        OutputPath       = Join-Path $WorkingRoot 'test-app.intunewin'
+                        SetupFile        = 'Install-WinGetPackage.ps1'
+                        UnencryptedSize  = 1024
+                    }
+                } -ParameterFilter { $PackagingContext }
+                Mock New-WinGetOwnershipNotes { '' }
+                Mock Get-WinGetDetectionRules { @() }
+                Mock Get-RequirementArchitecture { 'x64' }
+                Mock New-IntuneWin32AppPayload { [pscustomobject]@{ appVersion = '1.0.0'; rules = @() } }
+                Mock Invoke-HydrationGraphRequest { [pscustomobject]@{ id = '00000000-0000-0000-0000-000000000001' } }
+                Mock Publish-IntuneWin32AppContent { [pscustomobject]@{ ContentVersionId = '1'; ContentFileId = 'file-1'; UploadedChunkCount = 1; PackagePath = 'package' } }
+                Mock Write-HydrationLog { }
+                Mock Test-Path { $true } -ParameterFilter { $Path -like (Join-Path $WorkingRoot 'test-app-*') }
+                Mock Remove-Item {
+                    throw 'locked staging'
+                } -ParameterFilter { $Path -like (Join-Path $WorkingRoot 'test-app-*') }
+
+                $previousErrorActionPreference = $ErrorActionPreference
+                try {
+                    $ErrorActionPreference = 'Stop'
+                    $result = Invoke-IntuneWinGetAppTemplate -Template $Template -DisplayName 'Test App' -WorkingDirectory $WorkingRoot
+                } finally {
+                    $ErrorActionPreference = $previousErrorActionPreference
+                }
+
+                $result.Action | Should -Be 'Created'
+                $result.Id | Should -Be '00000000-0000-0000-0000-000000000001'
             }
         }
     }

--- a/Tests/Private/Limit-GraphMessage.Tests.ps1
+++ b/Tests/Private/Limit-GraphMessage.Tests.ps1
@@ -1,0 +1,15 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Graph/Limit-GraphMessage.ps1
+}
+
+Describe 'Limit-GraphMessage' {
+    It 'Should return empty string for null input' {
+        Limit-GraphMessage -Message $null -MaximumLength 100 | Should -Be ''
+    }
+
+    It 'Should truncate messages longer than the maximum length' {
+        Limit-GraphMessage -Message ('A' * 12) -MaximumLength 5 | Should -Be 'AAAAA...'
+    }
+}

--- a/Tests/Private/Limit-GraphMessage.Tests.ps1
+++ b/Tests/Private/Limit-GraphMessage.Tests.ps1
@@ -12,4 +12,8 @@ Describe 'Limit-GraphMessage' {
     It 'Should truncate messages longer than the maximum length' {
         Limit-GraphMessage -Message ('A' * 12) -MaximumLength 5 | Should -Be 'AAAAA...'
     }
+
+    It 'Should reject non-positive maximum lengths' {
+        { Limit-GraphMessage -Message 'Graph error' -MaximumLength 0 } | Should -Throw
+    }
 }

--- a/Tests/Private/New-IntuneWin32AppPayload.Tests.ps1
+++ b/Tests/Private/New-IntuneWin32AppPayload.Tests.ps1
@@ -1,0 +1,115 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Utilities/Get-ConfigurationSection.ps1
+    . $PSScriptRoot/../../Private/Utilities/Resolve-MinimumSupportedOperatingSystem.ps1
+    . $PSScriptRoot/../../Private/Utilities/Resolve-ApplicableArchitecture.ps1
+    . $PSScriptRoot/../../Private/Utilities/ConvertTo-HydrationBoolValue.ps1
+    . $PSScriptRoot/../../Private/WinGet/ConvertTo-IntuneWinDetectionRule.ps1
+    . $PSScriptRoot/../../Private/WinGet/ConvertTo-IntuneWinRequirementRule.ps1
+    . $PSScriptRoot/../../Private/WinGet/New-IntuneWin32AppPayload.ps1
+}
+
+Describe 'New-IntuneWin32AppPayload' {
+    BeforeAll {
+        $script:artifactRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/New-IntuneWin32AppPayload'
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:artifactRoot -ItemType Directory -Force
+        'Write-Output ''detected''' | Set-Content -Path (Join-Path $script:artifactRoot 'detection.ps1')
+        'Write-Output ''requirement''' | Set-Content -Path (Join-Path $script:artifactRoot 'requirement.ps1')
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+    }
+
+    It 'Should build a win32LobApp payload with mapped rules and defaults' {
+        $payload = New-IntuneWin32AppPayload -Configuration @{
+            PackageInformation    = @{ SetupFile = 'setup.exe' }
+            Information           = @{
+                DisplayName     = 'Contoso App'
+                Description     = 'Line of business app'
+                Publisher       = 'Contoso'
+                AppVersion      = '1.0.0'
+                Notes           = 'Notes'
+                RoleScopeTagIds = @('1', '2')
+            }
+            Program               = @{
+                InstallCommand          = 'setup.exe /install'
+                UninstallCommand        = 'setup.exe /uninstall'
+                InstallExperience       = 'system'
+                DeviceRestartBehavior   = 'suppress'
+                AllowAvailableUninstall = 'true'
+            }
+            RequirementRule       = @{
+                MinimumRequiredOperatingSystem = 'W10_22H2'
+                Architecture                   = 'x64'
+                MinimumFreeDiskSpaceInMB       = 1024
+                MinimumMemoryInMB              = 2048
+            }
+            DetectionRule         = @(
+                @{ DetectionType = 'Script'; ScriptFile = 'detection.ps1'; EnforceSignatureCheck = 'false'; RunAs32Bit = 'false' }
+            )
+            CustomRequirementRule = @(
+                @{ RequirementType = 'Script'; ScriptFile = 'requirement.ps1'; Value = '1' }
+            )
+        } -PackageFileName 'app.intunewin' -SetupFilePath 'setup.exe' -IconBase64 'ZmFrZS1pY29u' -ScriptRootPath $script:artifactRoot
+
+        $payload['@odata.type'] | Should -Be '#microsoft.graph.win32LobApp'
+        $payload.displayName | Should -Be 'Contoso App'
+        $payload.fileName | Should -Be 'app.intunewin'
+        $payload.setupFilePath | Should -Be 'setup.exe'
+        $payload.deviceRestartBehavior | Should -Be 'suppress'
+        $payload.allowAvailableUninstall | Should -BeTrue
+        $payload.applicableArchitectures | Should -Be 'x64'
+        $payload.minimumSupportedOperatingSystem.v10_21H1 | Should -BeTrue
+        $payload.ContainsKey('minimumSupportedWindowsRelease') | Should -BeFalse
+        $payload.minimumFreeDiskSpaceInMB | Should -Be 1024
+        $payload.minimumMemoryInMB | Should -Be 2048
+        $payload.roleScopeTagIds | Should -Be @('1', '2')
+        $payload.rules | Should -HaveCount 2
+        $payload.ContainsKey('detectionRules') | Should -BeFalse
+        $payload.ContainsKey('requirementRules') | Should -BeFalse
+        $payload.largeIcon.value | Should -Be 'ZmFrZS1pY29u'
+    }
+
+    It 'Should omit optional architecture when set to All' {
+        $payload = New-IntuneWin32AppPayload -Configuration @{
+            Information     = @{ DisplayName = 'Contoso App' }
+            Program         = @{ InstallCommand = 'setup.exe'; UninstallCommand = 'setup.exe /remove' }
+            RequirementRule = @{ Architecture = 'All' }
+        }
+
+        $payload.ContainsKey('applicableArchitectures') | Should -BeFalse
+    }
+
+    It 'Should map Windows 10 20H2 to the Graph minimum OS key' {
+        $payload = New-IntuneWin32AppPayload -Configuration @{
+            Information     = @{ DisplayName = 'Contoso App' }
+            Program         = @{ InstallCommand = 'setup.exe'; UninstallCommand = 'setup.exe /remove' }
+            RequirementRule = @{ MinimumRequiredOperatingSystem = 'W10_20H2' }
+        }
+
+        $payload.minimumSupportedOperatingSystem.v10_20H2 | Should -BeTrue
+        $payload.minimumSupportedOperatingSystem.PSObject.Properties.Name | Should -Not -Contain 'v10_2H20'
+    }
+
+    It 'Should normalize blank optional URLs to null' {
+        $payload = New-IntuneWin32AppPayload -Configuration @{
+            Information = @{
+                DisplayName    = 'Contoso App'
+                InformationURL = '   '
+                PrivacyURL     = ''
+            }
+            Program     = @{ InstallCommand = 'setup.exe'; UninstallCommand = 'setup.exe /remove' }
+        }
+
+        $payload.informationUrl | Should -BeNullOrEmpty
+        $payload.privacyInformationUrl | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Private/New-IntuneWinPackage.Tests.ps1
+++ b/Tests/Private/New-IntuneWinPackage.Tests.ps1
@@ -1,0 +1,65 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Format-WinGetInstallerSummary.ps1
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinPackagingCapability.ps1
+    . $PSScriptRoot/../../Private/WinGet/New-IntuneWinPackagingContext.ps1
+    . $PSScriptRoot/../../Private/WinGet/New-IntuneWinPackage.ps1
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinPackageMetadata.ps1
+    . $PSScriptRoot/../../Private/WinGet/Expand-IntuneWinPackageEncryptedContent.ps1
+}
+
+Describe 'New-IntuneWinPackage' {
+    BeforeEach {
+        $script:artifactRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/New-IntuneWinPackage'
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:artifactRoot -ItemType Directory -Force
+        $script:sourceRoot = Join-Path $script:artifactRoot 'source'
+        $null = New-Item -Path $script:sourceRoot -ItemType Directory -Force
+        Set-Content -Path (Join-Path $script:sourceRoot 'Install-WinGetPackage.ps1') -Value "Write-Output 'install'"
+        Set-Content -Path (Join-Path $script:sourceRoot 'support.txt') -Value 'wrapper-data'
+        $script:outputPath = Join-Path $script:artifactRoot 'contoso.intunewin'
+        $script:packageMetadata = [pscustomobject]@{
+            PackageIdentifier = 'Contoso.App'
+            PackageVersion    = '1.0.0'
+            DisplayName       = 'Contoso App'
+            Publisher         = 'Contoso'
+            SelectedInstaller = [pscustomobject]@{
+                InstallerUrl = 'https://downloads.contoso.test/app.exe'
+            }
+        }
+    }
+
+    AfterEach {
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+    }
+
+    It 'Should generate a portal-compatible intunewin package' {
+        $context = New-IntuneWinPackagingContext -PackageMetadata $script:packageMetadata -SourcePath $script:sourceRoot -SetupFile 'Install-WinGetPackage.ps1' -OutputPath $script:outputPath
+
+        $result = New-IntuneWinPackage -PackagingContext $context
+        $metadata = Get-IntuneWinPackageMetadata -IntuneWinPath $script:outputPath
+
+        $result.OutputPath | Should -Be $script:outputPath
+        $metadata.FileName | Should -Be 'IntunePackage.intunewin'
+        $metadata.SetupFile | Should -Be 'Install-WinGetPackage.ps1'
+        $metadata.UnencryptedSize | Should -BeGreaterThan 0
+        $metadata.FileDigestAlgorithm | Should -Be 'SHA256'
+    }
+
+    It 'Should include the encrypted payload in the package' {
+        $context = New-IntuneWinPackagingContext -PackageMetadata $script:packageMetadata -SourcePath $script:sourceRoot -SetupFile 'Install-WinGetPackage.ps1' -OutputPath $script:outputPath
+        $null = New-IntuneWinPackage -PackagingContext $context
+
+        $extractedPath = Join-Path $script:artifactRoot 'IntunePackage.bin'
+        $result = Expand-IntuneWinPackageEncryptedContent -IntuneWinPath $script:outputPath -FileName 'IntunePackage.intunewin' -DestinationPath $extractedPath
+
+        $result | Should -Not -BeNullOrEmpty
+        $result.Length | Should -BeGreaterThan 0
+    }
+}

--- a/Tests/Private/New-IntuneWinPackage.Tests.ps1
+++ b/Tests/Private/New-IntuneWinPackage.Tests.ps1
@@ -82,4 +82,20 @@ Describe 'New-IntuneWinPackage' {
         $result.OutputPath | Should -Be $script:outputPath
         Test-Path -Path $script:outputPath | Should -BeTrue
     }
+
+    It 'Should support filename-only relative output paths' {
+        Push-Location -Path $script:artifactRoot
+        try {
+            $relativeOutputPath = 'relative-output.intunewin'
+            $context = New-IntuneWinPackagingContext -PackageMetadata $script:packageMetadata -SourcePath $script:sourceRoot -SetupFile 'Install-WinGetPackage.ps1' -OutputPath $relativeOutputPath
+
+            $newPackage = ${function:New-IntuneWinPackage}
+            $result = & $newPackage -PackagingContext $context
+        } finally {
+            Pop-Location
+        }
+
+        $result.OutputPath | Should -Be 'relative-output.intunewin'
+        Test-Path -Path (Join-Path $script:artifactRoot 'relative-output.intunewin') | Should -BeTrue
+    }
 }

--- a/Tests/Private/New-IntuneWinPackage.Tests.ps1
+++ b/Tests/Private/New-IntuneWinPackage.Tests.ps1
@@ -62,4 +62,24 @@ Describe 'New-IntuneWinPackage' {
         $result | Should -Not -BeNullOrEmpty
         $result.Length | Should -BeGreaterThan 0
     }
+
+    It 'Should not fail successful packaging when working directory cleanup fails' {
+        Mock Remove-Item {
+            throw 'locked working directory'
+        } -ParameterFilter { $Path -like (Join-Path $script:artifactRoot '.winget-packaging-*') }
+
+        $context = New-IntuneWinPackagingContext -PackageMetadata $script:packageMetadata -SourcePath $script:sourceRoot -SetupFile 'Install-WinGetPackage.ps1' -OutputPath $script:outputPath
+
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Stop'
+            $newPackage = ${function:New-IntuneWinPackage}
+            $result = & $newPackage -PackagingContext $context
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+
+        $result.OutputPath | Should -Be $script:outputPath
+        Test-Path -Path $script:outputPath | Should -BeTrue
+    }
 }

--- a/Tests/Private/New-IntuneWinPackagingContext.Tests.ps1
+++ b/Tests/Private/New-IntuneWinPackagingContext.Tests.ps1
@@ -1,0 +1,33 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Format-WinGetInstallerSummary.ps1
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinPackagingCapability.ps1
+    . $PSScriptRoot/../../Private/WinGet/New-IntuneWinPackagingContext.ps1
+}
+
+Describe 'New-IntuneWinPackagingContext' {
+    It 'Should infer setup file from selected installer metadata' {
+        $packageMetadata = [PSCustomObject]@{
+            PackageIdentifier = 'Contoso.App'
+            PackageVersion    = '2.0.0'
+            DisplayName       = 'Contoso App'
+            Publisher         = 'Contoso'
+            ManifestSource    = [PSCustomObject]@{
+                Type = 'GitHub'
+            }
+            SelectedInstaller = [PSCustomObject]@{
+                InstallerUrl = 'https://downloads.contoso.test/app-machine.exe'
+            }
+        }
+
+        $result = New-IntuneWinPackagingContext -PackageMetadata $packageMetadata -SourcePath 'TestDrive:/staging'
+
+        $result.PackageFormat | Should -Be 'intunewin'
+        $result.Source | Should -Be 'WinGet'
+        $result.PackageIdentifier | Should -Be 'Contoso.App'
+        $result.SetupFile | Should -Be 'app-machine.exe'
+        $result.PackagingCapability | Should -Not -BeNullOrEmpty
+        $result.PackagingCapability.Capabilities.ZipArchive | Should -BeTrue
+    }
+}

--- a/Tests/Private/New-WinGetOwnershipNotes.Tests.ps1
+++ b/Tests/Private/New-WinGetOwnershipNotes.Tests.ps1
@@ -1,0 +1,51 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/New-WinGetOwnershipNotes.ps1
+}
+
+Describe 'New-WinGetOwnershipNotes' {
+    It 'Should remove duplicate note lines while preserving first-seen order' {
+        $template = [pscustomobject]@{
+            templateId = 'contoso-app'
+            metadata   = [pscustomobject]@{
+                notes        = @(
+                    'Keep first',
+                    'Imported from WinGet',
+                    'Keep first'
+                )
+                placeholders = [pscustomobject]@{
+                    customNotes = @(
+                        'Custom note',
+                        'Imported from WinGet',
+                        'Custom note'
+                    )
+                }
+                markers      = [pscustomobject]@{
+                    source = 'Imported from WinGet'
+                }
+            }
+        }
+        $packageMetadata = [pscustomobject]@{
+            PackageIdentifier = 'Contoso.App'
+            PackageVersion    = '1.0.0'
+            ManifestSource    = [pscustomobject]@{
+                Repository = 'winget-pkgs'
+            }
+            ManifestPath      = 'manifests/c/Contoso/App/1.0.0'
+        }
+
+        $result = New-WinGetOwnershipNotes -Template $template -PackageMetadata $packageMetadata
+
+        $result -split [Environment]::NewLine | Should -Be @(
+            'Keep first',
+            'Imported from WinGet',
+            'Custom note',
+            'WinGetPackageIdentifier: Contoso.App',
+            'WinGetPackageVersion: 1.0.0',
+            'WinGetTemplateId: contoso-app',
+            'WinGetManifestRepository: winget-pkgs',
+            'WinGetManifestPath: manifests/c/Contoso/App/1.0.0'
+        )
+    }
+}

--- a/Tests/Private/Publish-IntuneWin32AppContent.Tests.ps1
+++ b/Tests/Private/Publish-IntuneWin32AppContent.Tests.ps1
@@ -131,4 +131,22 @@ Describe 'Publish-IntuneWin32AppContent' {
             $DesiredState -eq 'azureStorageUriRenewalSuccess'
         }
     }
+
+    It 'Should not fail a successful publish when temporary encrypted content cleanup fails' {
+        Mock Remove-Item {
+            throw 'locked encrypted content'
+        } -ParameterFilter { $Path -eq (Join-Path $script:artifactRoot 'app.bin') }
+
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Stop'
+            $result = Publish-IntuneWin32AppContent -AppId 'app-123' -IntuneWinPath './fake.intunewin' -WorkingDirectory $script:artifactRoot
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+
+        $result.ContentVersionId | Should -Be 'content-version-1'
+        $result.ContentFileId | Should -Be 'file-1'
+        $result.UploadedChunkCount | Should -Be 3
+    }
 }

--- a/Tests/Private/Publish-IntuneWin32AppContent.Tests.ps1
+++ b/Tests/Private/Publish-IntuneWin32AppContent.Tests.ps1
@@ -1,0 +1,134 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWin32RenewedUploadUri.ps1
+    . $PSScriptRoot/../../Private/WinGet/Publish-IntuneWin32AppContent.ps1
+}
+
+Describe 'Publish-IntuneWin32AppContent' {
+    BeforeAll {
+        . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinPackageMetadata.ps1
+        . $PSScriptRoot/../../Private/WinGet/Expand-IntuneWinPackageEncryptedContent.ps1
+        . $PSScriptRoot/../../Private/Graph/Invoke-HydrationGraphRequest.ps1
+        . $PSScriptRoot/../../Private/WinGet/Wait-IntuneWin32ContentState.ps1
+        . $PSScriptRoot/../../Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
+    }
+
+    BeforeEach {
+        $script:artifactRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/Publish-IntuneWin32AppContent'
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:artifactRoot -ItemType Directory -Force
+        'encrypted-content' | Set-Content -Path (Join-Path $script:artifactRoot 'app.bin')
+
+        Mock Get-IntuneWinPackageMetadata {
+            [pscustomobject]@{
+                FileName             = 'app.bin'
+                UnencryptedSize      = 321
+                EncryptionKey        = 'enc'
+                MacKey               = 'mackey'
+                InitializationVector = 'iv'
+                Mac                  = 'mac'
+                ProfileIdentifier    = 'profile'
+                FileDigest           = 'digest'
+                FileDigestAlgorithm  = 'SHA256'
+            }
+        }
+
+        Mock Expand-IntuneWinPackageEncryptedContent {
+            Get-Item -Path (Join-Path $script:artifactRoot 'app.bin')
+        }
+
+        Mock Wait-IntuneWin32ContentState {
+            [pscustomobject]@{
+                uploadState     = $DesiredState
+                azureStorageUri = 'https://storage.example/upload?sig=123'
+            }
+        }
+
+        Mock Send-IntuneWinAzureStorageChunkedUpload {
+            [pscustomobject]@{ ChunkCount = 3 }
+        }
+
+        Mock Invoke-HydrationGraphRequest {
+            switch ($Uri) {
+                'beta/deviceAppManagement/mobileApps/app-123/microsoft.graph.win32LobApp/contentVersions' {
+                    return @{ id = 'content-version-1' }
+                }
+                'beta/deviceAppManagement/mobileApps/app-123/microsoft.graph.win32LobApp/contentVersions/content-version-1/files' {
+                    return @{ id = 'file-1' }
+                }
+                default {
+                    return @{}
+                }
+            }
+        }
+    }
+
+    AfterEach {
+        if (Test-Path -Path $script:artifactRoot) {
+            Remove-Item -Path $script:artifactRoot -Recurse -Force
+        }
+    }
+
+    It 'Should create, upload, commit, and mark committed content' {
+        $result = Publish-IntuneWin32AppContent -AppId 'app-123' -IntuneWinPath './fake.intunewin' -WorkingDirectory $script:artifactRoot
+
+        $result.ContentVersionId | Should -Be 'content-version-1'
+        $result.ContentFileId | Should -Be 'file-1'
+        $result.UploadedChunkCount | Should -Be 3
+
+        Should -Invoke Get-IntuneWinPackageMetadata -Exactly 1
+        Should -Invoke Expand-IntuneWinPackageEncryptedContent -Exactly 1
+        Should -Invoke Wait-IntuneWin32ContentState -Exactly 2
+        Should -Invoke Send-IntuneWinAzureStorageChunkedUpload -Exactly 1
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 1 -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq 'beta/deviceAppManagement/mobileApps/app-123/microsoft.graph.win32LobApp/contentVersions/content-version-1/files/file-1/commit'
+        }
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 1 -ParameterFilter {
+            $Method -eq 'PATCH' -and $Uri -eq 'beta/deviceAppManagement/mobileApps/app-123'
+        }
+    }
+
+    It 'Should wait for SAS renewal success before returning a renewed upload URI' {
+        $script:renewedUploadUri = $null
+
+        Mock Send-IntuneWinAzureStorageChunkedUpload {
+            param(
+                [string]$FilePath,
+                [string]$UploadUri,
+                [scriptblock]$RenewUploadUri
+            )
+
+            $script:renewedUploadUri = & $RenewUploadUri
+            [pscustomobject]@{ ChunkCount = 3 }
+        }
+
+        Mock Wait-IntuneWin32ContentState {
+            if ($DesiredState -eq 'azureStorageUriRenewalSuccess') {
+                return [pscustomobject]@{
+                    uploadState     = 'azureStorageUriRenewalSuccess'
+                    azureStorageUri = 'https://storage.example/renewed?sig=456'
+                }
+            }
+
+            [pscustomobject]@{
+                uploadState     = $DesiredState
+                azureStorageUri = 'https://storage.example/upload?sig=123'
+            }
+        }
+
+        $null = Publish-IntuneWin32AppContent -AppId 'app-123' -IntuneWinPath './fake.intunewin' -WorkingDirectory $script:artifactRoot
+
+        $script:renewedUploadUri | Should -Be 'https://storage.example/renewed?sig=456'
+
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 1 -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq 'beta/deviceAppManagement/mobileApps/app-123/microsoft.graph.win32LobApp/contentVersions/content-version-1/files/file-1/renewUpload'
+        }
+        Should -Invoke Wait-IntuneWin32ContentState -Exactly 1 -ParameterFilter {
+            $DesiredState -eq 'azureStorageUriRenewalSuccess'
+        }
+    }
+}

--- a/Tests/Private/Resolve-WinGetAppIcon.Tests.ps1
+++ b/Tests/Private/Resolve-WinGetAppIcon.Tests.ps1
@@ -1,0 +1,57 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Resolve-WinGetAppIcon.ps1
+    $script:ModuleRoot = Join-Path $PSScriptRoot '..\..'
+}
+
+Describe 'Resolve-WinGetAppIcon' {
+    BeforeEach {
+        $script:testRoot = Join-Path $TestDrive 'winget-icon'
+        $null = New-Item -Path $script:testRoot -ItemType Directory -Force
+    }
+
+    It 'Should resolve an icon from a template-relative file path' {
+        $iconPath = Join-Path $script:testRoot 'icon.png'
+        [System.IO.File]::WriteAllBytes($iconPath, [byte[]](1, 2, 3, 4))
+
+        $template = [pscustomobject]@{
+            templateId        = 'contoso-app'
+            packageIdentifier = 'Contoso.App'
+            displayName       = 'Contoso App'
+            TemplatePath      = Join-Path $script:testRoot 'contoso-app.json'
+            icon              = [pscustomobject]@{
+                sourceType = 'file'
+                fileName   = 'icon.png'
+            }
+        }
+
+        $result = Resolve-WinGetAppIcon -Template $template
+
+        $result.Base64 | Should -Be ([Convert]::ToBase64String([byte[]](1, 2, 3, 4)))
+        $result.MimeType | Should -Be 'image/png'
+        $result.Source | Should -Be $iconPath
+    }
+
+    It 'Should fall back to the bundled module icon when no template file icon can be resolved' {
+        $fallbackIconPath = Join-Path $script:ModuleRoot 'media/IHTLogoClearLight.png'
+        $fallbackBytes = [System.IO.File]::ReadAllBytes($fallbackIconPath)
+
+        $template = [pscustomobject]@{
+            templateId        = 'unavailable-app'
+            packageIdentifier = 'Contoso.Unavailable'
+            displayName       = 'Unavailable App'
+            TemplatePath      = Join-Path $script:testRoot 'unavailable-app.json'
+            icon              = [pscustomobject]@{
+                sourceType = 'file'
+                fileName   = 'missing.png'
+            }
+        }
+
+        $result = Resolve-WinGetAppIcon -Template $template
+
+        $result.Base64 | Should -Be ([Convert]::ToBase64String($fallbackBytes))
+        $result.MimeType | Should -Be 'image/png'
+        $result.Source | Should -Be $fallbackIconPath
+    }
+}

--- a/Tests/Private/Resolve-WinGetAppIcon.Tests.ps1
+++ b/Tests/Private/Resolve-WinGetAppIcon.Tests.ps1
@@ -54,4 +54,24 @@ Describe 'Resolve-WinGetAppIcon' {
         $result.MimeType | Should -Be 'image/png'
         $result.Source | Should -Be $fallbackIconPath
     }
+
+    It 'Should treat no icon as an expected fallback path' {
+        $fallbackIconPath = Join-Path $script:ModuleRoot 'media/IHTLogoClearLight.png'
+        $fallbackBytes = [System.IO.File]::ReadAllBytes($fallbackIconPath)
+
+        $template = [pscustomobject]@{
+            templateId        = 'no-icon-app'
+            packageIdentifier = 'Contoso.NoIcon'
+            displayName       = 'No Icon App'
+            TemplatePath      = Join-Path $script:testRoot 'no-icon-app.json'
+            icon              = [pscustomobject]@{
+                sourceType = 'none'
+            }
+        }
+
+        $result = Resolve-WinGetAppIcon -Template $template
+
+        $result.Base64 | Should -Be ([Convert]::ToBase64String($fallbackBytes))
+        $result.Source | Should -Be $fallbackIconPath
+    }
 }

--- a/Tests/Private/Save-HydrationGeneratedScript.Tests.ps1
+++ b/Tests/Private/Save-HydrationGeneratedScript.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Hydration/Save-HydrationGeneratedScript.ps1
+
+    function Write-HydrationLog {
+        param(
+            [string]$Message,
+            [string]$Level
+        )
+
+        $null = $Message
+        $null = $Level
+    }
+}
+
+Describe 'Save-HydrationGeneratedScript' {
+    BeforeEach {
+        $script:GeneratedScriptsPath = Join-Path -Path $TestDrive -ChildPath 'GeneratedScripts'
+        $script:GeneratedScriptsNoticeWritten = $false
+        $script:HydrationSessionId = 'test-session'
+    }
+
+    AfterEach {
+        $script:GeneratedScriptsPath = $null
+        $script:GeneratedScriptsNoticeWritten = $false
+        $script:HydrationSessionId = $null
+    }
+
+    It 'Should write content to a nested generated script path' {
+        $result = Save-HydrationGeneratedScript -RelativePath 'WinGetApps/contoso/Install.ps1' -Content 'Write-Output "install"'
+
+        $result | Should -Be (Join-Path -Path $script:GeneratedScriptsPath -ChildPath 'WinGetApps/contoso/Install.ps1')
+        $result | Should -Exist
+        Get-Content -Path $result -Raw | Should -Match 'Write-Output "install"'
+    }
+
+    It 'Should copy source files to nested generated script paths' {
+        $sourcePath = Join-Path -Path 'TestDrive:' -ChildPath 'Source.ps1'
+        Set-Content -Path $sourcePath -Value 'Write-Output "source"' -Encoding utf8
+
+        $result = Save-HydrationGeneratedScript -RelativePath 'WinGetApps/contoso/Detection/Detect.ps1' -SourcePath $sourcePath
+
+        $result | Should -Exist
+        Get-Content -Path $result -Raw | Should -Match 'Write-Output "source"'
+    }
+
+    It 'Should throw a clear error when SourcePath is missing' {
+        $missingSourcePath = Join-Path -Path 'TestDrive:' -ChildPath 'Missing.ps1'
+
+        { Save-HydrationGeneratedScript -RelativePath 'WinGetApps/contoso/Install.ps1' -SourcePath $missingSourcePath } |
+            Should -Throw -ExpectedMessage "SourcePath must be an existing file: $missingSourcePath"
+    }
+
+    It 'Should make filesystem writes terminating' {
+        $source = Get-Content -Path "$PSScriptRoot/../../Private/Hydration/Save-HydrationGeneratedScript.ps1" -Raw
+
+        $source | Should -Match 'New-Item[\s\S]+-ErrorAction Stop'
+        $source | Should -Match 'Copy-Item[\s\S]+-ErrorAction Stop'
+        $source | Should -Match 'Set-Content[\s\S]+-ErrorAction Stop'
+    }
+}

--- a/Tests/Private/Save-HydrationGeneratedScript.Tests.ps1
+++ b/Tests/Private/Save-HydrationGeneratedScript.Tests.ps1
@@ -52,6 +52,18 @@ Describe 'Save-HydrationGeneratedScript' {
             Should -Throw -ExpectedMessage "SourcePath must be an existing file: $missingSourcePath"
     }
 
+    It 'Should reject rooted generated script paths' {
+        $rootedPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'Escape.ps1'
+
+        { Save-HydrationGeneratedScript -RelativePath $rootedPath -Content 'Write-Output "escape"' } |
+            Should -Throw -ExpectedMessage 'RelativePath must not be rooted.'
+    }
+
+    It 'Should reject generated script path traversal' {
+        { Save-HydrationGeneratedScript -RelativePath '../Escape.ps1' -Content 'Write-Output "escape"' } |
+            Should -Throw -ExpectedMessage 'RelativePath must stay within the generated scripts directory.'
+    }
+
     It 'Should make filesystem writes terminating' {
         $source = Get-Content -Path "$PSScriptRoot/../../Private/Hydration/Save-HydrationGeneratedScript.ps1" -Raw
 

--- a/Tests/Private/Send-IntuneWinAzureStorageChunkedUpload.Tests.ps1
+++ b/Tests/Private/Send-IntuneWinAzureStorageChunkedUpload.Tests.ps1
@@ -1,0 +1,45 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/WinGet/Get-IntuneWinUploadChunkLength.ps1
+    . $PSScriptRoot/../../Private/WinGet/Invoke-IntuneWinAzureStorageBlockUpload.ps1
+    . $PSScriptRoot/../../Private/WinGet/Send-IntuneWinAzureStorageChunkedUpload.ps1
+}
+
+Describe 'Send-IntuneWinAzureStorageChunkedUpload' {
+    BeforeEach {
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "IntuneWinUpload-$([guid]::NewGuid().ToString('N'))"
+        $null = New-Item -Path $script:testRoot -ItemType Directory -Force
+        $script:testFile = Join-Path $script:testRoot 'payload.bin'
+        [System.IO.File]::WriteAllBytes($script:testFile, [byte[]](1, 2, 3, 4, 5))
+        $script:uploadedBodies = [System.Collections.Generic.List[object]]::new()
+
+        Mock Invoke-IntuneWinAzureStorageBlockUpload {
+            param($Uri, [byte[]]$Body)
+
+            $null = $Uri
+            $script:uploadedBodies.Add($Body)
+            return @{ StatusCode = 201 }
+        }
+
+        Mock Invoke-RestMethod { return @{} }
+    }
+
+    AfterEach {
+        if (Test-Path -Path $script:testRoot) {
+            Remove-Item -Path $script:testRoot -Recurse -Force
+        }
+    }
+
+    It 'Should delegate each chunk to the typed block upload helper' {
+        $result = Send-IntuneWinAzureStorageChunkedUpload -FilePath $script:testFile -UploadUri 'https://storage.example.test/container/blob?sig=test' -ChunkSizeBytes 3
+
+        $result.ChunkCount | Should -Be 2
+        Should -Invoke Invoke-IntuneWinAzureStorageBlockUpload -Exactly 2
+        Should -Invoke Invoke-RestMethod -Exactly 1
+    }
+
+    It 'Should define the block upload body as raw bytes' {
+        (Get-Command Invoke-IntuneWinAzureStorageBlockUpload).Parameters['Body'].ParameterType | Should -Be ([byte[]])
+    }
+}

--- a/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
+++ b/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
@@ -243,6 +243,78 @@ Describe 'Sync-IntuneWinGetProactiveRemediation' {
         $script:patchedRemediationBody.ContainsKey('@odata.type') | Should -Be $false
     }
 
+    It 'Should delete an owned remediation when the current template set has no packages for its scope' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri, $Body)
+
+            switch ($Method) {
+                'GET' {
+                    if ($Uri -like '*User*') {
+                        return @{
+                            value = @(
+                                @{
+                                    id          = 'existing-user'
+                                    displayName = 'WinGet App Updates (User)'
+                                    description = "Imported by Intune Hydration Kit`nImported from WinGet`nWinGetRemediationScope: user`nWinGetPackageFingerprint: STALE"
+                                }
+                            )
+                        }
+                    }
+
+                    return @{
+                        value = @()
+                    }
+                }
+                'POST' {
+                    $script:postedRemediationBodies += $Body
+                    return @{ id = 'created-system' }
+                }
+                'DELETE' {
+                    $script:deletedRemediationUris += $Uri
+                    return @{}
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates
+        } @(
+            [pscustomobject]@{
+                templateId        = 'contoso-machine'
+                packageIdentifier = 'Contoso.Machine'
+                package           = [pscustomobject]@{
+                    match = [pscustomobject]@{
+                        scope = 'machine'
+                    }
+                }
+            }
+        )
+
+        $result.Action | Should -Be @('Created', 'Deleted')
+        $script:deletedRemediationUris | Should -Contain 'beta/deviceManagement/deviceHealthScripts/existing-user'
+    }
+
+    It 'Should mark empty remediation scopes skipped when no owned remediation exists' {
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates
+        } @(
+            [pscustomobject]@{
+                templateId        = 'contoso-machine'
+                packageIdentifier = 'Contoso.Machine'
+                package           = [pscustomobject]@{
+                    match = [pscustomobject]@{
+                        scope = 'machine'
+                    }
+                }
+            }
+        )
+
+        $result.Action | Should -Contain 'Skipped'
+        ($result | Where-Object { $_.Name -eq 'WinGet App Updates (User)' }).Status | Should -Be 'No packages'
+    }
+
     It 'Should delete owned proactive remediations during remove mode' {
         Mock Invoke-HydrationGraphRequest {
             param($Method, $Uri)

--- a/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
+++ b/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
@@ -175,6 +175,27 @@ Describe 'Sync-IntuneWinGetProactiveRemediation' {
         @($script:postedRemediationBodies).Count | Should -Be 0
     }
 
+    It 'Should skip WhatIf mode when proactive remediation availability is missing' {
+        Mock Get-IntuneProactiveRemediationAvailability {
+            [pscustomobject]@{
+                IsAvailable = $false
+                Status      = 'FeatureUnavailable'
+                Message     = 'Device health scripts are not available in this tenant.'
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates -WhatIfEnabled $true
+        } $script:testTemplates
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Skipped'
+        $result[0].Status | Should -Be 'FeatureUnavailable'
+
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 0 -ModuleName IntuneHydrationKit
+    }
+
     It 'Should update an owned remediation when the package fingerprint changes' {
         Mock Invoke-HydrationGraphRequest {
             param($Method, $Uri, $Body)

--- a/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
+++ b/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
@@ -1,0 +1,275 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    Get-Module -Name IntuneHydrationKit | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+    $script:TestModule = Get-Module -Name IntuneHydrationKit | Select-Object -First 1
+}
+
+Describe 'Sync-IntuneWinGetProactiveRemediation' {
+    BeforeEach {
+        InModuleScope IntuneHydrationKit {
+            $script:HydrationMarker = 'Imported by Intune Hydration Kit'
+        }
+        $script:generatedScriptsRoot = Join-Path ([System.IO.Path]::GetTempPath()) "WinGetRemediationScripts-$([guid]::NewGuid().ToString('N'))"
+        InModuleScope IntuneHydrationKit -Parameters @{ GeneratedScriptsPath = $script:generatedScriptsRoot } {
+            param($GeneratedScriptsPath)
+            $script:GeneratedScriptsPath = $GeneratedScriptsPath
+            $script:GeneratedScriptsNoticeWritten = $false
+            $script:HydrationSessionId = 'test-session'
+        }
+
+        $script:testTemplates = @(
+            [pscustomobject]@{
+                templateId        = 'contoso-machine'
+                packageIdentifier = 'Contoso.Machine'
+                package           = [pscustomobject]@{
+                    match = [pscustomobject]@{
+                        scope = 'machine'
+                    }
+                }
+            },
+            [pscustomobject]@{
+                templateId        = 'contoso-user'
+                packageIdentifier = 'Contoso.User'
+                package           = [pscustomobject]@{
+                    match = [pscustomobject]@{
+                        scope = 'user'
+                    }
+                }
+            }
+        )
+
+        Mock Write-HydrationLog { } -ModuleName IntuneHydrationKit
+        Mock Get-IntuneProactiveRemediationAvailability {
+            [pscustomobject]@{
+                IsAvailable = $true
+                Status      = 'Available'
+                Message     = 'Proactive remediations are available.'
+            }
+        } -ModuleName IntuneHydrationKit
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri, $Body)
+
+            switch ($Method) {
+                'GET' {
+                    return @{
+                        value = @()
+                    }
+                }
+                'POST' {
+                    if ($Uri -eq 'beta/deviceManagement/deviceHealthScripts') {
+                        if (-not $script:postedRemediationBodies) {
+                            $script:postedRemediationBodies = @()
+                        }
+
+                        $script:postedRemediationBodies += $Body
+                        return @{ id = "remediation-$($script:postedRemediationBodies.Count)" }
+                    }
+                }
+                'PATCH' {
+                    $script:patchedRemediationUri = $Uri
+                    $script:patchedRemediationBody = $Body
+                    return @{}
+                }
+                'DELETE' {
+                    if (-not $script:deletedRemediationUris) {
+                        $script:deletedRemediationUris = @()
+                    }
+
+                    $script:deletedRemediationUris += $Uri
+                    return @{}
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $script:postedRemediationBodies = @()
+        $script:patchedRemediationUri = $null
+        $script:patchedRemediationBody = $null
+        $script:deletedRemediationUris = @()
+    }
+
+    AfterEach {
+        if (Test-Path -Path $script:generatedScriptsRoot) {
+            Remove-Item -Path $script:generatedScriptsRoot -Recurse -Force
+        }
+
+        InModuleScope IntuneHydrationKit {
+            $script:GeneratedScriptsPath = $null
+            $script:GeneratedScriptsNoticeWritten = $false
+            $script:HydrationSessionId = $null
+        }
+    }
+
+    It 'Should create system and user proactive remediations for the selected templates' {
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates
+        } $script:testTemplates
+
+        $result | Should -HaveCount 2
+        $result.Action | Should -Be @('Created', 'Created')
+
+        $script:postedRemediationBodies | Should -HaveCount 2
+        $script:postedRemediationBodies[0].displayName | Should -Be 'WinGet App Updates (System)'
+        $script:postedRemediationBodies[0].runAsAccount | Should -Be 'system'
+        $script:postedRemediationBodies[0].isGlobalScript | Should -Be $false
+        $script:postedRemediationBodies[0].description | Should -BeLike '*Imported by Intune Hydration Kit*'
+        $script:postedRemediationBodies[0].description | Should -BeLike '*Imported from WinGet*'
+        $script:postedRemediationBodies[1].displayName | Should -Be 'WinGet App Updates (User)'
+        $script:postedRemediationBodies[1].runAsAccount | Should -Be 'user'
+
+        $systemDetection = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($script:postedRemediationBodies[0].detectionScriptContent))
+        $userRemediation = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($script:postedRemediationBodies[1].remediationScriptContent))
+
+        $systemDetection | Should -Match "Contoso\.Machine"
+        $systemDetection | Should -Match "\$scope = 'machine'"
+        $systemDetection | Should -Match 'upgrade --scope \$scope'
+        $userRemediation | Should -Match "Contoso\.User"
+        $userRemediation | Should -Match "\$scope = 'user'"
+        $userRemediation | Should -Match 'upgrade --id "\$packageIdentifier".*--scope \$scope'
+        (Join-Path $script:generatedScriptsRoot 'WinGetRemediations/System/Detect-WinGetAppUpdates.ps1') | Should -Exist
+        (Join-Path $script:generatedScriptsRoot 'WinGetRemediations/User/Remediate-WinGetAppUpdates.ps1') | Should -Exist
+    }
+
+    It 'Should skip when the proactive remediation feature is unavailable' {
+        Mock Get-IntuneProactiveRemediationAvailability {
+            [pscustomobject]@{
+                IsAvailable = $false
+                Status      = 'FeatureUnavailable'
+                Message     = 'Device health scripts are not available in this tenant.'
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates
+        } $script:testTemplates
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Skipped'
+        $result[0].Status | Should -Be 'FeatureUnavailable'
+
+        @($script:postedRemediationBodies).Count | Should -Be 0
+    }
+
+    It 'Should skip when permissions are insufficient' {
+        Mock Get-IntuneProactiveRemediationAvailability {
+            [pscustomobject]@{
+                IsAvailable = $false
+                Status      = 'InsufficientPermissions'
+                Message     = 'Insufficient permissions to access device health scripts.'
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates
+        } $script:testTemplates
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Skipped'
+        $result[0].Status | Should -Be 'InsufficientPermissions'
+
+        @($script:postedRemediationBodies).Count | Should -Be 0
+    }
+
+    It 'Should update an owned remediation when the package fingerprint changes' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri, $Body)
+
+            switch ($Method) {
+                'GET' {
+                    return @{
+                        value = @(
+                            @{
+                                id          = 'existing-system'
+                                displayName = 'WinGet App Updates (System)'
+                                description = "Auto-update remediation for WinGet apps (system scope).`nImported by Intune Hydration Kit`nImported from WinGet`nWinGetRemediationScope: system`nWinGetPackageCount: 1`nWinGetPackageFingerprint: OLDHASH"
+                            }
+                        )
+                    }
+                }
+                'PATCH' {
+                    $script:patchedRemediationUri = $Uri
+                    $script:patchedRemediationBody = $Body
+                    return @{}
+                }
+            }
+        } -ModuleName IntuneHydrationKit -ParameterFilter { $Method -in @('GET', 'PATCH') }
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates
+        } @(
+            [pscustomobject]@{
+                templateId        = 'contoso-machine'
+                packageIdentifier = 'Contoso.Machine'
+                package           = [pscustomobject]@{
+                    match = [pscustomobject]@{
+                        scope = 'machine'
+                    }
+                }
+            }
+        )
+
+        $result[0].Action | Should -Be 'Updated'
+
+        $script:patchedRemediationUri | Should -Be 'beta/deviceManagement/deviceHealthScripts/existing-system'
+        $script:patchedRemediationBody.description | Should -Not -BeLike '*OLDHASH*'
+        $script:patchedRemediationBody.ContainsKey('isGlobalScript') | Should -Be $false
+        $script:patchedRemediationBody.ContainsKey('@odata.type') | Should -Be $false
+    }
+
+    It 'Should delete owned proactive remediations during remove mode' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri)
+
+            switch ($Method) {
+                'GET' {
+                    if ($Uri -like '*System*') {
+                        return @{
+                            value = @(
+                                @{
+                                    id          = 'system-id'
+                                    displayName = 'WinGet App Updates (System)'
+                                    description = "Imported by Intune Hydration Kit`nImported from WinGet`nWinGetRemediationScope: system"
+                                }
+                            )
+                        }
+                    }
+
+                    return @{
+                        value = @(
+                            @{
+                                id          = 'user-id'
+                                displayName = 'WinGet App Updates (User)'
+                                description = "Imported by Intune Hydration Kit`nImported from WinGet`nWinGetRemediationScope: user"
+                            }
+                        )
+                    }
+                }
+                'DELETE' {
+                    if (-not $script:deletedRemediationUris) {
+                        $script:deletedRemediationUris = @()
+                    }
+
+                    $script:deletedRemediationUris += $Uri
+                    return @{}
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates -RemoveExisting
+        } $script:testTemplates
+
+        $result | Should -HaveCount 2
+        $result.Action | Should -Be @('Deleted', 'Deleted')
+
+        $script:deletedRemediationUris | Should -Contain 'beta/deviceManagement/deviceHealthScripts/system-id'
+        $script:deletedRemediationUris | Should -Contain 'beta/deviceManagement/deviceHealthScripts/user-id'
+    }
+}

--- a/Tests/Private/Test-IntuneWinGetAppOwnership.Tests.ps1
+++ b/Tests/Private/Test-IntuneWinGetAppOwnership.Tests.ps1
@@ -1,0 +1,27 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Hydration/Get-HydrationMarkerSet.ps1
+    . $PSScriptRoot/../../Private/Hydration/Test-HydrationKitObject.ps1
+    . $PSScriptRoot/../../Private/WinGet/Test-IntuneWinGetAppOwnership.ps1
+}
+
+Describe 'Test-IntuneWinGetAppOwnership' {
+    It 'Should return true when both hydration and WinGet markers exist' {
+        $result = Test-IntuneWinGetAppOwnership -Description 'Line of business app - Imported by Intune Hydration Kit' -Notes "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+
+        $result | Should -BeTrue
+    }
+
+    It 'Should return false when the hydration marker is missing' {
+        $result = Test-IntuneWinGetAppOwnership -Description 'Manual app' -Notes 'Imported from WinGet'
+
+        $result | Should -BeFalse
+    }
+
+    It 'Should return false when the WinGet marker is missing' {
+        $result = Test-IntuneWinGetAppOwnership -Description 'Manual app - Imported by Intune Hydration Kit' -Notes 'Operational note only'
+
+        $result | Should -BeFalse
+    }
+}

--- a/Tests/Private/Test-IsWinGetTemplateFile.Tests.ps1
+++ b/Tests/Private/Test-IsWinGetTemplateFile.Tests.ps1
@@ -1,0 +1,28 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' 'Private' 'MobileApps' 'Test-IsWinGetTemplateFile.ps1'
+    . $modulePath
+}
+
+Describe 'Test-IsWinGetTemplateFile' {
+    It 'Should return true for a file under WinGet directory' {
+        $testFile = [System.IO.FileInfo]::new('/Templates/MobileApps/Windows/WinGet/Apps/google-chrome.json')
+        Test-IsWinGetTemplateFile -TemplateFile $testFile | Should -Be $true
+    }
+
+    It 'Should return true for a file nested under WinGet' {
+        $testFile = [System.IO.FileInfo]::new('/Templates/MobileApps/Windows/WinGet/Presets/starter-pack.json')
+        Test-IsWinGetTemplateFile -TemplateFile $testFile | Should -Be $true
+    }
+
+    It 'Should return false for a file not under WinGet' {
+        $testFile = [System.IO.FileInfo]::new('/Templates/MobileApps/Windows/Store/CompanyPortal.json')
+        Test-IsWinGetTemplateFile -TemplateFile $testFile | Should -Be $false
+    }
+
+    It 'Should return false for a macOS template file' {
+        $testFile = [System.IO.FileInfo]::new('/Templates/MobileApps/macOS/MicrosoftRemoteDesktop.json')
+        Test-IsWinGetTemplateFile -TemplateFile $testFile | Should -Be $false
+    }
+}

--- a/Tests/Private/Wait-IntuneWin32ContentState.Tests.ps1
+++ b/Tests/Private/Wait-IntuneWin32ContentState.Tests.ps1
@@ -1,0 +1,54 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/Graph/Invoke-HydrationGraphRequest.ps1
+    . $PSScriptRoot/../../Private/WinGet/Wait-IntuneWin32ContentState.ps1
+}
+
+Describe 'Wait-IntuneWin32ContentState' {
+    BeforeEach {
+        Mock Invoke-HydrationGraphRequest {
+            [pscustomobject]@{ uploadState = 'commitFileSuccess' }
+        }
+
+        Mock Start-Sleep {}
+    }
+
+    It 'Should check upload state before sleeping' {
+        $result = Wait-IntuneWin32ContentState -AppId 'app-1' -ContentVersionId 'version-1' -FileId 'file-1' -DesiredState 'commitFileSuccess' -PollIntervalSeconds 5 -TimeoutSeconds 10
+
+        $result.uploadState | Should -Be 'commitFileSuccess'
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 1
+        Should -Invoke Start-Sleep -Exactly 0
+    }
+
+    It 'Should sleep only between unsuccessful polls' {
+        $script:pollCount = 0
+        Mock Invoke-HydrationGraphRequest {
+            $script:pollCount++
+            if ($script:pollCount -eq 1) {
+                return [pscustomobject]@{ uploadState = 'azureStorageUriRequestPending' }
+            }
+
+            [pscustomobject]@{ uploadState = 'azureStorageUriRequestSuccess' }
+        }
+
+        $result = Wait-IntuneWin32ContentState -AppId 'app-1' -ContentVersionId 'version-1' -FileId 'file-1' -DesiredState 'azureStorageUriRequestSuccess' -PollIntervalSeconds 5 -TimeoutSeconds 10
+
+        $result.uploadState | Should -Be 'azureStorageUriRequestSuccess'
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 2
+        Should -Invoke Start-Sleep -Exactly 1 -ParameterFilter { $Seconds -eq 5 }
+    }
+
+    It 'Should cap sleep to the remaining timeout window' {
+        Mock Invoke-HydrationGraphRequest {
+            [pscustomobject]@{ uploadState = 'azureStorageUriRequestPending' }
+        }
+
+        { Wait-IntuneWin32ContentState -AppId 'app-1' -ContentVersionId 'version-1' -FileId 'file-1' -DesiredState 'azureStorageUriRequestSuccess' -PollIntervalSeconds 5 -TimeoutSeconds 2 } |
+            Should -Throw "*Timed out waiting for upload state 'azureStorageUriRequestSuccess' for file 'file-1'*"
+
+        Should -Invoke Invoke-HydrationGraphRequest -Exactly 2
+        Should -Invoke Start-Sleep -Exactly 1 -ParameterFilter { $Seconds -eq 2 }
+    }
+}

--- a/Tests/Public/Import-IntuneWinGetApp.Tests.ps1
+++ b/Tests/Public/Import-IntuneWinGetApp.Tests.ps1
@@ -1,0 +1,876 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $script:batchOperationItems = @()
+    $script:invokeTemplateCallCount = 0
+    $modulePath = Join-Path $PSScriptRoot '..\..\'
+    $script:ModuleManifestPath = Join-Path $modulePath 'IntuneHydrationKit.psd1'
+    Get-Module -Name IntuneHydrationKit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module $script:ModuleManifestPath -Force
+    $script:TestModule = Get-Module -Name IntuneHydrationKit | Select-Object -First 1
+
+    if (-not $script:TestModule) {
+        throw 'Failed to import IntuneHydrationKit module'
+    }
+
+    function New-TestResolvedWinGetPackage {
+        param(
+            [Parameter(Mandatory)]
+            [string]$PackageIdentifier,
+
+            [Parameter(Mandatory)]
+            [string]$PackageVersion,
+
+            [Parameter(Mandatory)]
+            [string]$InstallerUrl,
+
+            [Parameter()]
+            [string]$InstallerType = 'exe'
+        )
+
+        [pscustomobject]@{
+            packageVersion    = $PackageVersion
+            manifestSource    = [pscustomobject]@{
+                repository  = 'microsoft/winget-pkgs'
+                ref         = 'master'
+                packagePath = "manifests/test/$PackageIdentifier"
+                versionPath = "manifests/test/$PackageIdentifier/$PackageVersion"
+            }
+            selectedInstaller = [pscustomobject]@{
+                Architecture  = 'x64'
+                Scope         = 'machine'
+                InstallerType = $InstallerType
+                InstallerUrl  = $InstallerUrl
+            }
+        }
+    }
+}
+
+Describe 'Import-IntuneWinGetApp' {
+    BeforeEach {
+        Get-Module -Name IntuneHydrationKit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+        Import-Module $script:ModuleManifestPath -Force
+        $script:TestModule = Get-Module -Name IntuneHydrationKit | Select-Object -First 1
+
+        $script:workingRoot = Join-Path $PSScriptRoot '../../build/PesterArtifacts/Import-IntuneWinGetApp'
+        $script:generatedScriptsRoot = Join-Path $script:workingRoot 'generated-scripts'
+        if (Test-Path -Path $script:workingRoot) {
+            Remove-Item -Path $script:workingRoot -Recurse -Force
+        }
+
+        $null = New-Item -Path $script:workingRoot -ItemType Directory -Force
+        & $script:TestModule {
+            param($GeneratedScriptsPath)
+            $script:GeneratedScriptsPath = $GeneratedScriptsPath
+            $script:GeneratedScriptsNoticeWritten = $false
+            $script:HydrationSessionId = 'test-session'
+        } $script:generatedScriptsRoot
+        $script:deletedGraphUris = @()
+        Mock Write-HydrationLog { } -ModuleName IntuneHydrationKit
+        Mock Publish-IntuneWin32AppContent {
+            param($AppId)
+
+            [pscustomobject]@{
+                AppId = $AppId
+            }
+        } -ModuleName IntuneHydrationKit
+        Mock Get-HydrationWinGetAppTemplates {
+            @(
+                [pscustomobject]@{
+                    templateId        = 'contoso-app'
+                    packageIdentifier = 'Contoso.App'
+                    displayName       = 'Contoso App'
+                    publisher         = 'Contoso Template Publisher'
+                    description       = 'WinGet packaged Contoso app'
+                    TemplatePath      = 'Templates/MobileApps/Windows/WinGet/Apps/contoso-app.json'
+                    resolvedPackage  = New-TestResolvedWinGetPackage -PackageIdentifier 'Contoso.App' -PackageVersion '2.0.0' -InstallerUrl 'https://downloads.contoso.test/app.exe'
+                    package           = [pscustomobject]@{
+                        match = [pscustomobject]@{
+                            architectures = @('x64')
+                            scope         = 'machine'
+                            locale        = 'en-US'
+                        }
+                    }
+                    install           = [pscustomobject]@{
+                        command         = 'winget install --id Contoso.App --exact --silent --scope machine --accept-package-agreements --accept-source-agreements'
+                        experience      = 'system'
+                        restartBehavior = 'suppress'
+                    }
+                    uninstall         = [pscustomobject]@{
+                        command  = 'winget uninstall --id Contoso.App --exact --silent'
+                        behavior = 'allow'
+                    }
+                    detection         = [pscustomobject]@{
+                        strategy = 'generated'
+                    }
+                    requirements      = [pscustomobject]@{
+                        minimumSupportedWindowsRelease = 'W10_22H2'
+                        architectures                  = @('x64')
+                        minimumFreeDiskSpaceInMB       = 1024
+                        minimumMemoryInMB              = 2048
+                    }
+                    icon              = [pscustomobject]@{
+                        sourceType = 'none'
+                        fileName   = $null
+                    }
+                    metadata          = [pscustomobject]@{
+                        notes        = @('Template note')
+                        placeholders = [pscustomobject]@{
+                            customNotes = @('Tenant note')
+                            owner       = 'Endpoint Engineering'
+                            scopeTagIds = @('1', '2')
+                        }
+                        markers      = [pscustomobject]@{
+                            hydration = 'Imported by Intune Hydration Kit'
+                            source    = 'Imported from WinGet'
+                        }
+                    }
+                }
+            )
+        } -ModuleName IntuneHydrationKit
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri, $Body)
+            $null = $Uri
+            switch ($Method) {
+                'GET' {
+                    return @{ value = @(); '@odata.nextLink' = $null }
+                }
+                'POST' {
+                    $script:capturedCreateBody = $Body
+                    return @{ id = 'app-123' }
+                }
+                'DELETE' {
+                    return @{}
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+        Mock Invoke-GraphBatchOperation { @() } -ModuleName IntuneHydrationKit
+        Mock Sync-IntuneWinGetProactiveRemediation { @() } -ModuleName IntuneHydrationKit
+    }
+
+    AfterEach {
+        if (Test-Path -Path $script:workingRoot) {
+            Remove-Item -Path $script:workingRoot -Recurse -Force
+        }
+        & $script:TestModule {
+            $script:GeneratedScriptsPath = $null
+            $script:GeneratedScriptsNoticeWritten = $false
+            $script:HydrationSessionId = $null
+        }
+        $script:capturedCreateBody = $null
+        $script:deletedGraphUris = @()
+        $script:batchOperationItems = @()
+        $script:invokeTemplateCallCount = 0
+    }
+
+    It 'Should create a WinGet-backed Win32 app with ownership metadata' {
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Created'
+        $result[0].Name | Should -Be 'Contoso App - [IHD]'
+        $script:capturedCreateBody.displayName | Should -Be 'Contoso App - [IHD]'
+        $script:capturedCreateBody.description | Should -BeLike '*Imported by Intune Hydration Kit*'
+        $script:capturedCreateBody.publisher | Should -Be 'Contoso Template Publisher'
+        $script:capturedCreateBody.developer | Should -Be 'Contoso Template Publisher'
+        $script:capturedCreateBody.notes | Should -BeLike '*Imported from WinGet*'
+        $script:capturedCreateBody.notes | Should -BeLike '*WinGetPackageIdentifier: Contoso.App*'
+        $script:capturedCreateBody.appVersion | Should -Be '2.0.0'
+        $script:capturedCreateBody.installCommandLine | Should -Be 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File .\Install-WinGetPackage.ps1'
+        $script:capturedCreateBody.uninstallCommandLine | Should -Be 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File .\Uninstall-WinGetPackage.ps1'
+        $script:capturedCreateBody.allowAvailableUninstall | Should -BeTrue
+        $script:capturedCreateBody.applicableArchitectures | Should -Be 'x64'
+        $script:capturedCreateBody.minimumFreeDiskSpaceInMB | Should -Be 1024
+        $script:capturedCreateBody.minimumMemoryInMB | Should -Be 2048
+        $script:capturedCreateBody.roleScopeTagIds | Should -Be @('1', '2')
+        $script:capturedCreateBody.rules | Should -HaveCount 1
+        $rule = @($script:capturedCreateBody.rules) | Select-Object -First 1
+        $scriptRuleType = if ($rule -is [hashtable]) { $rule['@odata.type'] } else { $rule.'@odata.type' }
+        $scriptRuleContent = if ($rule -is [hashtable]) { $rule['scriptContent'] } else { $rule.scriptContent }
+        $scriptRuleType | Should -Be '#microsoft.graph.win32LobAppPowerShellScriptRule'
+        $decodedScript = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($scriptRuleContent))
+        $decodedScript | Should -Match "\$PackageIdentifier = 'Contoso\.App'"
+        $decodedScript | Should -Match "\$PackageIdentifierPattern = 'Contoso\\\.App'"
+        $decodedScript | Should -Match 'Install-WinGetSystemBootstrap'
+        $decodedScript | Should -Match 'winget list --id "\$PackageIdentifier" --exact --accept-source-agreements'
+        $decodedScript | Should -Not -Match '--source winget'
+        $decodedScript | Should -Match 'Test-InstalledApplicationRegistry'
+        Should -Invoke Publish-IntuneWin32AppContent -Exactly 1 -ModuleName IntuneHydrationKit
+    }
+
+    It 'Should include a large icon when one is resolved for the template' {
+        Mock Resolve-WinGetAppIcon {
+            [pscustomobject]@{
+                Base64   = 'ZmFrZS1pY29u'
+                MimeType = 'image/png'
+                Source   = 'https://icons.contoso.test/contoso.png'
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $script:capturedCreateBody.largeIcon.value | Should -Be 'ZmFrZS1pY29u'
+        $script:capturedCreateBody.largeIcon.type | Should -Be 'image/png'
+    }
+
+    It 'Should generate shared WinGet detection rules and multi-architecture requirements' {
+        $templateRoot = Join-Path $script:workingRoot 'template'
+        $null = New-Item -Path $templateRoot -ItemType Directory -Force
+        $script:everythingTemplatePath = Join-Path $templateRoot 'everything-search.json'
+        '{}' | Set-Content -Path $script:everythingTemplatePath -Encoding utf8
+
+        Mock Get-HydrationWinGetAppTemplates {
+            @(
+                [pscustomobject]@{
+                    templateId        = 'everything-search'
+                    packageIdentifier = 'voidtools.Everything'
+                    displayName       = 'Everything'
+                    publisher         = 'voidtools'
+                    description       = 'WinGet packaged Everything'
+                    TemplatePath      = $script:everythingTemplatePath
+                    resolvedPackage  = New-TestResolvedWinGetPackage -PackageIdentifier 'voidtools.Everything' -PackageVersion '1.4.1.1032' -InstallerUrl 'https://www.voidtools.com/Everything-1.4.1.1032.x64.msi' -InstallerType 'wix'
+                    package           = [pscustomobject]@{
+                        match = [pscustomobject]@{
+                            architectures = @('x64', 'x86', 'arm64')
+                            scope         = 'machine'
+                            locale        = 'en-US'
+                        }
+                    }
+                    install           = [pscustomobject]@{
+                        command         = 'winget install --id voidtools.Everything --exact --silent --scope machine --accept-package-agreements --accept-source-agreements'
+                        experience      = 'system'
+                        restartBehavior = 'suppress'
+                    }
+                    uninstall         = [pscustomobject]@{
+                        command  = 'winget uninstall --id voidtools.Everything --exact --silent'
+                        behavior = 'allow'
+                    }
+                    detection         = [pscustomobject]@{
+                        strategy = 'generated'
+                    }
+                    requirements      = [pscustomobject]@{
+                        minimumSupportedWindowsRelease = 'W10_22H2'
+                        architectures                  = @('x64', 'x86', 'arm64')
+                        minimumFreeDiskSpaceInMB       = $null
+                        minimumMemoryInMB              = $null
+                    }
+                    icon              = [pscustomobject]@{
+                        sourceType = 'none'
+                        fileName   = $null
+                    }
+                    metadata          = [pscustomobject]@{
+                        notes        = @()
+                        placeholders = [pscustomobject]@{
+                            customNotes = @()
+                            owner       = ''
+                            scopeTagIds = @()
+                        }
+                        markers      = [pscustomobject]@{
+                            hydration = 'Imported by Intune Hydration Kit'
+                            source    = 'Imported from WinGet'
+                        }
+                    }
+                }
+            )
+        } -ModuleName IntuneHydrationKit
+
+        $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $script:capturedCreateBody.rules | Should -HaveCount 1
+        $scriptRule = @($script:capturedCreateBody.rules) | Select-Object -First 1
+        $scriptRuleType = if ($scriptRule -is [hashtable]) { $scriptRule['@odata.type'] } else { $scriptRule.'@odata.type' }
+        $scriptRuleContent = if ($scriptRule -is [hashtable]) { $scriptRule['scriptContent'] } else { $scriptRule.scriptContent }
+        $scriptRuleType | Should -Be '#microsoft.graph.win32LobAppPowerShellScriptRule'
+        $decodedScript = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($scriptRuleContent))
+        $decodedScript | Should -Match "\$PackageIdentifier = 'voidtools\.Everything'"
+        $decodedScript | Should -Match "\$PackageIdentifierPattern = 'voidtools\\\.Everything'"
+        $decodedScript | Should -Match 'Install-WinGetSystemBootstrap'
+        $decodedScript | Should -Match 'winget list --id "\$PackageIdentifier" --exact --accept-source-agreements'
+        $decodedScript | Should -Not -Match '--source winget'
+        $decodedScript | Should -Match 'Test-InstalledApplicationRegistry'
+        $script:capturedCreateBody.ContainsKey('applicableArchitectures') | Should -BeFalse
+    }
+
+    It 'Should sync proactive remediations when enabled' {
+        $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemediationEnabled
+
+        Should -Invoke Sync-IntuneWinGetProactiveRemediation -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+            @($Templates).Count -eq 1 -and
+            $WhatIfEnabled -eq $false -and
+            (-not $RemoveExisting)
+        }
+    }
+
+    It 'Should keep generated script detection when the selected installer has a ProductCode' {
+        Mock Publish-IntuneWin32AppContent {
+            [PSCustomObject]@{
+                AppId              = 'msi-app-id'
+                ContentVersionId   = 'version-1'
+                ContentFileId      = 'file-1'
+                PackagePath        = 'C:\staging\7zip.7zip.intunewin'
+                EncryptedSize      = 1024
+                UnencryptedSize    = 2048
+                UploadedChunkCount = 1
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $script:capturedCreateBody.rules | Should -HaveCount 1
+        $scriptRule = @($script:capturedCreateBody.rules) | Select-Object -First 1
+        $scriptRuleType = if ($scriptRule -is [hashtable]) { $scriptRule['@odata.type'] } else { $scriptRule.'@odata.type' }
+        $scriptRuleContent = if ($scriptRule -is [hashtable]) { $scriptRule['scriptContent'] } else { $scriptRule.scriptContent }
+        $scriptRuleType | Should -Be '#microsoft.graph.win32LobAppPowerShellScriptRule'
+        $decodedScript = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($scriptRuleContent))
+        $decodedScript | Should -Match "\$PackageIdentifier = 'Contoso\.App'"
+        $decodedScript | Should -Not -Match ([regex]::Escape('{23170F69-40C1-2702-2490-000001000000}'))
+    }
+
+    It 'Should generate wrapper scripts that log to the IntuneManagementExtension log directory' {
+        $script:capturedInstallScript = $null
+        $script:capturedUninstallScript = $null
+        $script:capturedDetectionScript = $null
+
+        Mock New-IntuneWinPackage {
+            [pscustomobject]@{
+                OutputPath      = Join-Path $script:workingRoot 'contoso-app.intunewin'
+                SetupFile       = 'Install-WinGetPackage.ps1'
+                UnencryptedSize = 1234
+            }
+        } -ModuleName IntuneHydrationKit
+
+        Mock New-IntuneWin32AppPayload {
+            param($ScriptRootPath)
+
+            $script:capturedInstallScript = Get-Content -Path (Join-Path $ScriptRootPath 'Install-WinGetPackage.ps1') -Raw
+            $script:capturedUninstallScript = Get-Content -Path (Join-Path $ScriptRootPath 'Uninstall-WinGetPackage.ps1') -Raw
+            $script:capturedDetectionScript = Get-Content -Path (Join-Path $ScriptRootPath 'Detect-WinGetPackage.ps1') -Raw
+
+            @{
+                displayName = 'Contoso App'
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $parseErrors = $null
+        [System.Management.Automation.Language.Parser]::ParseInput($script:capturedInstallScript, [ref]$null, [ref]$parseErrors) | Out-Null
+        $parseErrors | Should -BeNullOrEmpty
+        [System.Management.Automation.Language.Parser]::ParseInput($script:capturedDetectionScript, [ref]$null, [ref]$parseErrors) | Out-Null
+        $parseErrors | Should -BeNullOrEmpty
+        [System.Management.Automation.Language.Parser]::ParseInput($script:capturedUninstallScript, [ref]$null, [ref]$parseErrors) | Out-Null
+        $parseErrors | Should -BeNullOrEmpty
+        $script:capturedInstallScript | Should -Match 'Microsoft\\IntuneManagementExtension\\Logs'
+        $script:capturedInstallScript | Should -Match "\$operationName = 'Install'"
+        $script:capturedInstallScript | Should -Match "\$packageIdentifier = 'Contoso.App'"
+        $script:capturedInstallScript | Should -Match 'IntuneHydrationKit-WinGet-\$operationName-\$safePackageIdentifier\.log'
+        $script:capturedInstallScript | Should -Match '\-1978335189'
+        $script:capturedInstallScript | Should -Match 'Test-WinGetAlreadyInstalledNoUpgradeOutput'
+        $script:capturedInstallScript | Should -Match 'Found an existing package already installed'
+        $script:capturedInstallScript | Should -Match 'No available upgrade found'
+        $script:capturedInstallScript | Should -Match 'No newer package versions are available'
+        $script:capturedInstallScript | Should -Match "\$operationName -eq 'Install'"
+        $script:capturedInstallScript | Should -Match 'Package already installed \(no upgrade needed\)'
+        $script:capturedInstallScript | Should -Match 'RedirectStandardOutput'
+        $script:capturedInstallScript | Should -Match 'RedirectStandardError'
+        $script:capturedInstallScript | Should -Match 'Microsoft\.DesktopAppInstaller'
+        $script:capturedInstallScript | Should -Match 'Install-WinGetSystemBootstrap'
+        $script:capturedInstallScript | Should -Match 'NT AUTHORITY\\SYSTEM'
+        $script:capturedUninstallScript | Should -Match "\$operationName = 'Uninstall'"
+        $script:capturedUninstallScript | Should -Match "\$packageIdentifier = 'Contoso.App'"
+        $script:capturedUninstallScript | Should -Match "\$operationName -eq 'Install'"
+        $script:capturedDetectionScript | Should -Match "\$PackageIdentifier = 'Contoso\.App'"
+        $script:capturedDetectionScript | Should -Match "\$PackageIdentifierPattern = 'Contoso\\\.App'"
+        $script:capturedDetectionScript | Should -Match "\$DisplayName = 'Contoso App'"
+        $script:capturedDetectionScript | Should -Match "\$Publisher = 'Contoso Template Publisher'"
+        $script:capturedDetectionScript | Should -Match '--exact'
+        $script:capturedDetectionScript | Should -Not -Match '--source winget'
+        $script:capturedDetectionScript | Should -Match 'Test-InstalledApplicationRegistry'
+        $script:capturedDetectionScript | Should -Match 'Install-WinGetSystemBootstrap'
+        $script:capturedDetectionScript | Should -Match 'NT AUTHORITY\\SYSTEM'
+        (Join-Path $script:generatedScriptsRoot 'WinGetApps/contoso-app/Install-WinGetPackage.ps1') | Should -Exist
+        (Join-Path $script:generatedScriptsRoot 'WinGetApps/contoso-app/Uninstall-WinGetPackage.ps1') | Should -Exist
+        (Join-Path $script:generatedScriptsRoot 'WinGetApps/contoso-app/Detection/Detect-WinGetPackage.ps1') | Should -Exist
+    }
+
+    It 'Should skip apps already owned by the WinGet hydration importer' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @(
+                        @{
+                            id          = 'existing-id'
+                            displayName = 'Contoso App - [IHD]'
+                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+                        }
+                    )
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Skipped'
+        $result[0].Name | Should -Be 'Contoso App - [IHD]'
+        Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
+    }
+
+    It 'Should skip WinGet-owned apps with the mobile app suffix' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @(
+                        @{
+                            id          = 'existing-id'
+                            displayName = 'Contoso App - [IHD]'
+                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+                        }
+                    )
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Skipped'
+        $result[0].Name | Should -Be 'Contoso App - [IHD]'
+        Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
+    }
+
+    It 'Should delete proactive remediations with app deletes when enabled' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri)
+            $null = $Uri
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @(
+                        @{
+                            id          = 'existing-id'
+                            displayName = 'Contoso App - [IHD]'
+                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+                        }
+                    )
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemoveExisting -RemediationEnabled
+
+        Should -Invoke Sync-IntuneWinGetProactiveRemediation -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+            $RemoveExisting -and
+            $WhatIfEnabled -eq $false
+        }
+    }
+
+    It 'Should only delete template-scoped WinGet-owned apps' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @(
+                        @{
+                            id          = 'delete-me'
+                            displayName = 'Contoso App - [IHD]'
+                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+                        },
+                        @{
+                            id          = 'leave-me'
+                            displayName = 'Other App - [IHD]'
+                            description = 'Other app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Other.App"
+                        }
+                    )
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+        Mock Invoke-GraphBatchOperation {
+            $script:batchOperationItems = @($Items)
+            @(
+                [pscustomobject]@{
+                    Name   = 'Contoso App - [IHD]'
+                    Type   = 'WinGetWin32App'
+                    Action = 'Deleted'
+                    Status = 'Success'
+                    Id     = 'delete-me'
+                }
+            )
+        } -ModuleName IntuneHydrationKit
+
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemoveExisting
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Deleted'
+        $script:batchOperationItems | Should -HaveCount 1
+        $script:batchOperationItems[0].Id | Should -Be 'delete-me'
+    }
+
+    It 'Should delete WinGet-owned apps with the mobile app suffix' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @(
+                        @{
+                            id          = 'delete-me'
+                            displayName = 'Contoso App - [IHD]'
+                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+                        }
+                    )
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+        Mock Invoke-GraphBatchOperation {
+            $script:batchOperationItems = @($Items)
+            @(
+                [pscustomobject]@{
+                    Name   = 'Contoso App - [IHD]'
+                    Type   = 'WinGetWin32App'
+                    Action = 'Deleted'
+                    Status = 'Success'
+                    Id     = 'delete-me'
+                }
+            )
+        } -ModuleName IntuneHydrationKit
+
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemoveExisting
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Deleted'
+        $result[0].Name | Should -Be 'Contoso App - [IHD]'
+        $script:batchOperationItems | Should -HaveCount 1
+        $script:batchOperationItems[0].Id | Should -Be 'delete-me'
+    }
+
+    It 'Should return dry-run delete results without calling the batch deleter' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @(
+                        @{
+                            id          = 'delete-me'
+                            displayName = 'Contoso App - [IHD]'
+                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
+                        }
+                    )
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemoveExisting -WhatIf
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'WouldDelete'
+        $result[0].Status | Should -Be 'DryRun'
+        Should -Not -Invoke Invoke-GraphBatchOperation -ModuleName IntuneHydrationKit
+    }
+
+    It 'Should clean up the created app when content publishing fails' {
+        Mock Publish-IntuneWin32AppContent {
+            throw 'Upload failed'
+        } -ModuleName IntuneHydrationKit
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri, $Body)
+
+            if ($Method -eq 'GET') {
+                return @{ value = @(); '@odata.nextLink' = $null }
+            }
+
+            if ($Method -eq 'POST') {
+                $script:capturedCreateBody = $Body
+                return @{ id = 'app-123' }
+            }
+
+            if ($Method -eq 'DELETE') {
+                $script:deletedGraphUris += $Uri
+                return @{}
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Failed'
+        $result[0].Status | Should -BeLike '*Upload failed*'
+        $script:deletedGraphUris | Should -Contain 'beta/deviceAppManagement/mobileApps/app-123'
+        Should -Invoke Publish-IntuneWin32AppContent -Exactly 1 -ModuleName IntuneHydrationKit
+    }
+
+    It 'Should return dry-run results without packaging when WhatIf is used' {
+        $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -WhatIf
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'WouldCreate'
+        $result[0].Status | Should -Be 'DryRun'
+        Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
+    }
+
+    Context 'packageIdentifier validation' {
+        It 'Should skip template with missing packageIdentifier and return Failed result' {
+            Mock Get-HydrationWinGetAppTemplates {
+                @(
+                    [pscustomobject]@{
+                        templateId   = 'bad-template'
+                        displayName  = 'Bad App'
+                        publisher    = 'Bad Publisher'
+                        description  = 'Bad app description'
+                        TemplatePath = 'Templates/MobileApps/Windows/WinGet/Apps/bad-template.json'
+                        package      = [pscustomobject]@{
+                            match = [pscustomobject]@{
+                                architectures = @('x64')
+                                scope         = 'machine'
+                            }
+                        }
+                        install      = [pscustomobject]@{
+                            command         = 'winget install --id Bad.App --exact --silent --scope machine'
+                            experience      = 'system'
+                            restartBehavior = 'suppress'
+                        }
+                        uninstall    = [pscustomobject]@{
+                            command  = 'winget uninstall --id Bad.App --exact --silent'
+                            behavior = 'allow'
+                        }
+                        detection    = [pscustomobject]@{
+                            strategy = 'generated'
+                        }
+                        requirements = [pscustomobject]@{
+                            minimumSupportedWindowsRelease = 'W10_22H2'
+                            architectures                  = @('x64')
+                        }
+                        icon         = [pscustomobject]@{
+                            sourceType = 'none'
+                        }
+                        metadata     = [pscustomobject]@{
+                            notes        = @()
+                            placeholders = [pscustomobject]@{
+                                customNotes = @()
+                                owner       = ''
+                                scopeTagIds = @()
+                            }
+                            markers      = [pscustomobject]@{
+                                hydration = 'Imported by Intune Hydration Kit'
+                                source    = 'Imported from WinGet'
+                            }
+                        }
+                    }
+                )
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -TemplateId 'bad-template'
+
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Failed'
+            $result[0].Status | Should -BeLike '*Missing or blank packageIdentifier*'
+            Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should skip template with blank packageIdentifier and return Failed result' {
+            Mock Get-HydrationWinGetAppTemplates {
+                @(
+                    [pscustomobject]@{
+                        templateId        = 'blank-template'
+                        packageIdentifier = ''
+                        displayName       = 'Blank App'
+                        publisher         = 'Blank Publisher'
+                        description       = 'Blank app description'
+                        TemplatePath      = 'Templates/MobileApps/Windows/WinGet/Apps/blank-template.json'
+                        package           = [pscustomobject]@{
+                            match = [pscustomobject]@{
+                                architectures = @('x64')
+                                scope         = 'machine'
+                            }
+                        }
+                        install           = [pscustomobject]@{
+                            command         = 'winget install --id Blank.App --exact --silent --scope machine'
+                            experience      = 'system'
+                            restartBehavior = 'suppress'
+                        }
+                        uninstall         = [pscustomobject]@{
+                            command  = 'winget uninstall --id Blank.App --exact --silent'
+                            behavior = 'allow'
+                        }
+                        detection         = [pscustomobject]@{
+                            strategy = 'generated'
+                        }
+                        requirements      = [pscustomobject]@{
+                            minimumSupportedWindowsRelease = 'W10_22H2'
+                            architectures                  = @('x64')
+                        }
+                        icon              = [pscustomobject]@{
+                            sourceType = 'none'
+                        }
+                        metadata          = [pscustomobject]@{
+                            notes        = @()
+                            placeholders = [pscustomobject]@{
+                                customNotes = @()
+                                owner       = ''
+                                scopeTagIds = @()
+                            }
+                            markers      = [pscustomobject]@{
+                                hydration = 'Imported by Intune Hydration Kit'
+                                source    = 'Imported from WinGet'
+                            }
+                        }
+                    }
+                )
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -TemplateId 'blank-template'
+
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Failed'
+            $result[0].Status | Should -BeLike '*Missing or blank packageIdentifier*'
+            Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should skip template with whitespace-only packageIdentifier and return Failed result' {
+            Mock Get-HydrationWinGetAppTemplates {
+                @(
+                    [pscustomobject]@{
+                        templateId        = 'space-template'
+                        packageIdentifier = '   '
+                        displayName       = 'Space App'
+                        publisher         = 'Space Publisher'
+                        description       = 'Space app description'
+                        TemplatePath      = 'Templates/MobileApps/Windows/WinGet/Apps/space-template.json'
+                        package           = [pscustomobject]@{
+                            match = [pscustomobject]@{
+                                architectures = @('x64')
+                                scope         = 'machine'
+                            }
+                        }
+                        install           = [pscustomobject]@{
+                            command         = 'winget install --id Space.App --exact --silent --scope machine'
+                            experience      = 'system'
+                            restartBehavior = 'suppress'
+                        }
+                        uninstall         = [pscustomobject]@{
+                            command  = 'winget uninstall --id Space.App --exact --silent'
+                            behavior = 'allow'
+                        }
+                        detection         = [pscustomobject]@{
+                            strategy = 'generated'
+                        }
+                        requirements      = [pscustomobject]@{
+                            minimumSupportedWindowsRelease = 'W10_22H2'
+                            architectures                  = @('x64')
+                        }
+                        icon              = [pscustomobject]@{
+                            sourceType = 'none'
+                        }
+                        metadata          = [pscustomobject]@{
+                            notes        = @()
+                            placeholders = [pscustomobject]@{
+                                customNotes = @()
+                                owner       = ''
+                                scopeTagIds = @()
+                            }
+                            markers      = [pscustomobject]@{
+                                hydration = 'Imported by Intune Hydration Kit'
+                                source    = 'Imported from WinGet'
+                            }
+                        }
+                    }
+                )
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -TemplateId 'space-template'
+
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Failed'
+            $result[0].Status | Should -BeLike '*Missing or blank packageIdentifier*'
+            Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should process template with valid packageIdentifier normally' {
+            Mock Get-HydrationWinGetAppTemplates {
+                @(
+                    [pscustomobject]@{
+                        templateId        = 'valid-template'
+                        packageIdentifier = 'Valid.App'
+                        displayName       = 'Valid App'
+                        publisher         = 'Valid Publisher'
+                        description       = 'Valid app description'
+                        TemplatePath      = 'Templates/MobileApps/Windows/WinGet/Apps/valid-template.json'
+                        resolvedPackage  = New-TestResolvedWinGetPackage -PackageIdentifier 'Valid.App' -PackageVersion '1.0.0' -InstallerUrl 'https://downloads.valid.test/app.exe'
+                        package           = [pscustomobject]@{
+                            match = [pscustomobject]@{
+                                architectures = @('x64')
+                                scope         = 'machine'
+                                locale        = 'en-US'
+                            }
+                        }
+                        install           = [pscustomobject]@{
+                            command         = 'winget install --id Valid.App --exact --silent --scope machine --accept-package-agreements --accept-source-agreements'
+                            experience      = 'system'
+                            restartBehavior = 'suppress'
+                        }
+                        uninstall         = [pscustomobject]@{
+                            command  = 'winget uninstall --id Valid.App --exact --silent'
+                            behavior = 'allow'
+                        }
+                        detection         = [pscustomobject]@{
+                            strategy = 'generated'
+                        }
+                        requirements      = [pscustomobject]@{
+                            minimumSupportedWindowsRelease = 'W10_22H2'
+                            architectures                  = @('x64')
+                            minimumFreeDiskSpaceInMB       = 1024
+                            minimumMemoryInMB              = 2048
+                        }
+                        icon              = [pscustomobject]@{
+                            sourceType = 'none'
+                            fileName   = $null
+                        }
+                        metadata          = [pscustomobject]@{
+                            notes        = @('Template note')
+                            placeholders = [pscustomobject]@{
+                                customNotes = @('Tenant note')
+                                owner       = 'Endpoint Engineering'
+                                scopeTagIds = @('1', '2')
+                            }
+                            markers      = [pscustomobject]@{
+                                hydration = 'Imported by Intune Hydration Kit'
+                                source    = 'Imported from WinGet'
+                            }
+                        }
+                    }
+                )
+            } -ModuleName IntuneHydrationKit
+            Mock Invoke-IntuneWinGetAppTemplate {
+                $script:invokeTemplateCallCount += 1
+                [pscustomobject]@{
+                    Name   = 'Valid App - [IHD]'
+                    Id     = 'app-456'
+                    Path   = 'Templates/MobileApps/Windows/WinGet/Apps/valid-template.json'
+                    Type   = 'WinGetWin32App'
+                    Action = 'Created'
+                    Status = '1.0.0'
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -TemplateId 'valid-template'
+
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Created'
+            $result[0].Name | Should -Be 'Valid App - [IHD]'
+            $script:invokeTemplateCallCount | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add the WinGet-backed Win32 app import command and supporting packaging/upload helpers.
- Add ownership tagging, safe delete handling, generated wrapper scripts, detection/requirement rule mapping, icon fallback, and optional proactive remediation sync.
- Export Import-IntuneWinGetApp from the module.

## Scope
This is PR 2 in the split from closed PR #22. It intentionally includes the import engine and focused tests only. Bundled WinGet app templates, icons, docs, workflows, and settings integration are left for follow-up PRs.

## Validation
- pwsh -NoLogo -NoProfile -File ./build.ps1 -Task Analyze: passed, 0 errors, 173 warnings.
- Invoke-Pester -Path ./Tests -Output Detailed: passed, 834 tests.
- Focused WinGet Pester set: passed, 55 tests.
- git diff --check: passed.
- Import-Module ./IntuneHydrationKit.psd1 -Force; Get-Command Import-IntuneWinGetApp: passed.