### PR TITLE
Wire WinGet mobile app settings

### DIFF
--- a/Private/Configuration/Resolve-HydrationExecutionSettings.ps1
+++ b/Private/Configuration/Resolve-HydrationExecutionSettings.ps1
@@ -157,6 +157,13 @@ function Resolve-HydrationExecutionSettings {
             verbose = $VerboseOutput.IsPresent
         }
         imports        = $importsEnabled
+        mobileApps     = @{
+            presetId    = $null
+            templateIds = @()
+            remediation = @{
+                enabled = $true
+            }
+        }
         reporting      = @{
             outputPath = if ($ReportOutputPath) { $ReportOutputPath } else { $null }
             formats    = if ($ReportFormats) { $ReportFormats } else { @('markdown') }

--- a/Private/MobileApps/Get-WindowsLegacyMobileAppTemplateId.ps1
+++ b/Private/MobileApps/Get-WindowsLegacyMobileAppTemplateId.ps1
@@ -1,0 +1,14 @@
+function Get-WindowsLegacyMobileAppTemplateId {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+
+    return @(
+        'AdobeAcrobatReaderDC',
+        'CompanyPortal',
+        'PowerShell',
+        'SpotifyMusicAndPodcasts',
+        'WhatsApp',
+        'M365Apps'
+    )
+}

--- a/Public/Imports/Import-IntuneMobileApp.ps1
+++ b/Public/Imports/Import-IntuneMobileApp.ps1
@@ -12,6 +12,8 @@ function Import-IntuneMobileApp {
         Filter templates by platform. Valid values: Windows, macOS, All.
         Defaults to 'All' which imports all mobile app templates regardless of platform.
         Note: Mobile app templates are organized by Windows and macOS directories.
+    .PARAMETER TemplateId
+        Optional mobile app template file names to include, without the .json extension.
     .EXAMPLE
         Import-IntuneMobileApp
     .EXAMPLE
@@ -27,6 +29,9 @@ function Import-IntuneMobileApp {
         [Parameter()]
         [ValidateSet('Windows', 'macOS', 'All')]
         [string[]]$Platform = @('All'),
+
+        [Parameter()]
+        [string[]]$TemplateId,
 
         [Parameter()]
         [switch]$RemoveExisting
@@ -45,6 +50,25 @@ function Import-IntuneMobileApp {
         Get-FilteredTemplates -Path $TemplatePath -Platform $Platform -FilterMode 'Directory' -Recurse -ResourceType "mobile app template" |
             Where-Object { -not (Test-IsWinGetTemplateFile -TemplateFile $_) }
     )
+
+    if ($TemplateId) {
+        $requestedTemplateIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($currentTemplateId in @($TemplateId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })) {
+            $trimmedTemplateId = ([string]$currentTemplateId).Trim()
+            [void]$requestedTemplateIds.Add($trimmedTemplateId)
+            [void]$requestedTemplateIds.Add(($trimmedTemplateId -replace '[^a-zA-Z0-9]', ''))
+        }
+
+        if ($requestedTemplateIds.Count -gt 0) {
+            $templateFiles = @(
+                $templateFiles |
+                    Where-Object {
+                        $requestedTemplateIds.Contains($_.BaseName) -or
+                        $requestedTemplateIds.Contains(($_.BaseName -replace '[^a-zA-Z0-9]', ''))
+                    }
+            )
+        }
+    }
 
     if (-not $templateFiles -or $templateFiles.Count -eq 0) {
         Write-Warning "No mobile app templates found in: $TemplatePath"

--- a/Public/Imports/Import-IntuneMobileApp.ps1
+++ b/Public/Imports/Import-IntuneMobileApp.ps1
@@ -51,13 +51,17 @@ function Import-IntuneMobileApp {
             Where-Object { -not (Test-IsWinGetTemplateFile -TemplateFile $_) }
     )
 
+    $requestedTemplateIdDisplay = $null
     if ($TemplateId) {
         $requestedTemplateIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $requestedTemplateIdValues = [System.Collections.Generic.List[string]]::new()
         foreach ($currentTemplateId in @($TemplateId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })) {
             $trimmedTemplateId = ([string]$currentTemplateId).Trim()
+            $requestedTemplateIdValues.Add($trimmedTemplateId)
             [void]$requestedTemplateIds.Add($trimmedTemplateId)
             [void]$requestedTemplateIds.Add(($trimmedTemplateId -replace '[^a-zA-Z0-9]', ''))
         }
+        $requestedTemplateIdDisplay = $requestedTemplateIdValues -join ', '
 
         if ($requestedTemplateIds.Count -gt 0) {
             $templateFiles = @(
@@ -71,6 +75,11 @@ function Import-IntuneMobileApp {
     }
 
     if (-not $templateFiles -or $templateFiles.Count -eq 0) {
+        if (-not [string]::IsNullOrWhiteSpace($requestedTemplateIdDisplay)) {
+            Write-Warning "No mobile app templates matched TemplateId value(s): $requestedTemplateIdDisplay"
+            return @()
+        }
+
         Write-Warning "No mobile app templates found in: $TemplatePath"
         return @()
     }

--- a/Public/Orchestration/Invoke-IntuneHydration.ps1
+++ b/Public/Orchestration/Invoke-IntuneHydration.ps1
@@ -596,14 +596,7 @@ function Invoke-IntuneHydration {
             if ($includeWindowsMobileApps) {
                 $windowsFallbackMobileAppParams = @{
                     Platform       = @('Windows')
-                    TemplateId     = @(
-                        'AdobeAcrobatReaderDC',
-                        'CompanyPortal',
-                        'PowerShell',
-                        'SpotifyMusicAndPodcasts',
-                        'WhatsApp',
-                        'M365Apps'
-                    )
+                    TemplateId     = Get-WindowsLegacyMobileAppTemplateId
                     RemoveExisting = $RemoveExisting
                     WhatIf         = $effectiveWhatIfEnabled
                     Verbose        = $effectiveVerboseEnabled

--- a/Public/Orchestration/Invoke-IntuneHydration.ps1
+++ b/Public/Orchestration/Invoke-IntuneHydration.ps1
@@ -557,14 +557,60 @@ function Invoke-IntuneHydration {
             }
             Write-HydrationLog @logParams
 
-            $mobileAppParams = @{
-                Platform       = $platformFilters.MobileApps
-                RemoveExisting = $RemoveExisting
-                WhatIf         = $effectiveWhatIfEnabled
-                Verbose        = $effectiveVerboseEnabled
+            $mobileAppConfiguration = Get-MobileAppImportConfiguration -Settings $settings
+            $mobileAppPlatforms = @($platformFilters.MobileApps)
+            $includeWindowsMobileApps = $mobileAppPlatforms -contains 'All' -or $mobileAppPlatforms -contains 'Windows'
+            $includeMacOSMobileApps = $mobileAppPlatforms -contains 'All' -or $mobileAppPlatforms -contains 'macOS'
+
+            if ($includeWindowsMobileApps) {
+                $winGetAppParams = @{
+                    RemoveExisting     = $RemoveExisting
+                    RemediationEnabled = $mobileAppConfiguration.remediationEnabled
+                    WhatIf             = $effectiveWhatIfEnabled
+                    Verbose            = $effectiveVerboseEnabled
+                }
+
+                if ($mobileAppConfiguration.presetId) {
+                    $winGetAppParams['PresetId'] = $mobileAppConfiguration.presetId
+                }
+
+                if ($mobileAppConfiguration.templateIds.Count -gt 0) {
+                    $winGetAppParams['TemplateId'] = $mobileAppConfiguration.templateIds
+                }
+
+                $winGetAppResults = @((Import-IntuneWinGetApp @winGetAppParams) | Where-Object { $null -ne $_ })
+                $allResults += $winGetAppResults
             }
-            $mobileAppResults = @((Import-IntuneMobileApp @mobileAppParams) | Where-Object { $null -ne $_ })
-            $allResults += $mobileAppResults
+
+            if ($includeMacOSMobileApps) {
+                $macOSMobileAppParams = @{
+                    Platform       = @('macOS')
+                    RemoveExisting = $RemoveExisting
+                    WhatIf         = $effectiveWhatIfEnabled
+                    Verbose        = $effectiveVerboseEnabled
+                }
+                $macOSMobileAppResults = @((Import-IntuneMobileApp @macOSMobileAppParams) | Where-Object { $null -ne $_ })
+                $allResults += $macOSMobileAppResults
+            }
+
+            if ($includeWindowsMobileApps) {
+                $windowsFallbackMobileAppParams = @{
+                    Platform       = @('Windows')
+                    TemplateId     = @(
+                        'AdobeAcrobatReaderDC',
+                        'CompanyPortal',
+                        'PowerShell',
+                        'SpotifyMusicAndPodcasts',
+                        'WhatsApp',
+                        'M365Apps'
+                    )
+                    RemoveExisting = $RemoveExisting
+                    WhatIf         = $effectiveWhatIfEnabled
+                    Verbose        = $effectiveVerboseEnabled
+                }
+                $windowsFallbackMobileAppResults = @((Import-IntuneMobileApp @windowsFallbackMobileAppParams) | Where-Object { $null -ne $_ })
+                $allResults += $windowsFallbackMobileAppResults
+            }
         }
 
         $summaryParams = @{

--- a/Tests/Private/Get-WindowsLegacyMobileAppTemplateId.Tests.ps1
+++ b/Tests/Private/Get-WindowsLegacyMobileAppTemplateId.Tests.ps1
@@ -1,0 +1,18 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../Private/MobileApps/Get-WindowsLegacyMobileAppTemplateId.ps1
+}
+
+Describe 'Get-WindowsLegacyMobileAppTemplateId' {
+    It 'Should return the Windows legacy fallback mobile app template IDs' {
+        Get-WindowsLegacyMobileAppTemplateId | Should -Be @(
+            'AdobeAcrobatReaderDC',
+            'CompanyPortal',
+            'PowerShell',
+            'SpotifyMusicAndPodcasts',
+            'WhatsApp',
+            'M365Apps'
+        )
+    }
+}

--- a/Tests/Public/Import-HydrationSettings.Tests.ps1
+++ b/Tests/Public/Import-HydrationSettings.Tests.ps1
@@ -155,8 +155,69 @@ Describe 'Import-HydrationSettings' {
             $result.options.dryRun | Should -Be $false
             $result.imports.mobileApps | Should -Be $true
             $result.imports.cisBaselines | Should -Be $false
+            $result.mobileApps.presetId | Should -Be $null
+            $result.mobileApps.templateIds | Should -Be @()
+            $result.mobileApps.remediation.enabled | Should -Be $true
             $result.platforms | Should -Be @('All')
             $result.reporting.formats | Should -Be @('markdown')
+        }
+
+        It 'Should preserve mobile app settings overrides' {
+            $settingsContent = @{
+                tenant         = @{
+                    tenantId = '12345678-1234-1234-1234-123456789abc'
+                }
+                authentication = @{
+                    mode = 'interactive'
+                }
+                options        = @{
+                    create = $true
+                }
+                imports        = @{
+                    mobileApps = $true
+                }
+                mobileApps     = @{
+                    presetId    = 'mobile-apps'
+                    templateIds = @('google-chrome', 'visual-studio-code')
+                    remediation = @{
+                        enabled = $false
+                    }
+                }
+            }
+
+            $settingsPath = Join-Path $script:TestTempDir 'winget-settings.json'
+            $settingsContent | ConvertTo-Json -Depth 10 | Set-Content -Path $settingsPath
+
+            $result = Import-HydrationSettings -Path $settingsPath
+
+            $result.mobileApps.presetId | Should -Be 'mobile-apps'
+            $result.mobileApps.templateIds | Should -Be @('google-chrome', 'visual-studio-code')
+            $result.mobileApps.remediation.enabled | Should -Be $false
+        }
+
+        It 'Should throw when mobile app templateIds is not an array' {
+            $settingsContent = @{
+                tenant         = @{
+                    tenantId = '12345678-1234-1234-1234-123456789abc'
+                }
+                authentication = @{
+                    mode = 'interactive'
+                }
+                options        = @{
+                    create = $true
+                }
+                imports        = @{
+                    mobileApps = $true
+                }
+                mobileApps     = @{
+                    templateIds = 'google-chrome'
+                }
+            }
+
+            $settingsPath = Join-Path $script:TestTempDir 'winget-templateids-string.json'
+            $settingsContent | ConvertTo-Json -Depth 10 | Set-Content -Path $settingsPath
+
+            { Import-HydrationSettings -Path $settingsPath } | Should -Throw '*root.mobileApps.templateIds*must be an array*'
         }
 
         It 'Should throw when a required top-level section is missing' {

--- a/Tests/Public/Import-IntuneMobileApp.Tests.ps1
+++ b/Tests/Public/Import-IntuneMobileApp.Tests.ps1
@@ -93,6 +93,26 @@ Describe 'Import-IntuneMobileApp' {
                 Remove-Item -Path $emptyDir -Force -ErrorAction SilentlyContinue
             }
         }
+
+        It 'Should warn when no mobile app templates match requested template IDs' {
+            $tempDir = New-TestTemplateDirectory -Templates @(
+                @{
+                    '@odata.type' = '#microsoft.graph.winGetApp'
+                    displayName   = 'Existing App'
+                    publisher     = 'Test Publisher'
+                }
+            )
+
+            try {
+                $warnings = @()
+                $result = Import-IntuneMobileApp -TemplatePath $tempDir -TemplateId 'DoesNotExist' -WarningVariable warnings -WarningAction SilentlyContinue
+
+                $result | Should -BeNullOrEmpty
+                $warnings[0].Message | Should -Be 'No mobile app templates matched TemplateId value(s): DoesNotExist'
+            } finally {
+                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
     }
 
     Context 'App Creation' {

--- a/Tests/Public/Import-IntuneMobileApp.Tests.ps1
+++ b/Tests/Public/Import-IntuneMobileApp.Tests.ps1
@@ -202,6 +202,48 @@ Describe 'Import-IntuneMobileApp' {
             }
         }
 
+        It 'Should filter legacy mobile app templates by template ID' {
+            $script:capturedBatchBody = $null
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body)
+                if ($Method -eq 'GET') {
+                    return @{ value = @(); '@odata.nextLink' = $null }
+                }
+                if ($Method -eq 'POST' -and $Uri -like '*$batch*') {
+                    $script:capturedBatchBody = $Body | ConvertFrom-Json
+                    return @{
+                        responses = @(
+                            @{ id = '1'; status = 201; body = @{ id = 'spotify-app-id' } }
+                        )
+                    }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $tempDir = New-TestTemplateDirectory -Templates @(
+                @{
+                    '@odata.type' = '#microsoft.graph.winGetApp'
+                    displayName   = 'Spotify Music and Podcasts'
+                    publisher     = 'Spotify'
+                },
+                @{
+                    '@odata.type' = '#microsoft.graph.winGetApp'
+                    displayName   = 'Other App'
+                    publisher     = 'Other'
+                }
+            )
+
+            try {
+                $result = Import-IntuneMobileApp -TemplatePath $tempDir -TemplateId 'SpotifyMusicAndPodcasts'
+
+                $result | Should -HaveCount 1
+                $result[0].Name | Should -Be '[IHD] Spotify Music and Podcasts'
+                $script:capturedBatchBody.requests | Should -HaveCount 1
+                $script:capturedBatchBody.requests[0].body.displayName | Should -Be '[IHD] Spotify Music and Podcasts'
+            } finally {
+                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
         It 'Should skip apps that already exist with hydration kit tag' {
             # Mock existing app with hydration kit tag
             Mock Invoke-MgGraphRequest {

--- a/Tests/Public/Invoke-IntuneHydration.Tests.ps1
+++ b/Tests/Public/Invoke-IntuneHydration.Tests.ps1
@@ -311,6 +311,8 @@ Describe 'Invoke-IntuneHydration' {
             Mock Import-IntuneAppProtectionPolicy -ModuleName IntuneHydrationKit
             Mock Import-IntuneEnrollmentProfile -ModuleName IntuneHydrationKit
             Mock Import-IntuneConditionalAccessPolicy -ModuleName IntuneHydrationKit
+            Mock Import-IntuneMobileApp { @() } -ModuleName IntuneHydrationKit
+            Mock Import-IntuneWinGetApp { @() } -ModuleName IntuneHydrationKit
             Mock New-IntuneDynamicGroup -ModuleName IntuneHydrationKit
             Mock Get-ChildItem { @() } -ModuleName IntuneHydrationKit
 
@@ -618,6 +620,7 @@ Describe 'Invoke-IntuneHydration' {
             Mock Import-IntuneEnrollmentProfile { @() } -ModuleName IntuneHydrationKit
             Mock Import-IntuneConditionalAccessPolicy { @() } -ModuleName IntuneHydrationKit
             Mock Import-IntuneMobileApp { @() } -ModuleName IntuneHydrationKit
+            Mock Import-IntuneWinGetApp { @() } -ModuleName IntuneHydrationKit
             Mock Import-CISBaseline { @() } -ModuleName IntuneHydrationKit
             Mock New-IntuneDynamicGroup { @{ Action = 'Created'; Id = 'test-id' } } -ModuleName IntuneHydrationKit
             Mock Invoke-GroupBatchImport { @() } -ModuleName IntuneHydrationKit
@@ -665,6 +668,42 @@ Describe 'Invoke-IntuneHydration' {
             Should -Invoke Import-CISBaseline -ModuleName IntuneHydrationKit -Times 1
         }
 
+        It 'Should call WinGet and scoped legacy mobile app importers when MobileApps is enabled' {
+            Invoke-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive -Create -MobileApps -WhatIf
+
+            Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+                -not $PSBoundParameters.ContainsKey('PresetId') -and
+                -not $PSBoundParameters.ContainsKey('TemplateId') -and
+                $RemediationEnabled -eq $true -and
+                $WhatIf -eq $true
+            }
+
+            Should -Invoke Import-IntuneMobileApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+                @($Platform).Count -eq 1 -and $Platform[0] -eq 'macOS'
+            }
+
+            Should -Invoke Import-IntuneMobileApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+                @($Platform).Count -eq 1 -and
+                $Platform[0] -eq 'Windows' -and
+                @($TemplateId).Count -eq 6 -and
+                $TemplateId -contains 'AdobeAcrobatReaderDC' -and
+                $TemplateId -contains 'CompanyPortal' -and
+                $TemplateId -contains 'PowerShell' -and
+                $TemplateId -contains 'SpotifyMusicAndPodcasts' -and
+                $TemplateId -contains 'WhatsApp' -and
+                $TemplateId -contains 'M365Apps'
+            }
+        }
+
+        It 'Should not call WinGet apps for macOS-only MobileApps' {
+            Invoke-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive -Create -MobileApps -Platform macOS -WhatIf
+
+            Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 0
+            Should -Invoke Import-IntuneMobileApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+                @($Platform).Count -eq 1 -and $Platform[0] -eq 'macOS'
+            }
+        }
+
         It 'Should call all import functions when -All is specified' {
             Invoke-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive -Create -All -WhatIf
 
@@ -676,6 +715,7 @@ Describe 'Invoke-IntuneHydration' {
             Should -Invoke Import-IntuneAppProtectionPolicy -ModuleName IntuneHydrationKit -Times 1
             Should -Invoke Import-IntuneEnrollmentProfile -ModuleName IntuneHydrationKit -Times 1
             Should -Invoke Import-IntuneConditionalAccessPolicy -ModuleName IntuneHydrationKit -Times 1
+            Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 1
         }
 
         It 'Should call Import-IntuneBaseline without BaselinePath parameter' {
@@ -697,6 +737,84 @@ Describe 'Invoke-IntuneHydration' {
             Should -Invoke Import-IntuneDeviceFilter -ModuleName IntuneHydrationKit -Times 1
             Should -Invoke Import-IntuneCompliancePolicy -ModuleName IntuneHydrationKit -Times 0
             Should -Invoke Import-IntuneConditionalAccessPolicy -ModuleName IntuneHydrationKit -Times 0
+            Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 0
+        }
+    }
+
+    Context 'Mobile app settings' {
+        BeforeEach {
+            Mock Connect-IntuneHydration -ModuleName IntuneHydrationKit
+            Mock Test-IntunePrerequisites -ModuleName IntuneHydrationKit
+            Mock Initialize-HydrationLogging -ModuleName IntuneHydrationKit
+            Mock Write-HydrationLog -ModuleName IntuneHydrationKit
+            Mock Write-HydrationExecutionSettingsSummary -ModuleName IntuneHydrationKit
+            Mock Write-HydrationExecutionSummary {
+                @{
+                    Summary            = @{ Failed = 0 }
+                    ReportPath         = $null
+                    JsonReportPath     = $null
+                    ElapsedTime        = [TimeSpan]::FromSeconds(3)
+                    ElapsedTimeDisplay = '00:00:03'
+                }
+            } -ModuleName IntuneHydrationKit
+            Mock Get-ObfuscatedTenantId { return '12345678-****-****-****-123456789abc' } -ModuleName IntuneHydrationKit
+            Mock Import-IntuneMobileApp { @() } -ModuleName IntuneHydrationKit
+            Mock Import-IntuneWinGetApp { @() } -ModuleName IntuneHydrationKit
+        }
+
+        It 'Should pass configured mobile app preset and template IDs from settings mode' {
+            $testSettingsPath = Join-Path $script:TestTempPath 'settings-mobile-apps.json'
+            '{}' | Set-Content -Path $testSettingsPath -Encoding utf8
+
+            Mock Import-HydrationSettings {
+                @{
+                    tenant         = @{ tenantId = '12345678-1234-1234-1234-123456789abc' }
+                    authentication = @{ mode = 'interactive'; environment = 'Global' }
+                    options        = @{ create = $true; delete = $false; dryRun = $true; verbose = $false }
+                    imports        = @{ mobileApps = $true }
+                    mobileApps     = @{
+                        presetId    = 'mobile-apps'
+                        templateIds = @('google-chrome')
+                        remediation = @{ enabled = $false }
+                    }
+                    reporting      = @{ formats = @('markdown') }
+                    platforms      = @('Windows')
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Invoke-IntuneHydration -SettingsPath $testSettingsPath | Out-Null
+
+            Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+                $PresetId -eq 'mobile-apps' -and
+                @($TemplateId).Count -eq 1 -and
+                $TemplateId[0] -eq 'google-chrome' -and
+                $RemediationEnabled -eq $false -and
+                $WhatIf -eq $true
+            }
+        }
+
+        It 'Should not import WinGet apps in settings mode with macOS-only platform filter' {
+            $testSettingsPath = Join-Path $script:TestTempPath 'settings-mobile-apps-macos.json'
+            '{}' | Set-Content -Path $testSettingsPath -Encoding utf8
+
+            Mock Import-HydrationSettings {
+                @{
+                    tenant         = @{ tenantId = '12345678-1234-1234-1234-123456789abc' }
+                    authentication = @{ mode = 'interactive'; environment = 'Global' }
+                    options        = @{ create = $true; delete = $false; dryRun = $true; verbose = $false }
+                    imports        = @{ mobileApps = $true }
+                    mobileApps     = @{ presetId = 'mobile-apps'; templateIds = @('google-chrome') }
+                    reporting      = @{ formats = @('markdown') }
+                    platforms      = @('macOS')
+                }
+            } -ModuleName IntuneHydrationKit
+
+            Invoke-IntuneHydration -SettingsPath $testSettingsPath | Out-Null
+
+            Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 0
+            Should -Invoke Import-IntuneMobileApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
+                @($Platform).Count -eq 1 -and $Platform[0] -eq 'macOS'
+            }
         }
     }
 }

--- a/Tests/Public/Invoke-IntuneHydration.Tests.ps1
+++ b/Tests/Public/Invoke-IntuneHydration.Tests.ps1
@@ -669,6 +669,8 @@ Describe 'Invoke-IntuneHydration' {
         }
 
         It 'Should call WinGet and scoped legacy mobile app importers when MobileApps is enabled' {
+            $expectedWindowsFallbackTemplateIds = & $script:TestModule { Get-WindowsLegacyMobileAppTemplateId }
+
             Invoke-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive -Create -MobileApps -WhatIf
 
             Should -Invoke Import-IntuneWinGetApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
@@ -685,13 +687,7 @@ Describe 'Invoke-IntuneHydration' {
             Should -Invoke Import-IntuneMobileApp -ModuleName IntuneHydrationKit -Times 1 -ParameterFilter {
                 @($Platform).Count -eq 1 -and
                 $Platform[0] -eq 'Windows' -and
-                @($TemplateId).Count -eq 6 -and
-                $TemplateId -contains 'AdobeAcrobatReaderDC' -and
-                $TemplateId -contains 'CompanyPortal' -and
-                $TemplateId -contains 'PowerShell' -and
-                $TemplateId -contains 'SpotifyMusicAndPodcasts' -and
-                $TemplateId -contains 'WhatsApp' -and
-                $TemplateId -contains 'M365Apps'
+                (Compare-Object -ReferenceObject $expectedWindowsFallbackTemplateIds -DifferenceObject $TemplateId).Count -eq 0
             }
         }
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -30,6 +30,13 @@
         "mobileApps": true,
         "cisBaselines": false
     },
+    "mobileApps": {
+        "presetId": null,
+        "templateIds": [],
+        "remediation": {
+            "enabled": true
+        }
+    },
     "platforms": [
         "All"
     ],

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -130,7 +130,7 @@
                 "mobileApps": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Import mobile app templates"
+                    "description": "Import mobile apps. Windows apps use bundled WinGet-backed Win32 apps plus selected legacy fallback templates; macOS apps use bundled mobile app templates."
                 },
                 "cisBaselines": {
                     "type": "boolean",
@@ -153,6 +153,36 @@
                 ["Windows", "macOS"],
                 ["iOS", "Android"]
             ]
+        },
+        "mobileApps": {
+            "type": "object",
+            "description": "Windows mobile app import configuration for bundled WinGet-backed Win32 apps.",
+            "properties": {
+                "presetId": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Optional preset ID from Templates/MobileApps/Windows/WinGet/Presets. Leave null to import the full bundled WinGet catalog."
+                },
+                "templateIds": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Optional bundled WinGet template IDs to import in addition to the selected preset.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "remediation": {
+                    "type": "object",
+                    "description": "Proactive remediation generation for the selected WinGet app set.",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Create or update WinGet proactive remediation scripts when mobile apps are included."
+                        }
+                    }
+                }
+            }
         },
         "reporting": {
             "type": "object",


### PR DESCRIPTION
## Summary
- add settings schema/example support for WinGet mobile app selection
- route Windows mobile app hydration through Import-IntuneWinGetApp
- keep macOS legacy mobile apps and selected Windows fallback templates scoped

## Validation
- Invoke-Pester focused settings/mobile app/orchestration tests: 109/109 passed
- ./build.ps1 -Task Test: 870/870 passed
- ./build.ps1 -Task Analyze: 0 errors, 173 existing warnings
- git diff --check: passed