### PR TITLE
Add browser auth flow and mobile app cleanup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - 2026-05-12
+## [0.8.1] - 2026-05-25
 
 ### Added
 
+- **Authentication**: Added a themed browser PKCE interactive sign-in flow.
 - **Mobile Apps**: Added bundled WinGet app templates and WinGet-backed Win32 app import support under the Mobile Apps workflow.
+- **Pre-flight checks**: Added selected-workload access probing for Device Filters.
 
 ### Changed
 
+- **Authentication**: Interactive auth retries with a fresh browser token and does not persist refresh tokens.
 - **Runtime permission checks**: Added selected-import access checks and clearer Global Administrator guidance for tenants where PIM-elevated roles may not be accepted by downstream Intune authorization.
+- **Sovereign clouds**: Centralized Graph environment metadata for consistent GCC High and DoD endpoint handling.
+
+### Fixed
+
+- **Mobile Apps**: Fixed new mobile app names to append ` - [IHD]` after the app name instead of prefixing `[IHD]`.
+- **Mobile Apps**: Fixed legacy Windows `TemplateId` matching for nested Store and M365 templates.
 
 ## [0.7.1] - 2026-05-08
 

--- a/IntuneHydrationKit.build.ps1
+++ b/IntuneHydrationKit.build.ps1
@@ -24,6 +24,7 @@ $ModuleFiles = @(
 $ModuleFolders = @(
     'Public'
     'Private'
+    'media'
     'Templates'
 )
 

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion     = '0.7.1'
+    ModuleVersion     = '0.8.1'
 
     # ID used to uniquely identify this module
     GUID              = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -104,9 +104,15 @@ To update to the latest version:
 Update-Module -Name IntuneHydrationKit
 ```
 
-## v0.7.1
+## v0.8.1
 
-- **OpenIntuneBaseline:** Updated to windows-v3.8.
+- **Authentication:** Interactive sign-in now uses a themed browser PKCE flow with fresh-token retry and no persistent refresh-token cache.
+- **Mobile Apps:** Added bundled WinGet app templates and WinGet-backed Win32 app import support under the Mobile Apps workflow.
+- **Pre-flight checks:** Device Filter runs now validate selected Intune workload access before imports and report concise authorization guidance.
+- **Runtime permission checks:** Added selected-import access checks and clearer Global Administrator guidance for tenants where PIM-elevated roles may not be accepted by downstream Intune authorization.
+- **Mobile Apps:** Fixed new mobile app names to append ` - [IHD]` after the app name instead of prefixing `[IHD]`.
+- **Mobile Apps:** Fixed legacy Windows mobile app TemplateId matching for nested Store and M365 templates.
+- **Sovereign clouds:** Centralized Graph environment metadata for consistent GCC High and DoD endpoint handling.
 
 '@
         }

--- a/Private/Auth/Connect-HydrationGraphViaBrowser.ps1
+++ b/Private/Auth/Connect-HydrationGraphViaBrowser.ps1
@@ -1,0 +1,42 @@
+function Connect-HydrationGraphViaBrowser {
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '',
+        Justification = 'Connect-MgGraph -AccessToken requires a SecureString; OAuth access token is already in memory.')]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory)]
+        [string[]]$Scopes,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Global', 'USGov', 'USGovDoD', 'Germany', 'China')]
+        [string]$Environment,
+
+        [string]$ClientId = '14d82eec-204b-4c2f-b7e8-296a70dab67e'
+    )
+
+    $environmentInfo = Get-HydrationGraphEnvironmentInfo -Environment $Environment
+    $resolvedScopes = ConvertTo-HydrationOAuthScope -Scopes $Scopes -GraphEndpoint $environmentInfo.Endpoint
+
+    foreach ($attempt in 1..2) {
+        $tokens = Get-HydrationTokenViaBrowser `
+            -ClientId $ClientId `
+            -TenantId $TenantId `
+            -AuthorityHost $environmentInfo.AuthorityHost `
+            -Scopes $resolvedScopes
+
+        $secureToken = ConvertTo-SecureString -String $tokens.access_token -AsPlainText -Force
+        try {
+            Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
+            Connect-MgGraph -AccessToken $secureToken -Environment $Environment -NoWelcome -ErrorAction Stop
+            return
+        } catch {
+            if ($attempt -eq 2) {
+                throw
+            }
+
+            Write-Verbose "Browser Graph token could not connect; retrying with a fresh browser sign-in: $_"
+        }
+    }
+}

--- a/Private/Auth/ConvertTo-HydrationOAuthScope.ps1
+++ b/Private/Auth/ConvertTo-HydrationOAuthScope.ps1
@@ -1,0 +1,21 @@
+function ConvertTo-HydrationOAuthScope {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Scopes,
+
+        [Parameter(Mandatory)]
+        [string]$GraphEndpoint
+    )
+
+    $oidcScopes = @('openid', 'profile', 'offline_access', 'email')
+    $graphResource = $GraphEndpoint.TrimEnd('/')
+
+    return @(foreach ($scope in $Scopes) {
+            if ($scope -like 'https://*' -or $scope -in $oidcScopes) {
+                $scope
+            } else {
+                "$graphResource/$scope"
+            }
+        })
+}

--- a/Private/Auth/Get-HydrationBrowserAuthLogoDataUri.ps1
+++ b/Private/Auth/Get-HydrationBrowserAuthLogoDataUri.ps1
@@ -1,0 +1,12 @@
+function Get-HydrationBrowserAuthLogoDataUri {
+    [CmdletBinding()]
+    param()
+
+    $logoPath = Join-Path $script:ModuleRoot 'media/IHTLogoClearLight.png'
+    if (-not (Test-Path -Path $logoPath)) {
+        return $null
+    }
+
+    $logoBytes = [System.IO.File]::ReadAllBytes($logoPath)
+    return "data:image/png;base64,$([Convert]::ToBase64String($logoBytes))"
+}

--- a/Private/Auth/Get-HydrationFreeTcpPort.ps1
+++ b/Private/Auth/Get-HydrationFreeTcpPort.ps1
@@ -1,0 +1,12 @@
+function Get-HydrationFreeTcpPort {
+    [CmdletBinding()]
+    param()
+
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $listener.Start()
+    try {
+        return $listener.LocalEndpoint.Port
+    } finally {
+        $listener.Stop()
+    }
+}

--- a/Private/Auth/Get-HydrationGraphAccessIssue.ps1
+++ b/Private/Auth/Get-HydrationGraphAccessIssue.ps1
@@ -1,0 +1,37 @@
+function Get-HydrationGraphAccessIssue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.ErrorRecord]$ErrorRecord,
+
+        [Parameter(Mandatory)]
+        [string]$Workload,
+
+        [Parameter(Mandatory)]
+        [string]$Endpoint,
+
+        [Parameter(Mandatory)]
+        [string]$RequiredScope,
+
+        [string]$RoleHint = 'Use a Global Administrator account with active Intune service access.'
+    )
+
+    $statusCode = Get-GraphStatusCode -ErrorRecord $ErrorRecord
+    $rawMessage = if ($ErrorRecord.ErrorDetails -and $ErrorRecord.ErrorDetails.Message) {
+        $ErrorRecord.ErrorDetails.Message
+    } else {
+        $ErrorRecord.Exception.Message
+    }
+
+    if (-not $statusCode) {
+        if ($rawMessage -match '\b401\b|Unauthorized') {
+            $statusCode = 401
+        } elseif ($rawMessage -match '\b403\b|Forbidden|Access denied') {
+            $statusCode = 403
+        }
+    }
+
+    $statusText = if ($statusCode) { "HTTP $statusCode" } else { 'Graph access error' }
+
+    return "$Workload access check failed: $statusText from $Endpoint. Required scope $RequiredScope is present; verify Intune service authorization/RBAC. $RoleHint"
+}

--- a/Private/Auth/Get-HydrationGraphEnvironmentInfo.ps1
+++ b/Private/Auth/Get-HydrationGraphEnvironmentInfo.ps1
@@ -14,8 +14,17 @@ function Get-HydrationGraphEnvironmentInfo {
         'China' { 'https://microsoftgraph.chinacloudapi.cn' }
     }
 
+    $authorityHost = switch ($Environment) {
+        'Global' { 'https://login.microsoftonline.com' }
+        'USGov' { 'https://login.microsoftonline.us' }
+        'USGovDoD' { 'https://login.microsoftonline.us' }
+        'Germany' { 'https://login.microsoftonline.de' }
+        'China' { 'https://login.chinacloudapi.cn' }
+    }
+
     return @{
-        Environment = $Environment
-        Endpoint    = $endpoint
+        Environment   = $Environment
+        Endpoint      = $endpoint
+        AuthorityHost = $authorityHost
     }
 }

--- a/Private/Auth/Get-HydrationGraphWorkloadAccessProbe.ps1
+++ b/Private/Auth/Get-HydrationGraphWorkloadAccessProbe.ps1
@@ -1,0 +1,57 @@
+function Get-HydrationGraphWorkloadAccessProbe {
+    <#
+    .SYNOPSIS
+        Builds the selected Graph workload access probes for pre-flight validation.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable[]])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Imports,
+
+        [Parameter()]
+        [hashtable]$MobileAppConfiguration = @{},
+
+        [Parameter()]
+        [string[]]$MobileAppPlatforms = @('All')
+    )
+
+    $probes = [System.Collections.Generic.List[hashtable]]::new()
+
+    if ($Imports.ContainsKey('deviceFilters') -and $Imports.deviceFilters) {
+        $probes.Add(@{
+                Workload      = 'Device Filters'
+                Endpoint      = 'beta/deviceManagement/assignmentFilters'
+                Uri           = 'beta/deviceManagement/assignmentFilters?$top=1&$select=id'
+                RequiredScope = 'DeviceManagementConfiguration.ReadWrite.All'
+                RoleHint      = 'Use a Global Administrator account with active Intune service access; PIM-elevated roles can still be rejected by the downstream Intune service.'
+            })
+    }
+
+    if ($Imports.ContainsKey('mobileApps') -and $Imports.mobileApps) {
+        $probes.Add(@{
+                Workload      = 'Mobile Apps'
+                Endpoint      = 'beta/deviceAppManagement/mobileApps'
+                Uri           = 'beta/deviceAppManagement/mobileApps?$top=1&$select=id'
+                RequiredScope = 'DeviceManagementApps.ReadWrite.All'
+                RoleHint      = 'Use a Global Administrator account with active Intune app management access; PIM-elevated roles can still be rejected by the downstream Intune service.'
+            })
+
+        $remediationEnabled = $true
+        if ($MobileAppConfiguration.ContainsKey('remediationEnabled') -and $null -ne $MobileAppConfiguration.remediationEnabled) {
+            $remediationEnabled = [bool]$MobileAppConfiguration.remediationEnabled
+        }
+
+        if ($remediationEnabled -and (Test-HydrationMobileAppsIncludeWinGet -Configuration $MobileAppConfiguration -Platforms $MobileAppPlatforms)) {
+            $probes.Add(@{
+                    Workload      = 'WinGet Proactive Remediations'
+                    Endpoint      = 'beta/deviceManagement/deviceHealthScripts'
+                    Uri           = 'beta/deviceManagement/deviceHealthScripts?$top=1&$select=id'
+                    RequiredScope = 'DeviceManagementScripts.ReadWrite.All'
+                    RoleHint      = 'Use a Global Administrator account with active Intune device script access; PIM-elevated roles can still be rejected by the downstream Intune service.'
+                })
+        }
+    }
+
+    return $probes.ToArray()
+}

--- a/Private/Auth/Get-HydrationOAuthCallbackResult.ps1
+++ b/Private/Auth/Get-HydrationOAuthCallbackResult.ps1
@@ -1,0 +1,41 @@
+function Get-HydrationOAuthCallbackResult {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$Code,
+
+        [AllowEmptyString()]
+        [string]$AuthError,
+
+        [AllowEmptyString()]
+        [string]$ErrorDescription,
+
+        [AllowEmptyString()]
+        [string]$ReturnedState,
+
+        [Parameter(Mandatory)]
+        [string]$ExpectedState
+    )
+
+    if ($ReturnedState -ne $ExpectedState) {
+        return [PSCustomObject]@{
+            Status       = 'Error'
+            Message      = 'OAuth state mismatch. Return to PowerShell and try signing in again.'
+            ErrorMessage = 'OAuth state mismatch. Aborting authentication.'
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Code)) {
+        return [PSCustomObject]@{
+            Status       = 'Error'
+            Message      = $ErrorDescription
+            ErrorMessage = "Authorization failed: $AuthError - $ErrorDescription"
+        }
+    }
+
+    return [PSCustomObject]@{
+        Status       = 'Success'
+        Message      = $null
+        ErrorMessage = $null
+    }
+}

--- a/Private/Auth/Get-HydrationTokenViaBrowser.ps1
+++ b/Private/Auth/Get-HydrationTokenViaBrowser.ps1
@@ -1,0 +1,99 @@
+function Get-HydrationTokenViaBrowser {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ClientId,
+
+        [Parameter(Mandatory)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory)]
+        [string]$AuthorityHost,
+
+        [Parameter(Mandatory)]
+        [string[]]$Scopes,
+
+        [int]$RedirectPort
+    )
+
+    if (-not $RedirectPort -or $RedirectPort -le 0) {
+        $RedirectPort = Get-HydrationFreeTcpPort
+    }
+
+    $redirectUri = "http://localhost:$RedirectPort/"
+    $verifier = New-HydrationCodeVerifier
+    $challenge = New-HydrationCodeChallenge -Verifier $verifier
+    $state = [Guid]::NewGuid().ToString('N')
+
+    $authParams = [ordered]@{
+        client_id             = $ClientId
+        response_type         = 'code'
+        redirect_uri          = $redirectUri
+        response_mode         = 'query'
+        scope                 = ($Scopes -join ' ')
+        state                 = $state
+        code_challenge        = $challenge
+        code_challenge_method = 'S256'
+        prompt                = 'select_account'
+    }
+
+    $query = ($authParams.GetEnumerator() | ForEach-Object {
+            "$($_.Key)=$([Uri]::EscapeDataString([string]$_.Value))"
+        }) -join '&'
+    $authUri = "$($AuthorityHost.TrimEnd('/'))/$TenantId/oauth2/v2.0/authorize?$query"
+
+    $listener = [System.Net.HttpListener]::new()
+    $listener.Prefixes.Add($redirectUri)
+    $listener.Start()
+
+    try {
+        Write-Information (Format-HydrationDisplayMessage -Message "Opening browser for Microsoft Graph sign-in" -Style 'Info') -InformationAction Continue
+        Start-Process $authUri | Out-Null
+
+        $contextTask = $listener.GetContextAsync()
+        if (-not $contextTask.Wait([TimeSpan]::FromMinutes(5))) {
+            throw 'Authentication timed out after 5 minutes.'
+        }
+
+        $context = $contextTask.Result
+        $code = $context.Request.QueryString['code']
+        $authError = $context.Request.QueryString['error']
+        $errorDescription = $context.Request.QueryString['error_description']
+        $returnedState = $context.Request.QueryString['state']
+        $callbackResult = Get-HydrationOAuthCallbackResult `
+            -Code $code `
+            -AuthError $authError `
+            -ErrorDescription $errorDescription `
+            -ReturnedState $returnedState `
+            -ExpectedState $state
+
+        $html = if ($callbackResult.Status -eq 'Success') {
+            New-HydrationBrowserAuthResponseHtml -Status Success
+        } else {
+            New-HydrationBrowserAuthResponseHtml -Status Error -Message $callbackResult.Message
+        }
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($html)
+        $context.Response.ContentType = 'text/html; charset=utf-8'
+        $context.Response.ContentLength64 = $bytes.Length
+        $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+        $context.Response.Close()
+
+        if ($callbackResult.ErrorMessage) {
+            throw $callbackResult.ErrorMessage
+        }
+
+        $body = @{
+            client_id     = $ClientId
+            grant_type    = 'authorization_code'
+            code          = $code
+            redirect_uri  = $redirectUri
+            code_verifier = $verifier
+            scope         = ($Scopes -join ' ')
+        }
+
+        Invoke-HydrationOAuthTokenRequest -AuthorityHost $AuthorityHost -TenantId $TenantId -Body $body
+    } finally {
+        $listener.Stop()
+        $listener.Close()
+    }
+}

--- a/Private/Auth/Invoke-HydrationOAuthTokenRequest.ps1
+++ b/Private/Auth/Invoke-HydrationOAuthTokenRequest.ps1
@@ -1,0 +1,16 @@
+function Invoke-HydrationOAuthTokenRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$AuthorityHost,
+
+        [Parameter(Mandatory)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Body
+    )
+
+    $tokenUri = "$($AuthorityHost.TrimEnd('/'))/$TenantId/oauth2/v2.0/token"
+    Invoke-RestMethod -Method POST -Uri $tokenUri -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+}

--- a/Private/Auth/New-HydrationBrowserAuthResponseHtml.ps1
+++ b/Private/Auth/New-HydrationBrowserAuthResponseHtml.ps1
@@ -1,0 +1,41 @@
+function New-HydrationBrowserAuthResponseHtml {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Success', 'Error')]
+        [string]$Status,
+
+        [string]$Message
+    )
+
+    $isSuccess = $Status -eq 'Success'
+    $title = if ($isSuccess) { 'Authentication complete' } else { 'Authentication failed' }
+    $defaultMessage = if ($isSuccess) {
+        'You can close this tab and return to PowerShell.'
+    } else {
+        'Return to PowerShell for the full error.'
+    }
+
+    $logoDataUri = Get-HydrationBrowserAuthLogoDataUri
+    $logoHtml = if ($logoDataUri) {
+        "<img class='logo' src='$logoDataUri' alt='Intune Hydration Kit logo' />"
+    } else {
+        "<div class='mark'>IHK</div>"
+    }
+
+    $templatePath = Join-Path $script:ModuleRoot 'Private/Auth/Templates/BrowserAuthResponse.html'
+    $template = [System.IO.File]::ReadAllText($templatePath)
+    $replacements = @{
+        '{{TITLE}}'       = [System.Net.WebUtility]::HtmlEncode($title)
+        '{{MESSAGE}}'     = [System.Net.WebUtility]::HtmlEncode($(if ($Message) { $Message } else { $defaultMessage }))
+        '{{ACCENT}}'      = if ($isSuccess) { '#21a366' } else { '#c2410c' }
+        '{{STATUS_TEXT}}' = if ($isSuccess) { 'Connected' } else { 'Action needed' }
+        '{{LOGO_HTML}}'   = $logoHtml
+    }
+
+    foreach ($key in $replacements.Keys) {
+        $template = $template.Replace($key, $replacements[$key])
+    }
+
+    return $template
+}

--- a/Private/Auth/New-HydrationCodeChallenge.ps1
+++ b/Private/Auth/New-HydrationCodeChallenge.ps1
@@ -1,0 +1,10 @@
+function New-HydrationCodeChallenge {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Verifier
+    )
+
+    $hash = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($Verifier))
+    return [Convert]::ToBase64String($hash).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}

--- a/Private/Auth/New-HydrationCodeVerifier.ps1
+++ b/Private/Auth/New-HydrationCodeVerifier.ps1
@@ -1,0 +1,8 @@
+function New-HydrationCodeVerifier {
+    [CmdletBinding()]
+    param()
+
+    $bytes = [byte[]]::new(32)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}

--- a/Private/Auth/Templates/BrowserAuthResponse.html
+++ b/Private/Auth/Templates/BrowserAuthResponse.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intune Hydration Kit - {{TITLE}}</title>
+<style>
+:root {
+    color-scheme: dark;
+    --ink: #f7fbff;
+    --muted: #c6d4ea;
+    --panel: rgba(2, 12, 36, 0.72);
+    --line: rgba(0, 214, 255, 0.32);
+    --accent: {{ACCENT}};
+    --cyan: #00d7ff;
+    --blue: #1176ff;
+    --bg: #020817;
+}
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at 76% 21%, rgba(0, 215, 255, 0.22), transparent 28%),
+        radial-gradient(circle at 13% 82%, rgba(17, 118, 255, 0.18), transparent 34%),
+        linear-gradient(135deg, #020713 0%, #061a42 56%, #020817 100%);
+    color: var(--ink);
+    font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background-image: radial-gradient(rgba(0, 215, 255, 0.42) 1px, transparent 1px);
+    background-size: 18px 18px;
+    -webkit-mask-image: linear-gradient(90deg, transparent 0%, transparent 58%, #000 100%);
+    mask-image: linear-gradient(90deg, transparent 0%, transparent 58%, #000 100%);
+    opacity: 0.42;
+}
+body::after {
+    content: "";
+    position: fixed;
+    left: -8%;
+    right: -8%;
+    bottom: -12%;
+    height: 42%;
+    background:
+        repeating-radial-gradient(ellipse at 50% 100%, transparent 0 24px, rgba(0, 127, 255, 0.22) 25px 26px);
+    opacity: 0.38;
+}
+main {
+    position: relative;
+    z-index: 1;
+    width: min(880px, calc(100vw - 32px));
+    min-height: 420px;
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) 260px;
+    gap: 36px;
+    align-items: center;
+    padding: 44px;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: var(--panel);
+    box-shadow: 0 32px 90px rgba(0, 0, 0, 0.42), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
+}
+.content {
+    min-width: 0;
+}
+.eyebrow {
+    margin: 0 0 10px;
+    color: var(--muted);
+    font-size: 19px;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+.brand {
+    display: grid;
+    gap: 0;
+    margin-bottom: 20px;
+}
+.brand span:first-child {
+    color: #ffffff;
+    font-size: clamp(42px, 7vw, 72px);
+    font-weight: 900;
+    line-height: 0.95;
+}
+.brand span:last-child {
+    width: max-content;
+    max-width: 100%;
+    background: linear-gradient(90deg, var(--blue), var(--cyan));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-size: clamp(40px, 6.4vw, 68px);
+    font-weight: 900;
+    line-height: 1.03;
+}
+.rule {
+    width: 122px;
+    height: 3px;
+    margin: 0 0 22px;
+    background: linear-gradient(90deg, var(--cyan), rgba(17, 118, 255, 0));
+}
+.message {
+    width: min(560px, 100%);
+    margin: 0 0 24px;
+    color: var(--muted);
+    font-size: 20px;
+    line-height: 1.45;
+}
+.logo {
+    width: 224px;
+    height: 224px;
+    object-fit: contain;
+    filter: drop-shadow(0 0 32px rgba(0, 215, 255, 0.45));
+}
+.mark {
+    display: inline-grid;
+    place-items: center;
+    width: 180px;
+    height: 180px;
+    border: 2px solid var(--cyan);
+    border-radius: 24px;
+    background: rgba(0, 215, 255, 0.08);
+    color: #ffffff;
+    font-size: 48px;
+    font-weight: 700;
+}
+.visual {
+    display: grid;
+    place-items: center;
+    min-width: 0;
+}
+.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: linear-gradient(135deg, rgba(0, 215, 255, 0.12), rgba(17, 118, 255, 0.08));
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+.dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--accent);
+}
+h1 {
+    margin: 0 0 12px;
+    font-size: 28px;
+    line-height: 1.2;
+    letter-spacing: 0;
+}
+@media (max-width: 720px) {
+    main {
+        grid-template-columns: 1fr;
+        gap: 22px;
+        padding: 30px;
+        min-height: auto;
+    }
+    .visual {
+        order: -1;
+    }
+    .logo {
+        width: 148px;
+        height: 148px;
+    }
+    .brand span:first-child {
+        font-size: 42px;
+    }
+    .brand span:last-child {
+        font-size: 40px;
+    }
+    .message {
+        font-size: 17px;
+    }
+}
+</style>
+</head>
+<body>
+<main>
+<section class="content" aria-label="Authentication status">
+<p class="eyebrow">Automate. Hydrate. Protect.</p>
+<div class="brand"><span>Intune</span><span>Hydration Kit</span></div>
+<div class="rule"></div>
+<h1>{{TITLE}}</h1>
+<p class="message">{{MESSAGE}}</p>
+<div class="status"><span class="dot"></span>{{STATUS_TEXT}} for Microsoft Graph</div>
+</section>
+<section class="visual" aria-hidden="true">
+{{LOGO_HTML}}
+</section>
+</main>
+</body>
+</html>

--- a/Private/Auth/Test-HydrationGraphWorkloadAccess.ps1
+++ b/Private/Auth/Test-HydrationGraphWorkloadAccess.ps1
@@ -1,0 +1,66 @@
+function Test-HydrationGraphWorkloadAccess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Imports,
+
+        [Parameter()]
+        [bool]$MobileAppsRemediationEnabled = $true,
+
+        [Parameter()]
+        [bool]$MobileAppsIncludeWinGet = $true
+    )
+
+    $issues = [System.Collections.Generic.List[string]]::new()
+
+    $probes = @(
+        @{
+            ImportKey      = 'deviceFilters'
+            Workload       = 'Device Filters'
+            Endpoint       = 'beta/deviceManagement/assignmentFilters'
+            Uri            = 'beta/deviceManagement/assignmentFilters?$top=1&$select=id'
+            RequiredScope  = 'DeviceManagementConfiguration.ReadWrite.All'
+            RoleHint       = 'Use a Global Administrator account with active Intune service access; PIM-elevated roles can still be rejected by the downstream Intune service.'
+        },
+        @{
+            ImportKey      = 'mobileApps'
+            Workload       = 'Mobile Apps'
+            Endpoint       = 'beta/deviceAppManagement/mobileApps'
+            Uri            = 'beta/deviceAppManagement/mobileApps?$top=1&$select=id'
+            RequiredScope  = 'DeviceManagementApps.ReadWrite.All'
+            RoleHint       = 'Use a Global Administrator account with active Intune app management access; PIM-elevated roles can still be rejected by the downstream Intune service.'
+        },
+        @{
+            ImportKey      = 'mobileApps'
+            Workload       = 'WinGet Proactive Remediations'
+            Endpoint       = 'beta/deviceManagement/deviceHealthScripts'
+            Uri            = 'beta/deviceManagement/deviceHealthScripts?$top=1&$select=id'
+            RequiredScope  = 'DeviceManagementScripts.ReadWrite.All'
+            RoleHint       = 'Use a Global Administrator account with active Intune device script access; PIM-elevated roles can still be rejected by the downstream Intune service.'
+            RequiresMobileAppsRemediation = $true
+        }
+    )
+
+    foreach ($probe in $probes) {
+        if (-not ($Imports.ContainsKey($probe.ImportKey) -and $Imports[$probe.ImportKey])) {
+            continue
+        }
+
+        if ($probe.RequiresMobileAppsRemediation -and (-not $MobileAppsRemediationEnabled -or -not $MobileAppsIncludeWinGet)) {
+            continue
+        }
+
+        try {
+            $null = Invoke-MgGraphRequest -Method GET -Uri $probe.Uri -ErrorAction Stop
+        } catch {
+            $issues.Add((Get-HydrationGraphAccessIssue `
+                        -ErrorRecord $_ `
+                        -Workload $probe.Workload `
+                        -Endpoint $probe.Endpoint `
+                        -RequiredScope $probe.RequiredScope `
+                        -RoleHint $probe.RoleHint))
+        }
+    }
+
+    return $issues.ToArray()
+}

--- a/Private/Auth/Test-HydrationGraphWorkloadAccess.ps1
+++ b/Private/Auth/Test-HydrationGraphWorkloadAccess.ps1
@@ -5,51 +5,19 @@ function Test-HydrationGraphWorkloadAccess {
         [hashtable]$Imports,
 
         [Parameter()]
-        [bool]$MobileAppsRemediationEnabled = $true,
+        [hashtable]$MobileAppConfiguration = @{},
 
         [Parameter()]
-        [bool]$MobileAppsIncludeWinGet = $true
+        [string[]]$MobileAppPlatforms = @('All')
     )
 
     $issues = [System.Collections.Generic.List[string]]::new()
-
-    $probes = @(
-        @{
-            ImportKey      = 'deviceFilters'
-            Workload       = 'Device Filters'
-            Endpoint       = 'beta/deviceManagement/assignmentFilters'
-            Uri            = 'beta/deviceManagement/assignmentFilters?$top=1&$select=id'
-            RequiredScope  = 'DeviceManagementConfiguration.ReadWrite.All'
-            RoleHint       = 'Use a Global Administrator account with active Intune service access; PIM-elevated roles can still be rejected by the downstream Intune service.'
-        },
-        @{
-            ImportKey      = 'mobileApps'
-            Workload       = 'Mobile Apps'
-            Endpoint       = 'beta/deviceAppManagement/mobileApps'
-            Uri            = 'beta/deviceAppManagement/mobileApps?$top=1&$select=id'
-            RequiredScope  = 'DeviceManagementApps.ReadWrite.All'
-            RoleHint       = 'Use a Global Administrator account with active Intune app management access; PIM-elevated roles can still be rejected by the downstream Intune service.'
-        },
-        @{
-            ImportKey      = 'mobileApps'
-            Workload       = 'WinGet Proactive Remediations'
-            Endpoint       = 'beta/deviceManagement/deviceHealthScripts'
-            Uri            = 'beta/deviceManagement/deviceHealthScripts?$top=1&$select=id'
-            RequiredScope  = 'DeviceManagementScripts.ReadWrite.All'
-            RoleHint       = 'Use a Global Administrator account with active Intune device script access; PIM-elevated roles can still be rejected by the downstream Intune service.'
-            RequiresMobileAppsRemediation = $true
-        }
-    )
+    $probes = Get-HydrationGraphWorkloadAccessProbe `
+        -Imports $Imports `
+        -MobileAppConfiguration $MobileAppConfiguration `
+        -MobileAppPlatforms $MobileAppPlatforms
 
     foreach ($probe in $probes) {
-        if (-not ($Imports.ContainsKey($probe.ImportKey) -and $Imports[$probe.ImportKey])) {
-            continue
-        }
-
-        if ($probe.RequiresMobileAppsRemediation -and (-not $MobileAppsRemediationEnabled -or -not $MobileAppsIncludeWinGet)) {
-            continue
-        }
-
         try {
             $null = Invoke-MgGraphRequest -Method GET -Uri $probe.Uri -ErrorAction Stop
         } catch {

--- a/Private/Auth/Test-HydrationMobileAppsIncludeWinGet.ps1
+++ b/Private/Auth/Test-HydrationMobileAppsIncludeWinGet.ps1
@@ -1,0 +1,51 @@
+function Test-HydrationMobileAppsIncludeWinGet {
+    <#
+    .SYNOPSIS
+        Determines whether the selected mobile app configuration includes WinGet app templates.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [hashtable]$Configuration = @{},
+
+        [Parameter()]
+        [string[]]$Platforms = @('All')
+    )
+
+    $selectedPlatforms = @($Platforms | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($selectedPlatforms.Count -eq 0) {
+        $selectedPlatforms = @('All')
+    }
+
+    if (-not ($selectedPlatforms -contains 'All' -or $selectedPlatforms -contains 'Windows')) {
+        return $false
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Configuration.presetId)) {
+        return $true
+    }
+
+    $requestedTemplateIds = @($Configuration.templateIds | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($requestedTemplateIds.Count -eq 0) {
+        return $true
+    }
+
+    $winGetAppTemplatePath = Join-Path -Path $script:TemplatesPath -ChildPath 'MobileApps/Windows/WinGet/Apps'
+    if (-not (Test-Path -Path $winGetAppTemplatePath)) {
+        return $false
+    }
+
+    $winGetTemplateIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($templateFile in Get-ChildItem -Path $winGetAppTemplatePath -Filter '*.json' -File) {
+        [void]$winGetTemplateIds.Add([System.IO.Path]::GetFileNameWithoutExtension($templateFile.Name))
+    }
+
+    foreach ($templateId in $requestedTemplateIds) {
+        if ($winGetTemplateIds.Contains([string]$templateId)) {
+            return $true
+        }
+    }
+
+    return $false
+}

--- a/Private/Groups/Invoke-GroupBatchImport.ps1
+++ b/Private/Groups/Invoke-GroupBatchImport.ps1
@@ -78,18 +78,6 @@ function Invoke-GroupBatchImport {
         return $body
     }
 
-    # Helper function to get Graph base URI for the current environment
-    function Get-GraphBaseUri {
-        param([string]$Environment)
-        switch ($Environment) {
-            "USGov" { return "https://graph.microsoft.us" }
-            "USGovDoD" { return "https://graph.microsoft.us" }
-            "China" { return "https://graph.chinacloudapi.cn" }
-            "Germany" { return "https://graph.microsoft.de" }
-            default { return "https://graph.microsoft.com" }
-        }
-    }
-
     $results = @()
     $maxBatchSize = if ($script:MaxBatchSize) { $script:MaxBatchSize } else { 10 }
 
@@ -490,7 +478,7 @@ function Invoke-GroupBatchImport {
         }
 
         # Get Graph base URI for owner reference
-        $graphBaseUri = Get-GraphBaseUri -Environment $mgContext.Environment
+        $graphBaseUri = (Get-HydrationGraphEnvironmentInfo -Environment $mgContext.Environment).Endpoint
 
         # Create each SP owner group sequentially (need to add owner after creation)
         foreach ($groupDef in $spOwnerGroups) {

--- a/Private/MobileApps/Get-HydrationMobileAppBaseName.ps1
+++ b/Private/MobileApps/Get-HydrationMobileAppBaseName.ps1
@@ -1,0 +1,38 @@
+function Get-HydrationMobileAppBaseName {
+    <#
+    .SYNOPSIS
+        Returns the raw app name used to derive hydration mobile app display names.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$DisplayName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DisplayName)) {
+        return $DisplayName
+    }
+
+    $suffix = ' - [IHD]'
+    $prefix = [string]$script:ImportPrefix
+    if ([string]::IsNullOrWhiteSpace($prefix)) {
+        $prefix = '[IHD] '
+    }
+
+    $baseName = $DisplayName.Trim()
+    if ($baseName.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $baseName = $baseName.Substring($prefix.Length).TrimStart()
+    }
+
+    if ($baseName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $baseName = $baseName.Substring(0, $baseName.Length - $suffix.Length).TrimEnd()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($baseName)) {
+        return $DisplayName
+    }
+
+    return $baseName
+}

--- a/Private/MobileApps/Get-HydrationMobileAppDisplayName.ps1
+++ b/Private/MobileApps/Get-HydrationMobileAppDisplayName.ps1
@@ -3,9 +3,9 @@ function Get-HydrationMobileAppDisplayName {
     .SYNOPSIS
         Returns the Intune Hydration Kit display name for a mobile app.
     .DESCRIPTION
-        Appends the mobile app identification suffix used by Intune Hydration Kit.
-        Existing suffixed names are returned unchanged so templates can safely be
-        processed more than once.
+        Returns the app-name-first mobile app identification format used by
+        Intune Hydration Kit. Legacy prefixed names and already-suffixed names
+        are normalized so templates can safely be processed more than once.
     .PARAMETER DisplayName
         The template display name to format.
     .OUTPUTS
@@ -20,9 +20,14 @@ function Get-HydrationMobileAppDisplayName {
     )
 
     $suffix = ' - [IHD]'
-    if ([string]::IsNullOrWhiteSpace($DisplayName) -or $DisplayName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    if ([string]::IsNullOrWhiteSpace($DisplayName)) {
         return $DisplayName
     }
 
-    return "$DisplayName$suffix"
+    $baseName = Get-HydrationMobileAppBaseName -DisplayName $DisplayName
+    if ([string]::IsNullOrWhiteSpace($baseName)) {
+        return $DisplayName
+    }
+
+    return "$baseName$suffix"
 }

--- a/Private/MobileApps/Get-HydrationMobileAppExistingMatch.ps1
+++ b/Private/MobileApps/Get-HydrationMobileAppExistingMatch.ps1
@@ -1,0 +1,40 @@
+function Get-HydrationMobileAppExistingMatch {
+    <#
+    .SYNOPSIS
+        Finds an existing mobile app by any supported hydration name variant.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$ExistingApps,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$DisplayName,
+
+        [Parameter()]
+        [ValidateSet('IsTagged', 'IsOwned')]
+        [string]$OwnershipProperty = 'IsTagged'
+    )
+
+    foreach ($nameVariant in Get-HydrationMobileAppNameVariant -DisplayName $DisplayName) {
+        if (-not $ExistingApps.ContainsKey($nameVariant)) {
+            continue
+        }
+
+        $existingApp = $ExistingApps[$nameVariant]
+        $ownershipState = if ($existingApp -is [hashtable]) {
+            $existingApp[$OwnershipProperty]
+        } else {
+            $property = $existingApp.PSObject.Properties[$OwnershipProperty]
+            if ($property) { $property.Value } else { $false }
+        }
+
+        if ($ownershipState) {
+            return $nameVariant
+        }
+    }
+
+    return $null
+}

--- a/Private/MobileApps/Get-HydrationMobileAppNameVariant.ps1
+++ b/Private/MobileApps/Get-HydrationMobileAppNameVariant.ps1
@@ -20,28 +20,20 @@ function Get-HydrationMobileAppNameVariant {
 
     $suffix = ' - [IHD]'
     $rawName = $DisplayName.Trim()
-    $escapedPrefix = [regex]::Escape($script:ImportPrefix)
+    $baseName = Get-HydrationMobileAppBaseName -DisplayName $rawName
 
-    $normalizedName = $rawName -replace "^$escapedPrefix", ''
-    $normalizedName = if ($normalizedName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
-        $normalizedName.Substring(0, $normalizedName.Length - $suffix.Length)
-    } else {
-        $normalizedName
-    }
-
-    $currentName = Get-HydrationMobileAppDisplayName -DisplayName $normalizedName
-    $legacyPrefixedName = "$($script:ImportPrefix)$normalizedName"
-    $rawNameWithoutSuffix = if ($rawName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
-        $rawName.Substring(0, $rawName.Length - $suffix.Length)
-    } else {
-        $rawName
+    $currentName = Get-HydrationMobileAppDisplayName -DisplayName $baseName
+    $legacyPrefixedName = "$($script:ImportPrefix)$baseName"
+    $rawNameWithoutSuffix = $rawName
+    if ($rawNameWithoutSuffix.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $rawNameWithoutSuffix = $rawNameWithoutSuffix.Substring(0, $rawNameWithoutSuffix.Length - $suffix.Length).TrimEnd()
     }
 
     @(
         $currentName
         $rawName
         $legacyPrefixedName
-        $normalizedName
+        $baseName
         $rawNameWithoutSuffix
     ) |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |

--- a/Private/MobileApps/Get-HydrationMobileAppNameVariant.ps1
+++ b/Private/MobileApps/Get-HydrationMobileAppNameVariant.ps1
@@ -1,0 +1,49 @@
+function Get-HydrationMobileAppNameVariant {
+    <#
+    .SYNOPSIS
+        Returns all supported Intune Hydration Kit mobile app display-name variants.
+    .DESCRIPTION
+        Centralizes the current suffix format and legacy raw/prefixed formats used
+        for idempotency and template-scoped deletes.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$DisplayName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DisplayName)) {
+        return @()
+    }
+
+    $suffix = ' - [IHD]'
+    $rawName = $DisplayName.Trim()
+    $escapedPrefix = [regex]::Escape($script:ImportPrefix)
+
+    $normalizedName = $rawName -replace "^$escapedPrefix", ''
+    $normalizedName = if ($normalizedName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $normalizedName.Substring(0, $normalizedName.Length - $suffix.Length)
+    } else {
+        $normalizedName
+    }
+
+    $currentName = Get-HydrationMobileAppDisplayName -DisplayName $normalizedName
+    $legacyPrefixedName = "$($script:ImportPrefix)$normalizedName"
+    $rawNameWithoutSuffix = if ($rawName.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $rawName.Substring(0, $rawName.Length - $suffix.Length)
+    } else {
+        $rawName
+    }
+
+    @(
+        $currentName
+        $rawName
+        $legacyPrefixedName
+        $normalizedName
+        $rawNameWithoutSuffix
+    ) |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+}

--- a/Private/MobileApps/Get-MobileAppTemplateNameSet.ps1
+++ b/Private/MobileApps/Get-MobileAppTemplateNameSet.ps1
@@ -3,10 +3,10 @@ function Get-MobileAppTemplateNameSet {
     .SYNOPSIS
         Builds a HashSet of display names from mobile app template files.
     .DESCRIPTION
-        Reads each template file, extracts the displayName, applies the
-        hydration mobile-app display-name transformation (suffix), and
-        returns a case-insensitive HashSet of
-        the resulting names. Used for scoping deletion to known templates.
+        Reads each template file, extracts displayName, and returns a
+        case-insensitive HashSet containing the current suffixed name plus
+        supported raw and legacy-prefixed variants. Used for idempotency and
+        template-scoped deletes.
     .PARAMETER TemplateFiles
         Array of FileInfo objects representing the template files to read.
     #>

--- a/Private/MobileApps/Get-MobileAppTemplateNameSet.ps1
+++ b/Private/MobileApps/Get-MobileAppTemplateNameSet.ps1
@@ -23,7 +23,9 @@ function Get-MobileAppTemplateNameSet {
             $template = Get-Content -Path $templateFile.FullName -Raw -Encoding utf8 | ConvertFrom-Json
             if (-not [string]::IsNullOrWhiteSpace($template.displayName)) {
                 $templateDisplayName = [string]$template.displayName
-                [void]$displayNames.Add((Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName))
+                foreach ($nameVariant in Get-HydrationMobileAppNameVariant -DisplayName $templateDisplayName) {
+                    [void]$displayNames.Add($nameVariant)
+                }
             }
         } catch {
             Write-Verbose "Skipping template display-name lookup for '$($templateFile.FullName)': $($_.Exception.Message)"

--- a/Private/MobileApps/Test-HydrationMobileAppNameInSet.ps1
+++ b/Private/MobileApps/Test-HydrationMobileAppNameInSet.ps1
@@ -1,0 +1,24 @@
+function Test-HydrationMobileAppNameInSet {
+    <#
+    .SYNOPSIS
+        Checks whether any supported hydration mobile app name variant exists in a name set.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory)]
+        [System.Collections.Generic.HashSet[string]]$NameSet
+    )
+
+    foreach ($nameVariant in Get-HydrationMobileAppNameVariant -DisplayName $DisplayName) {
+        if ($NameSet.Contains($nameVariant)) {
+            return $true
+        }
+    }
+
+    return $false
+}

--- a/Private/Templates/Get-FilteredTemplates.ps1
+++ b/Private/Templates/Get-FilteredTemplates.ps1
@@ -68,9 +68,9 @@ function Get-FilteredTemplates {
                     $matched = $template.Name -like "*[-_]$plat.json"
                 }
                 'Directory' {
-                    $parentDir = Split-Path -Path $template.DirectoryName -Leaf
-                    $matched = $parentDir -eq $plat -or
-                    ($plat -eq 'macOS' -and $parentDir -eq 'Mac')
+                    $pathParts = $template.DirectoryName -split '[/\\]'
+                    $matched = $pathParts -contains $plat -or
+                    ($plat -eq 'macOS' -and $pathParts -contains 'Mac')
                 }
                 'Folder' {
                     # OpenIntuneBaseline uses uppercase folder names: WINDOWS, WINDOWS365, MACOS, BYOD

--- a/Private/WinGet/Get-ExistingWinGetApps.ps1
+++ b/Private/WinGet/Get-ExistingWinGetApps.ps1
@@ -26,7 +26,7 @@ function Get-ExistingWinGetApps {
         foreach ($existingApp in @($response.value)) {
             $appToEvaluate = $existingApp
             $appName = [string]$existingApp.displayName
-            $isPotentialMatch = $KnownTemplateNames.Contains($appName)
+            $isPotentialMatch = Test-HydrationMobileAppNameInSet -DisplayName $appName -NameSet $KnownTemplateNames
 
             if ($isPotentialMatch -and [string]::IsNullOrWhiteSpace($existingApp.description) -and [string]::IsNullOrWhiteSpace($existingApp.notes)) {
                 try {

--- a/Private/WinGet/Remove-IntuneWinGetApps.ps1
+++ b/Private/WinGet/Remove-IntuneWinGetApps.ps1
@@ -40,7 +40,7 @@ function Remove-IntuneWinGetApps {
             continue
         }
 
-        if (-not $KnownTemplateNames.Contains($existingApp.DisplayName)) {
+        if (-not (Test-HydrationMobileAppNameInSet -DisplayName $existingApp.DisplayName -NameSet $KnownTemplateNames)) {
             Write-Verbose "Skipping '$($existingApp.DisplayName)' - not in current WinGet templates"
             Write-Debug "Delete decision: skipping '$($existingApp.DisplayName)' because it is WinGet-owned but not in the current template set."
             continue

--- a/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
+++ b/Private/WinGet/Sync-IntuneWinGetProactiveRemediation.ps1
@@ -60,9 +60,15 @@ function Sync-IntuneWinGetProactiveRemediation {
         }
 
         foreach ($existingRemediation in $OwnedExisting) {
-            Invoke-HydrationGraphRequest -Method DELETE -Uri "beta/deviceManagement/deviceHealthScripts/$($existingRemediation.id)" | Out-Null
-            Write-HydrationLog -Message "  Deleted: $($Definition.DisplayName)" -Level Info
-            $results.Add((New-HydrationResult -Name $Definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation' -Action 'Deleted' -Status 'Removed'))
+            try {
+                Invoke-HydrationGraphRequest -Method DELETE -Uri "beta/deviceManagement/deviceHealthScripts/$($existingRemediation.id)" | Out-Null
+                Write-HydrationLog -Message "  Deleted: $($Definition.DisplayName)" -Level Info
+                $results.Add((New-HydrationResult -Name $Definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation' -Action 'Deleted' -Status 'Removed'))
+            } catch {
+                $errorMessage = Get-GraphErrorMessage -ErrorRecord $_
+                Write-HydrationLog -Message "  Failed: $($Definition.DisplayName) - $errorMessage" -Level Warning
+                $results.Add((New-HydrationResult -Name $Definition.DisplayName -Id $existingRemediation.id -Type 'WinGetRemediation' -Action 'Failed' -Status $errorMessage))
+            }
         }
 
         return $true

--- a/Public/Authentication/Connect-IntuneHydration.ps1
+++ b/Public/Authentication/Connect-IntuneHydration.ps1
@@ -57,14 +57,13 @@ function Connect-IntuneHydration {
         }
 
         if ($Interactive) {
-            $connectParams['Scopes'] = $scopes
+            Connect-HydrationGraphViaBrowser -TenantId $TenantId -Scopes $scopes -Environment $Environment
         } else {
             # Create credential object for client secret auth
             $credential = New-Object System.Management.Automation.PSCredential($ClientId, $ClientSecret)
             $connectParams['ClientSecretCredential'] = $credential
+            Connect-MgGraph @connectParams
         }
-
-        Connect-MgGraph @connectParams
 
         $null = Set-HydrationConnectionState -TenantId $TenantId -Environment $Environment
 
@@ -79,4 +78,3 @@ function Connect-IntuneHydration {
         $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 }
-

--- a/Public/Authentication/Test-IntunePrerequisites.ps1
+++ b/Public/Authentication/Test-IntunePrerequisites.ps1
@@ -12,13 +12,23 @@ function Test-IntunePrerequisites {
         Test-IntunePrerequisites
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter()]
+        [hashtable]$Imports = @{},
+
+        [Parameter()]
+        [bool]$MobileAppsRemediationEnabled = $true,
+
+        [Parameter()]
+        [bool]$MobileAppsIncludeWinGet = $true
+    )
 
     Write-Information (Format-HydrationDisplayMessage -Message 'Validating Intune prerequisites...' -Style 'Section' -Emoji '🔎') -InformationAction Continue
 
     $issues = @()
     $notes = [System.Collections.Generic.List[object]]::new()
     $riskBasedPolicyNames = @()
+    $conditionalAccessSelected = $Imports.Count -eq 0 -or ($Imports.ContainsKey('conditionalAccess') -and $Imports.conditionalAccess)
 
     # Required scopes from Connect-IntuneHydration
     $requiredScopes = Get-HydrationGraphScopes
@@ -68,7 +78,7 @@ function Test-IntunePrerequisites {
             $issues += "No active Intune license found. Please ensure Intune is licensed for this tenant."
         }
 
-        if (-not $hasPremiumP2) {
+        if ($conditionalAccessSelected -and -not $hasPremiumP2) {
             $riskBasedPolicyNames = @(
                 'Require multifactor authentication for risky sign-ins'
                 'Require password change for high-risk users'
@@ -81,10 +91,12 @@ function Test-IntunePrerequisites {
                 })
         }
 
-        $notes.Add([PSCustomObject]@{
-                Message     = 'Some Conditional Access templates use private preview features and will be skipped unless the tenant is explicitly authorized.'
-                DetailLines = @()
-            })
+        if ($conditionalAccessSelected) {
+            $notes.Add([PSCustomObject]@{
+                    Message     = 'Some Conditional Access templates use private preview features and will be skipped unless the tenant is explicitly authorized.'
+                    DetailLines = @()
+                })
+        }
 
         # Check for required permission scopes
         $context = Get-MgContext
@@ -107,6 +119,16 @@ function Test-IntunePrerequisites {
                 } else {
                     Write-Verbose 'All required permission scopes are present'
                 }
+            }
+        }
+
+        if ($issues.Count -eq 0) {
+            $workloadAccessIssues = @(Test-HydrationGraphWorkloadAccess `
+                    -Imports $Imports `
+                    -MobileAppsRemediationEnabled $MobileAppsRemediationEnabled `
+                    -MobileAppsIncludeWinGet $MobileAppsIncludeWinGet)
+            if ($workloadAccessIssues.Count -gt 0) {
+                $issues += $workloadAccessIssues
             }
         }
 

--- a/Public/Authentication/Test-IntunePrerequisites.ps1
+++ b/Public/Authentication/Test-IntunePrerequisites.ps1
@@ -17,10 +17,10 @@ function Test-IntunePrerequisites {
         [hashtable]$Imports = @{},
 
         [Parameter()]
-        [bool]$MobileAppsRemediationEnabled = $true,
+        [hashtable]$MobileAppConfiguration = @{},
 
         [Parameter()]
-        [bool]$MobileAppsIncludeWinGet = $true
+        [string[]]$MobileAppPlatforms = @('All')
     )
 
     Write-Information (Format-HydrationDisplayMessage -Message 'Validating Intune prerequisites...' -Style 'Section' -Emoji '🔎') -InformationAction Continue
@@ -125,8 +125,8 @@ function Test-IntunePrerequisites {
         if ($issues.Count -eq 0) {
             $workloadAccessIssues = @(Test-HydrationGraphWorkloadAccess `
                     -Imports $Imports `
-                    -MobileAppsRemediationEnabled $MobileAppsRemediationEnabled `
-                    -MobileAppsIncludeWinGet $MobileAppsIncludeWinGet)
+                    -MobileAppConfiguration $MobileAppConfiguration `
+                    -MobileAppPlatforms $MobileAppPlatforms)
             if ($workloadAccessIssues.Count -gt 0) {
                 $issues += $workloadAccessIssues
             }

--- a/Public/Imports/Import-IntuneMobileApp.ps1
+++ b/Public/Imports/Import-IntuneMobileApp.ps1
@@ -120,19 +120,7 @@ function Import-IntuneMobileApp {
 
     # Remove existing apps if requested
     if ($RemoveExisting) {
-        # Load template names to scope deletes to only apps this kit would create
-        $knownTemplateNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-        foreach ($templateFile in $templateFiles) {
-            try {
-                $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
-                $templateName = if ($template.displayName) { $template.displayName } else { $template.name }
-                if ($templateName) {
-                    [void]$knownTemplateNames.Add([string]$templateName)
-                }
-            } catch {
-                Write-Verbose "Failed to parse template: $($templateFile.Name)"
-            }
-        }
+        $knownTemplateNames = Get-MobileAppTemplateNameSet -TemplateFiles $templateFiles
 
         $appsToDelete = @()
         foreach ($appName in $existingApps.Keys) {
@@ -143,9 +131,7 @@ function Import-IntuneMobileApp {
                 continue
             }
 
-            $escapedPrefix = [regex]::Escape($script:ImportPrefix)
-            $nameForLookup = $appName -replace "^$escapedPrefix", ''
-            if (-not ($knownTemplateNames.Contains($appName) -or $knownTemplateNames.Contains($nameForLookup))) {
+            if (-not (Test-HydrationMobileAppNameInSet -DisplayName $appName -NameSet $knownTemplateNames)) {
                 Write-Verbose "Skipping '$appName' - not in this kit's templates (may be from another tool)"
                 continue
             }
@@ -179,19 +165,16 @@ function Import-IntuneMobileApp {
     foreach ($templateFile in $templateFiles) {
         try {
             $template = Get-Content -Path $templateFile.FullName -Raw -Encoding utf8 | ConvertFrom-Json
-            $displayName = "$($script:ImportPrefix)$($template.displayName)"
             if (-not $template.displayName) {
                 Write-Warning "Template missing displayName: $($templateFile.FullName)"
                 $results += New-HydrationResult -Name $templateFile.Name -Path $templateFile.FullName -Type 'MobileApp' -Action 'Failed' -Status 'Missing displayName'
                 continue
             }
 
-            # Check both prefixed and unprefixed names (backward compat with pre-prefix apps)
             $originalName = $template.displayName
-            $hasLegacyMatch = -not [string]::IsNullOrWhiteSpace($originalName) -and $originalName -ne $displayName -and
-            $existingApps.ContainsKey($originalName) -and $existingApps[$originalName].IsTagged
-            if (($existingApps.ContainsKey($displayName) -and $existingApps[$displayName].IsTagged) -or $hasLegacyMatch) {
-                $matchedName = if ($existingApps.ContainsKey($displayName) -and $existingApps[$displayName].IsTagged) { $displayName } else { $originalName }
+            $displayName = Get-HydrationMobileAppDisplayName -DisplayName $originalName
+            $matchedName = Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps -DisplayName $originalName
+            if ($matchedName) {
                 Write-HydrationLog -Message "  Skipped: $displayName" -Level Info
                 $results += New-HydrationResult -Name $displayName -Id $existingApps[$matchedName].Id -Path $templateFile.FullName -Type 'MobileApp' -Action 'Skipped' -Status 'Already exists'
                 continue

--- a/Public/Imports/Import-IntuneWinGetApp.ps1
+++ b/Public/Imports/Import-IntuneWinGetApp.ps1
@@ -67,7 +67,9 @@ function Import-IntuneWinGetApp {
     foreach ($template in $templates) {
         if (-not [string]::IsNullOrWhiteSpace($template.displayName)) {
             $templateDisplayName = [string]$template.displayName
-            [void]$knownTemplateNames.Add((Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName))
+            foreach ($nameVariant in Get-HydrationMobileAppNameVariant -DisplayName $templateDisplayName) {
+                [void]$knownTemplateNames.Add($nameVariant)
+            }
         }
     }
 
@@ -109,8 +111,9 @@ function Import-IntuneWinGetApp {
         }
 
         $displayName = Get-HydrationMobileAppDisplayName -DisplayName $templateDisplayName
-        if ($existingApps.Lookup.ContainsKey($displayName) -and $existingApps.Lookup[$displayName].IsOwned) {
-            $matchedApp = $existingApps.Lookup[$displayName]
+        $matchedName = Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps.Lookup -DisplayName $templateDisplayName -OwnershipProperty IsOwned
+        if ($matchedName) {
+            $matchedApp = $existingApps.Lookup[$matchedName]
             Write-Debug "Create decision: skipping '$displayName' because matching WinGet-owned app '$($matchedApp.DisplayName)' already exists with AppId='$($matchedApp.Id)'."
             Write-HydrationLog -Message "  Skipped: $displayName" -Level Info
             $results += New-HydrationResult -Name $displayName -Id $matchedApp.Id -Path $template.TemplatePath -Type 'WinGetWin32App' -Action 'Skipped' -Status 'Already exists'

--- a/Public/Orchestration/Invoke-IntuneHydration.ps1
+++ b/Public/Orchestration/Invoke-IntuneHydration.ps1
@@ -357,7 +357,14 @@ function Invoke-IntuneHydration {
         Write-HydrationLog @logParams
 
         # Always run pre-flight checks (read-only operations)
-        Test-IntunePrerequisites -Verbose:$effectiveVerboseEnabled | Out-Null
+        $preflightMobileAppConfiguration = Get-MobileAppImportConfiguration -Settings $settings
+        $preflightMobileAppPlatforms = @($platformFilters.MobileApps)
+        $preflightMobileAppsIncludeWinGet = $preflightMobileAppPlatforms -contains 'All' -or $preflightMobileAppPlatforms -contains 'Windows'
+        Test-IntunePrerequisites `
+            -Imports $settings.imports `
+            -MobileAppsRemediationEnabled $preflightMobileAppConfiguration.remediationEnabled `
+            -MobileAppsIncludeWinGet $preflightMobileAppsIncludeWinGet `
+            -Verbose:$effectiveVerboseEnabled | Out-Null
 
         # Step 3: Dynamic Groups
         if ($settings.imports.dynamicGroups) {

--- a/Public/Orchestration/Invoke-IntuneHydration.ps1
+++ b/Public/Orchestration/Invoke-IntuneHydration.ps1
@@ -358,12 +358,10 @@ function Invoke-IntuneHydration {
 
         # Always run pre-flight checks (read-only operations)
         $preflightMobileAppConfiguration = Get-MobileAppImportConfiguration -Settings $settings
-        $preflightMobileAppPlatforms = @($platformFilters.MobileApps)
-        $preflightMobileAppsIncludeWinGet = $preflightMobileAppPlatforms -contains 'All' -or $preflightMobileAppPlatforms -contains 'Windows'
         Test-IntunePrerequisites `
             -Imports $settings.imports `
-            -MobileAppsRemediationEnabled $preflightMobileAppConfiguration.remediationEnabled `
-            -MobileAppsIncludeWinGet $preflightMobileAppsIncludeWinGet `
+            -MobileAppConfiguration $preflightMobileAppConfiguration `
+            -MobileAppPlatforms $platformFilters.MobileApps `
             -Verbose:$effectiveVerboseEnabled | Out-Null
 
         # Step 3: Dynamic Groups

--- a/Tests/Private/BrowserAuth.Tests.ps1
+++ b/Tests/Private/BrowserAuth.Tests.ps1
@@ -1,0 +1,165 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $script:ModuleRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/ConvertTo-HydrationOAuthScope.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Get-HydrationGraphEnvironmentInfo.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Get-HydrationBrowserAuthLogoDataUri.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/New-HydrationBrowserAuthResponseHtml.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Get-HydrationFreeTcpPort.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/New-HydrationCodeVerifier.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/New-HydrationCodeChallenge.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Invoke-HydrationOAuthTokenRequest.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Get-HydrationOAuthCallbackResult.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Get-HydrationTokenViaBrowser.ps1')
+    . (Join-Path $script:ModuleRoot 'Private/Auth/Connect-HydrationGraphViaBrowser.ps1')
+
+    if (-not (Get-Command Connect-MgGraph -ErrorAction SilentlyContinue)) {
+        function Connect-MgGraph { }
+    }
+    if (-not (Get-Command Disconnect-MgGraph -ErrorAction SilentlyContinue)) {
+        function Disconnect-MgGraph { }
+    }
+    if (-not (Get-Command Format-HydrationDisplayMessage -ErrorAction SilentlyContinue)) {
+        function Format-HydrationDisplayMessage {
+            param([string]$Message)
+            return $Message
+        }
+    }
+}
+
+Describe 'Browser authentication helpers' {
+    Context 'ConvertTo-HydrationOAuthScope' {
+        It 'Should prefix bare Graph scopes with the selected Graph endpoint' {
+            $result = ConvertTo-HydrationOAuthScope `
+                -Scopes @('User.Read', 'DeviceManagementConfiguration.ReadWrite.All') `
+                -GraphEndpoint 'https://graph.microsoft.us'
+
+            $result | Should -Contain 'https://graph.microsoft.us/User.Read'
+            $result | Should -Contain 'https://graph.microsoft.us/DeviceManagementConfiguration.ReadWrite.All'
+        }
+
+        It 'Should preserve fully qualified and OIDC scopes' {
+            $result = ConvertTo-HydrationOAuthScope `
+                -Scopes @('https://graph.microsoft.com/User.Read', 'openid', 'profile') `
+                -GraphEndpoint 'https://graph.microsoft.com'
+
+            $result | Should -Contain 'https://graph.microsoft.com/User.Read'
+            $result | Should -Contain 'openid'
+            $result | Should -Contain 'profile'
+        }
+
+        It 'Should not add refresh-token scopes implicitly' {
+            $result = ConvertTo-HydrationOAuthScope `
+                -Scopes @('User.Read') `
+                -GraphEndpoint 'https://graph.microsoft.com'
+
+            $result | Should -Not -Contain 'offline_access'
+        }
+    }
+
+    Context 'Get-HydrationGraphEnvironmentInfo' {
+        It 'Should include the US Gov authority host' {
+            $result = Get-HydrationGraphEnvironmentInfo -Environment USGov
+
+            $result.Endpoint | Should -Be 'https://graph.microsoft.us'
+            $result.AuthorityHost | Should -Be 'https://login.microsoftonline.us'
+        }
+
+        It 'Should include the China authority host' {
+            $result = Get-HydrationGraphEnvironmentInfo -Environment China
+
+            $result.Endpoint | Should -Be 'https://microsoftgraph.chinacloudapi.cn'
+            $result.AuthorityHost | Should -Be 'https://login.chinacloudapi.cn'
+        }
+    }
+
+    Context 'New-HydrationBrowserAuthResponseHtml' {
+        It 'Should render themed success HTML with the IHD logo' {
+            $html = New-HydrationBrowserAuthResponseHtml -Status Success
+
+            $html | Should -Match 'Intune Hydration Kit'
+            $html | Should -Match 'Authentication complete'
+            $html | Should -Match 'data:image/png;base64,'
+            $html | Should -Not -Match '\{\{TITLE\}\}'
+        }
+
+        It 'Should HTML-encode error messages' {
+            $html = New-HydrationBrowserAuthResponseHtml -Status Error -Message '<script>alert(1)</script>'
+
+            $html | Should -Match '&lt;script&gt;alert\(1\)&lt;/script&gt;'
+            $html | Should -Not -Match '<script>alert'
+        }
+    }
+
+    Context 'Get-HydrationOAuthCallbackResult' {
+        It 'Should reject callbacks with mismatched OAuth state before reporting success' {
+            $result = Get-HydrationOAuthCallbackResult `
+                -Code 'fake-code' `
+                -AuthError '' `
+                -ErrorDescription '' `
+                -ReturnedState 'wrong-state' `
+                -ExpectedState 'expected-state'
+
+            $result.Status | Should -Be 'Error'
+            $result.Message | Should -Match 'OAuth state mismatch'
+            $result.ErrorMessage | Should -Be 'OAuth state mismatch. Aborting authentication.'
+        }
+
+        It 'Should accept callbacks with a code and matching OAuth state' {
+            $result = Get-HydrationOAuthCallbackResult `
+                -Code 'fake-code' `
+                -AuthError '' `
+                -ErrorDescription '' `
+                -ReturnedState 'expected-state' `
+                -ExpectedState 'expected-state'
+
+            $result.Status | Should -Be 'Success'
+            $result.ErrorMessage | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Connect-HydrationGraphViaBrowser' {
+        BeforeEach {
+            Mock Get-HydrationGraphEnvironmentInfo {
+                @{
+                    Endpoint      = 'https://graph.microsoft.com'
+                    AuthorityHost = 'https://login.microsoftonline.com'
+                }
+            }
+            Mock ConvertTo-HydrationOAuthScope { @('https://graph.microsoft.com/User.Read') }
+            Mock Disconnect-MgGraph { }
+        }
+
+        It 'Should retry with a fresh browser sign-in when token connection fails' {
+            $script:ConnectAttempts = 0
+
+            Mock Get-HydrationTokenViaBrowser { [pscustomobject]@{ access_token = 'browser-access' } }
+            Mock Connect-MgGraph {
+                $script:ConnectAttempts++
+                if ($script:ConnectAttempts -eq 1) {
+                    throw 'browser token rejected'
+                }
+            }
+
+            Connect-HydrationGraphViaBrowser -TenantId '12345678-1234-1234-1234-123456789abc' -Scopes @('User.Read') -Environment Global
+
+            Should -Invoke Get-HydrationTokenViaBrowser -Times 2
+            Should -Invoke Connect-MgGraph -Times 2
+            Should -Invoke Disconnect-MgGraph -Times 2
+        }
+
+        It 'Should not retry indefinitely when fresh browser token connection fails' {
+            Mock Get-HydrationTokenViaBrowser { [pscustomobject]@{ access_token = 'browser-access' } }
+            Mock Connect-MgGraph { throw 'browser token rejected' }
+
+            {
+                Connect-HydrationGraphViaBrowser -TenantId '12345678-1234-1234-1234-123456789abc' -Scopes @('User.Read') -Environment Global
+            } | Should -Throw
+
+            Should -Invoke Get-HydrationTokenViaBrowser -Times 2
+            Should -Invoke Connect-MgGraph -Times 2
+            Should -Invoke Disconnect-MgGraph -Times 2
+        }
+    }
+}

--- a/Tests/Private/Get-FilteredTemplates.Tests.ps1
+++ b/Tests/Private/Get-FilteredTemplates.Tests.ps1
@@ -286,6 +286,22 @@ Describe 'Get-FilteredTemplates' {
             $result | Should -HaveCount 1
             $result.Name | Should -Be 'AppProtection.json'
         }
+
+        It 'Should match nested platform directories' {
+            $mockTemplates = @(
+                New-MockFileInfo -Name 'CompanyPortal.json' -DirectoryName "$script:TestBasePath/Windows/Store"
+                New-MockFileInfo -Name 'M365Apps.json' -DirectoryName "$script:TestBasePath/Windows/M365"
+                New-MockFileInfo -Name 'MicrosoftEdge.json' -DirectoryName "$script:TestBasePath/macOS"
+            )
+
+            Mock Get-HydrationTemplates { return $mockTemplates }
+
+            $result = Get-FilteredTemplates -Path $script:TestBasePath -Platform 'Windows' -FilterMode 'Directory'
+
+            $result | Should -HaveCount 2
+            $result.Name | Should -Contain 'CompanyPortal.json'
+            $result.Name | Should -Contain 'M365Apps.json'
+        }
     }
 
     Context 'When using Folder filter mode (OpenIntuneBaseline structure)' {

--- a/Tests/Private/Get-HydrationMobileAppNameVariant.Tests.ps1
+++ b/Tests/Private/Get-HydrationMobileAppNameVariant.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..'
+    Get-Module -Name IntuneHydrationKit | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $moduleRoot 'IntuneHydrationKit.psd1') -Force
+}
+
+Describe 'Get-HydrationMobileAppNameVariant' {
+    It 'Should return current, raw, and legacy-prefixed variants for template names' {
+        InModuleScope IntuneHydrationKit {
+            $result = Get-HydrationMobileAppNameVariant -DisplayName 'Company Portal'
+
+            $result | Should -Contain 'Company Portal - [IHD]'
+            $result | Should -Contain 'Company Portal'
+            $result | Should -Contain '[IHD] Company Portal'
+        }
+    }
+
+    It 'Should normalize legacy-prefixed app names back to the raw template name' {
+        InModuleScope IntuneHydrationKit {
+            $result = Get-HydrationMobileAppNameVariant -DisplayName '[IHD] Company Portal'
+
+            $result | Should -Contain 'Company Portal'
+            $result | Should -Contain '[IHD] Company Portal'
+            $result | Should -Contain 'Company Portal - [IHD]'
+            $result | Should -Not -Contain '[IHD] Company Portal - [IHD]'
+        }
+    }
+
+    It 'Should normalize current suffixed app names back to the raw template name' {
+        InModuleScope IntuneHydrationKit {
+            $result = Get-HydrationMobileAppNameVariant -DisplayName 'Company Portal - [IHD]'
+
+            $result | Should -Contain 'Company Portal'
+            $result | Should -Contain 'Company Portal - [IHD]'
+        }
+    }
+}

--- a/Tests/Private/Get-HydrationMobileAppNameVariant.Tests.ps1
+++ b/Tests/Private/Get-HydrationMobileAppNameVariant.Tests.ps1
@@ -6,6 +6,42 @@ BeforeAll {
     Import-Module (Join-Path $moduleRoot 'IntuneHydrationKit.psd1') -Force
 }
 
+Describe 'Get-HydrationMobileAppBaseName' {
+    It 'Should normalize raw, legacy-prefixed, and current suffixed names to the same base name' {
+        InModuleScope IntuneHydrationKit {
+            Get-HydrationMobileAppBaseName -DisplayName 'Company Portal' |
+                Should -Be 'Company Portal'
+            Get-HydrationMobileAppBaseName -DisplayName '[IHD] Company Portal' |
+                Should -Be 'Company Portal'
+            Get-HydrationMobileAppBaseName -DisplayName 'Company Portal - [IHD]' |
+                Should -Be 'Company Portal'
+        }
+    }
+}
+
+Describe 'Get-HydrationMobileAppDisplayName' {
+    It 'Should append the app-name-first suffix to raw template names' {
+        InModuleScope IntuneHydrationKit {
+            Get-HydrationMobileAppDisplayName -DisplayName 'Company Portal' |
+                Should -Be 'Company Portal - [IHD]'
+        }
+    }
+
+    It 'Should normalize legacy-prefixed template names to the app-name-first suffix' {
+        InModuleScope IntuneHydrationKit {
+            Get-HydrationMobileAppDisplayName -DisplayName '[IHD] Company Portal' |
+                Should -Be 'Company Portal - [IHD]'
+        }
+    }
+
+    It 'Should not duplicate the app-name-first suffix' {
+        InModuleScope IntuneHydrationKit {
+            Get-HydrationMobileAppDisplayName -DisplayName 'Company Portal - [IHD]' |
+                Should -Be 'Company Portal - [IHD]'
+        }
+    }
+}
+
 Describe 'Get-HydrationMobileAppNameVariant' {
     It 'Should return current, raw, and legacy-prefixed variants for template names' {
         InModuleScope IntuneHydrationKit {

--- a/Tests/Private/Get-MobileAppTemplateNameSet.Tests.ps1
+++ b/Tests/Private/Get-MobileAppTemplateNameSet.Tests.ps1
@@ -29,6 +29,8 @@ Describe 'Get-MobileAppTemplateNameSet' {
             $result = Get-MobileAppTemplateNameSet -TemplateFiles $TemplateFiles
 
             $result | Should -Contain 'Company Portal - [IHD]'
+            $result | Should -Contain 'Company Portal'
+            $result | Should -Contain '[IHD] Company Portal'
             $result | Should -Contain 'WhatsApp - [IHD]'
         }
     }

--- a/Tests/Private/HydrationMobileAppNameMatching.Tests.ps1
+++ b/Tests/Private/HydrationMobileAppNameMatching.Tests.ps1
@@ -1,0 +1,74 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..'
+    Get-Module -Name IntuneHydrationKit | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $moduleRoot 'IntuneHydrationKit.psd1') -Force
+}
+
+Describe 'Hydration mobile app name matching' {
+    It 'Should find tagged existing apps by current suffix name' {
+        InModuleScope IntuneHydrationKit {
+            $existingApps = @{
+                'Company Portal - [IHD]' = @{ Id = 'app-id'; IsTagged = $true }
+            }
+
+            Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps -DisplayName 'Company Portal' |
+                Should -Be 'Company Portal - [IHD]'
+        }
+    }
+
+    It 'Should find tagged existing apps by legacy prefixed name' {
+        InModuleScope IntuneHydrationKit {
+            $existingApps = @{
+                '[IHD] Company Portal' = @{ Id = 'app-id'; IsTagged = $true }
+            }
+
+            Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps -DisplayName 'Company Portal' |
+                Should -Be '[IHD] Company Portal'
+        }
+    }
+
+    It 'Should ignore untagged existing apps' {
+        InModuleScope IntuneHydrationKit {
+            $existingApps = @{
+                'Company Portal - [IHD]' = @{ Id = 'app-id'; IsTagged = $false }
+            }
+
+            Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps -DisplayName 'Company Portal' |
+                Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Should find owned WinGet apps using the ownership property selector' {
+        InModuleScope IntuneHydrationKit {
+            $existingApps = @{
+                '[IHD] Company Portal' = [pscustomobject]@{ Id = 'app-id'; IsOwned = $true }
+            }
+
+            Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps -DisplayName 'Company Portal' -OwnershipProperty IsOwned |
+                Should -Be '[IHD] Company Portal'
+        }
+    }
+
+    It 'Should fail closed when the selected ownership property is missing' {
+        InModuleScope IntuneHydrationKit {
+            $existingApps = @{
+                'Company Portal - [IHD]' = [pscustomobject]@{ Id = 'app-id'; IsTagged = $true }
+            }
+
+            Get-HydrationMobileAppExistingMatch -ExistingApps $existingApps -DisplayName 'Company Portal' -OwnershipProperty IsOwned |
+                Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Should match any supported name variant in a template name set' {
+        InModuleScope IntuneHydrationKit {
+            $nameSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            [void]$nameSet.Add('Company Portal - [IHD]')
+
+            Test-HydrationMobileAppNameInSet -DisplayName '[IHD] Company Portal' -NameSet $nameSet |
+                Should -BeTrue
+        }
+    }
+}

--- a/Tests/Private/Invoke-GroupBatchImport.Tests.ps1
+++ b/Tests/Private/Invoke-GroupBatchImport.Tests.ps1
@@ -10,6 +10,7 @@ BeforeAll {
     $getGraphStatusCodePath = Join-Path $PSScriptRoot '..\..\Private\Graph\Get-GraphStatusCode.ps1'
     $testHydrationKitObjectPath = Join-Path $PSScriptRoot '..\..\Private\Hydration\Test-HydrationKitObject.ps1'
     $getGraphPagedResultsPath = Join-Path $PSScriptRoot '..\..\Private\Graph\Get-GraphPagedResults.ps1'
+    $getHydrationGraphEnvironmentInfoPath = Join-Path $PSScriptRoot '..\..\Private\Auth\Get-HydrationGraphEnvironmentInfo.ps1'
     . $functionPath
     . $newHydrationResultPath
     . $getHydrationMarkerSetPath
@@ -18,6 +19,7 @@ BeforeAll {
     . $getGraphErrorMessagePath
     . $testHydrationKitObjectPath
     . $getGraphPagedResultsPath
+    . $getHydrationGraphEnvironmentInfoPath
 }
 
 Describe 'Invoke-GroupBatchImport' {
@@ -284,6 +286,35 @@ Describe 'Invoke-GroupBatchImport' {
             Invoke-GroupBatchImport -GroupDefinitions $script:spOwnerGroupDefs -GroupType 'Static'
 
             Should -Invoke Invoke-MgGraphRequest -ParameterFilter { $Method -eq 'POST' -and $Uri -eq 'v1.0/servicePrincipals' } -Times 1
+        }
+
+        It 'Should use canonical Graph environment endpoint for owner references' {
+            Mock Get-MgContext {
+                return @{
+                    Environment = 'USGovDoD'
+                    TenantId    = '00000000-0000-0000-0000-000000000000'
+                }
+            }
+            Mock Invoke-MgGraphRequest -ParameterFilter { $Method -eq 'POST' -and $Uri -like '*$batch*' } {
+                return @{ responses = @(@{ id = '1'; status = 200; body = @{ value = @() } }) }
+            }
+            Mock Invoke-MgGraphRequest -ParameterFilter { $Method -eq 'GET' -and $Uri -like '*servicePrincipals*' } {
+                return @{ value = @(@{ id = 'sp-id-123' }) }
+            }
+            Mock Invoke-MgGraphRequest -ParameterFilter { $Method -eq 'POST' -and $Uri -eq 'v1.0/groups' } {
+                return @{ id = 'new-group-id'; displayName = 'Windows Autopilot device preparation' }
+            }
+            Mock Invoke-MgGraphRequest -ParameterFilter { $Method -eq 'POST' -and $Uri -like '*owners*' } {
+                return @{}
+            }
+
+            Invoke-GroupBatchImport -GroupDefinitions $script:spOwnerGroupDefs -GroupType 'Static'
+
+            Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+                $Method -eq 'POST' -and
+                $Uri -like '*owners*' -and
+                $Body.'@odata.id' -eq 'https://dod-graph.microsoft.us/v1.0/servicePrincipals/sp-id-123'
+            } -Times 1
         }
     }
 

--- a/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
+++ b/Tests/Private/Sync-IntuneWinGetProactiveRemediation.Tests.ps1
@@ -365,4 +365,41 @@ Describe 'Sync-IntuneWinGetProactiveRemediation' {
         $script:deletedRemediationUris | Should -Contain 'beta/deviceManagement/deviceHealthScripts/system-id'
         $script:deletedRemediationUris | Should -Contain 'beta/deviceManagement/deviceHealthScripts/user-id'
     }
+
+    It 'Should return failed remediation results instead of throwing when delete is unauthorized' {
+        Mock Invoke-HydrationGraphRequest {
+            param($Method, $Uri)
+
+            switch ($Method) {
+                'GET' {
+                    if ($Uri -like '*System*') {
+                        return @{
+                            value = @(
+                                @{
+                                    id          = 'system-id'
+                                    displayName = 'WinGet App Updates (System)'
+                                    description = "Imported by Intune Hydration Kit`nImported from WinGet`nWinGetRemediationScope: system"
+                                }
+                            )
+                        }
+                    }
+
+                    return @{ value = @() }
+                }
+                'DELETE' {
+                    throw 'HTTP/2.0 403 Forbidden {"error":{"code":"UnknownError","message":"User is not authorized to perform this operation"}}'
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+
+        $result = & $script:TestModule {
+            param([object[]]$Templates)
+            Sync-IntuneWinGetProactiveRemediation -Templates $Templates -RemoveExisting
+        } $script:testTemplates
+
+        $result | Should -HaveCount 1
+        $result[0].Action | Should -Be 'Failed'
+        $result[0].Type | Should -Be 'WinGetRemediation'
+        $result[0].Status | Should -Match '403|not authorized|UnknownError'
+    }
 }

--- a/Tests/Public/Connect-IntuneHydration.Tests.ps1
+++ b/Tests/Public/Connect-IntuneHydration.Tests.ps1
@@ -101,8 +101,8 @@ Describe 'Connect-IntuneHydration' {
 
     Context 'Graph Environment Mapping' {
         BeforeAll {
-            # Mock Connect-MgGraph to prevent actual connections
-            Mock Connect-MgGraph { } -ModuleName IntuneHydrationKit
+            # Mock browser auth to prevent actual connections
+            Mock Connect-HydrationGraphViaBrowser { } -ModuleName IntuneHydrationKit
             Mock Get-ObfuscatedTenantId { return '12345678****-****-****-123456789abc' } -ModuleName IntuneHydrationKit
         }
 
@@ -139,14 +139,14 @@ Describe 'Connect-IntuneHydration' {
 
     Context 'Interactive Authentication' {
         BeforeAll {
-            Mock Connect-MgGraph { } -ModuleName IntuneHydrationKit
+            Mock Connect-HydrationGraphViaBrowser { } -ModuleName IntuneHydrationKit
             Mock Get-ObfuscatedTenantId { return '12345678****-****-****-123456789abc' } -ModuleName IntuneHydrationKit
         }
 
-        It 'Should call Connect-MgGraph with scopes for interactive auth' {
+        It 'Should call browser auth with scopes for interactive auth' {
             Connect-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive
 
-            Should -Invoke Connect-MgGraph -ModuleName IntuneHydrationKit -ParameterFilter {
+            Should -Invoke Connect-HydrationGraphViaBrowser -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Scopes -ne $null -and $Scopes.Count -gt 0
             }
         }
@@ -199,15 +199,15 @@ Describe 'Connect-IntuneHydration' {
     }
 
     Context 'Error Handling' {
-        It 'Should throw when Connect-MgGraph fails' {
-            Mock Connect-MgGraph { throw 'Connection failed' } -ModuleName IntuneHydrationKit
+        It 'Should throw when browser auth fails' {
+            Mock Connect-HydrationGraphViaBrowser { throw 'Connection failed' } -ModuleName IntuneHydrationKit
 
             { Connect-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive } |
                 Should -Throw
         }
 
         It 'Should not update HydrationState when connection fails' {
-            Mock Connect-MgGraph { throw 'Connection failed' } -ModuleName IntuneHydrationKit
+            Mock Connect-HydrationGraphViaBrowser { throw 'Connection failed' } -ModuleName IntuneHydrationKit
 
             try {
                 Connect-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive
@@ -222,14 +222,14 @@ Describe 'Connect-IntuneHydration' {
 
     Context 'Required Scopes' {
         BeforeAll {
-            Mock Connect-MgGraph { } -ModuleName IntuneHydrationKit
+            Mock Connect-HydrationGraphViaBrowser { } -ModuleName IntuneHydrationKit
             Mock Get-ObfuscatedTenantId { return '12345678****-****-****-123456789abc' } -ModuleName IntuneHydrationKit
         }
 
         It 'Should request DeviceManagementConfiguration.ReadWrite.All scope' {
             Connect-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive
 
-            Should -Invoke Connect-MgGraph -ModuleName IntuneHydrationKit -ParameterFilter {
+            Should -Invoke Connect-HydrationGraphViaBrowser -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Scopes -contains 'DeviceManagementConfiguration.ReadWrite.All'
             }
         }
@@ -237,7 +237,7 @@ Describe 'Connect-IntuneHydration' {
         It 'Should request Group.ReadWrite.All scope' {
             Connect-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive
 
-            Should -Invoke Connect-MgGraph -ModuleName IntuneHydrationKit -ParameterFilter {
+            Should -Invoke Connect-HydrationGraphViaBrowser -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Scopes -contains 'Group.ReadWrite.All'
             }
         }
@@ -245,7 +245,7 @@ Describe 'Connect-IntuneHydration' {
         It 'Should request Policy.ReadWrite.ConditionalAccess scope' {
             Connect-IntuneHydration -TenantId '12345678-1234-1234-1234-123456789abc' -Interactive
 
-            Should -Invoke Connect-MgGraph -ModuleName IntuneHydrationKit -ParameterFilter {
+            Should -Invoke Connect-HydrationGraphViaBrowser -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Scopes -contains 'Policy.ReadWrite.ConditionalAccess'
             }
         }

--- a/Tests/Public/Import-IntuneMobileApp.Tests.ps1
+++ b/Tests/Public/Import-IntuneMobileApp.Tests.ps1
@@ -21,16 +21,82 @@ BeforeAll {
         New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
 
         foreach ($template in $Templates) {
-            $fileName = if ($template.displayName) {
+            $relativePath = if ($template -is [hashtable] -and $template.ContainsKey('RelativePath')) {
+                [string]$template.RelativePath
+            } elseif ($template.PSObject.Properties['RelativePath']) {
+                [string]$template.RelativePath
+            } else {
+                $null
+            }
+            $fileName = if ($relativePath) {
+                $relativePath
+            } elseif ($template.displayName) {
                 "$($template.displayName -replace '[^a-zA-Z0-9]', '-').json"
             } else {
                 "template-$(Get-Random).json"
             }
             $filePath = Join-Path $tempDir $fileName
-            $template | ConvertTo-Json -Depth 10 | Set-Content -Path $filePath -Encoding UTF8
+            $fileDirectory = Split-Path -Path $filePath -Parent
+            if (-not (Test-Path -Path $fileDirectory)) {
+                New-Item -Path $fileDirectory -ItemType Directory -Force | Out-Null
+            }
+
+            $templateBody = [ordered]@{}
+            if ($template -is [hashtable]) {
+                foreach ($key in $template.Keys) {
+                    if ($key -ne 'RelativePath') {
+                        $templateBody[$key] = $template[$key]
+                    }
+                }
+            } else {
+                foreach ($property in $template.PSObject.Properties) {
+                    if ($property.Name -ne 'RelativePath') {
+                        $templateBody[$property.Name] = $property.Value
+                    }
+                }
+            }
+            $templateBody | ConvertTo-Json -Depth 10 | Set-Content -Path $filePath -Encoding UTF8
         }
 
         return $tempDir
+    }
+
+    function New-TestExistingMobileApp {
+        param(
+            [Parameter()]
+            [string]$Id = 'existing-id',
+
+            [Parameter()]
+            [string]$DisplayName = 'Existing App - [IHD]',
+
+            [Parameter()]
+            [AllowNull()]
+            [string]$Notes = 'Imported by Intune Hydration Kit'
+        )
+
+        @{
+            id          = $Id
+            displayName = $DisplayName
+            notes       = $Notes
+        }
+    }
+
+    function Set-TestExistingMobileAppsMock {
+        param(
+            [Parameter(Mandatory)]
+            [object[]]$Apps
+        )
+
+        $script:testExistingMobileApps = @($Apps)
+        Mock Invoke-MgGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @($script:testExistingMobileApps)
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
     }
 }
 
@@ -86,12 +152,8 @@ Describe 'Import-IntuneMobileApp' {
             $emptyDir = Join-Path ([System.IO.Path]::GetTempPath()) "EmptyMobileAppsTest-$(Get-Random)"
             New-Item -Path $emptyDir -ItemType Directory -Force | Out-Null
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $emptyDir
-                $result | Should -BeNullOrEmpty
-            } finally {
-                Remove-Item -Path $emptyDir -Force -ErrorAction SilentlyContinue
-            }
+            $result = Import-IntuneMobileApp -TemplatePath $emptyDir
+            $result | Should -BeNullOrEmpty
         }
 
         It 'Should warn when no mobile app templates match requested template IDs' {
@@ -103,15 +165,42 @@ Describe 'Import-IntuneMobileApp' {
                 }
             )
 
-            try {
-                $warnings = @()
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -TemplateId 'DoesNotExist' -WarningVariable warnings -WarningAction SilentlyContinue
+            $warnings = @()
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -TemplateId 'DoesNotExist' -WarningVariable warnings -WarningAction SilentlyContinue
 
-                $result | Should -BeNullOrEmpty
-                $warnings[0].Message | Should -Be 'No mobile app templates matched TemplateId value(s): DoesNotExist'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -BeNullOrEmpty
+            $warnings[0].Message | Should -Be 'No mobile app templates matched TemplateId value(s): DoesNotExist'
+        }
+
+        It 'Should match legacy Windows mobile app TemplateIds in nested platform directories' {
+            Mock Invoke-MgGraphRequest {
+                param($Method)
+                if ($Method -eq 'GET') {
+                    return @{ value = @(); '@odata.nextLink' = $null }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $tempDir = New-TestTemplateDirectory -Templates @(
+                @{ RelativePath = 'Windows/Store/AdobeAcrobatReaderDC.json'; '@odata.type' = '#microsoft.graph.winGetApp'; displayName = 'Adobe Acrobat Reader DC'; publisher = 'Test Publisher' }
+                @{ RelativePath = 'Windows/Store/CompanyPortal.json'; '@odata.type' = '#microsoft.graph.winGetApp'; displayName = 'Company Portal'; publisher = 'Test Publisher' }
+                @{ RelativePath = 'Windows/Store/PowerShell.json'; '@odata.type' = '#microsoft.graph.winGetApp'; displayName = 'PowerShell'; publisher = 'Test Publisher' }
+                @{ RelativePath = 'Windows/Store/Spotify-MusicandPodcasts.json'; '@odata.type' = '#microsoft.graph.winGetApp'; displayName = 'Spotify Music and Podcasts'; publisher = 'Test Publisher' }
+                @{ RelativePath = 'Windows/Store/WhatsApp.json'; '@odata.type' = '#microsoft.graph.winGetApp'; displayName = 'WhatsApp'; publisher = 'Test Publisher' }
+                @{ RelativePath = 'Windows/M365/M365Apps.json'; '@odata.type' = '#microsoft.graph.officeSuiteApp'; displayName = 'M365 Apps'; publisher = 'Microsoft' }
+            )
+
+            $warnings = @()
+            $result = Import-IntuneMobileApp `
+                -TemplatePath $tempDir `
+                -Platform Windows `
+                -TemplateId @('AdobeAcrobatReaderDC', 'CompanyPortal', 'PowerShell', 'SpotifyMusicAndPodcasts', 'WhatsApp', 'M365Apps') `
+                -WhatIf `
+                -WarningVariable warnings `
+                -WarningAction SilentlyContinue
+
+            $warnings | Should -BeNullOrEmpty
+            $result | Should -HaveCount 6
+            @($result | Where-Object { $_.Action -ne 'WouldCreate' }) | Should -BeNullOrEmpty
         }
     }
 
@@ -146,15 +235,11 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Created'
-                $result[0].Name | Should -Be '[IHD] Test WinGet App'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Created'
+            $result[0].Name | Should -Be 'Test WinGet App - [IHD]'
         }
 
         It 'Should ignore WinGet catalog JSON files in the generic mobile app importer' {
@@ -182,44 +267,40 @@ Describe 'Import-IntuneMobileApp' {
                 }
             )
 
-            try {
-                $winGetAppPath = Join-Path $tempDir 'Windows/WinGet/Apps'
-                $winGetPresetPath = Join-Path $tempDir 'Windows/WinGet/Presets'
-                $winGetSchemaPath = Join-Path $tempDir 'Windows/WinGet/Schemas'
-                New-Item -Path $winGetAppPath, $winGetPresetPath, $winGetSchemaPath -ItemType Directory -Force | Out-Null
+            $winGetAppPath = Join-Path $tempDir 'Windows/WinGet/Apps'
+            $winGetPresetPath = Join-Path $tempDir 'Windows/WinGet/Presets'
+            $winGetSchemaPath = Join-Path $tempDir 'Windows/WinGet/Schemas'
+            New-Item -Path $winGetAppPath, $winGetPresetPath, $winGetSchemaPath -ItemType Directory -Force | Out-Null
 
-                @{
-                    '$schema'          = '../Schemas/winGetAppTemplate.schema.json'
-                    schemaVersion      = '1.0.0'
-                    templateId         = 'catalog-app'
-                    displayName        = 'Catalog App'
-                    packageIdentifier  = 'Vendor.CatalogApp'
-                    package            = @{ match = @{ packageIdentifier = 'Vendor.CatalogApp' } }
-                    install            = @{ command = 'winget install --id Vendor.CatalogApp --silent' }
-                    icon               = @{ sourceType = 'file'; fileName = 'catalog.png' }
-                    resolvedPackage    = @{ selectedInstaller = @{}; manifestSource = @{ repository = 'microsoft/winget-pkgs' } }
-                } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $winGetAppPath 'catalog-app.json') -Encoding UTF8
-                @{
-                    '$schema'     = '../Schemas/winGetAppPreset.schema.json'
-                    schemaVersion = '1.0.0'
-                    presetId      = 'catalog-preset'
-                    displayName   = 'Catalog Preset'
-                    appIds        = @('catalog-app')
-                } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $winGetPresetPath 'catalog-preset.json') -Encoding UTF8
-                @{ '$schema' = 'https://json-schema.org/draft/2020-12/schema'; type = 'object' } |
-                    ConvertTo-Json -Depth 10 |
-                    Set-Content -Path (Join-Path $winGetSchemaPath 'catalog.schema.json') -Encoding UTF8
+            @{
+                '$schema'         = '../Schemas/winGetAppTemplate.schema.json'
+                schemaVersion     = '1.0.0'
+                templateId        = 'catalog-app'
+                displayName       = 'Catalog App'
+                packageIdentifier = 'Vendor.CatalogApp'
+                package           = @{ match = @{ packageIdentifier = 'Vendor.CatalogApp' } }
+                install           = @{ command = 'winget install --id Vendor.CatalogApp --silent' }
+                icon              = @{ sourceType = 'file'; fileName = 'catalog.png' }
+                resolvedPackage   = @{ selectedInstaller = @{}; manifestSource = @{ repository = 'microsoft/winget-pkgs' } }
+            } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $winGetAppPath 'catalog-app.json') -Encoding UTF8
+            @{
+                '$schema'     = '../Schemas/winGetAppPreset.schema.json'
+                schemaVersion = '1.0.0'
+                presetId      = 'catalog-preset'
+                displayName   = 'Catalog Preset'
+                appIds        = @('catalog-app')
+            } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $winGetPresetPath 'catalog-preset.json') -Encoding UTF8
+            @{ '$schema' = 'https://json-schema.org/draft/2020-12/schema'; type = 'object' } |
+                ConvertTo-Json -Depth 10 |
+                Set-Content -Path (Join-Path $winGetSchemaPath 'catalog.schema.json') -Encoding UTF8
 
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Created'
-                $result[0].Name | Should -Be '[IHD] Legacy Mobile App'
-                $script:capturedBatchBody.requests | Should -HaveCount 1
-                $script:capturedBatchBody.requests[0].body.displayName | Should -Be '[IHD] Legacy Mobile App'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Created'
+            $result[0].Name | Should -Be 'Legacy Mobile App - [IHD]'
+            $script:capturedBatchBody.requests | Should -HaveCount 1
+            $script:capturedBatchBody.requests[0].body.displayName | Should -Be 'Legacy Mobile App - [IHD]'
         }
 
         It 'Should filter legacy mobile app templates by template ID' {
@@ -252,31 +333,16 @@ Describe 'Import-IntuneMobileApp' {
                 }
             )
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -TemplateId 'SpotifyMusicAndPodcasts'
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -TemplateId 'SpotifyMusicAndPodcasts'
 
-                $result | Should -HaveCount 1
-                $result[0].Name | Should -Be '[IHD] Spotify Music and Podcasts'
-                $script:capturedBatchBody.requests | Should -HaveCount 1
-                $script:capturedBatchBody.requests[0].body.displayName | Should -Be '[IHD] Spotify Music and Podcasts'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Name | Should -Be 'Spotify Music and Podcasts - [IHD]'
+            $script:capturedBatchBody.requests | Should -HaveCount 1
+            $script:capturedBatchBody.requests[0].body.displayName | Should -Be 'Spotify Music and Podcasts - [IHD]'
         }
 
         It 'Should skip apps that already exist with hydration kit tag' {
-            # Mock existing app with hydration kit tag
-            Mock Invoke-MgGraphRequest {
-                param($Method)
-                if ($Method -eq 'GET') {
-                    return @{
-                        value             = @(
-                            @{ id = 'existing-id'; displayName = '[IHD] Existing App'; notes = 'Imported by Intune Hydration Kit' }
-                        )
-                        '@odata.nextLink' = $null
-                    }
-                }
-            } -ModuleName IntuneHydrationKit
+            Set-TestExistingMobileAppsMock -Apps @(New-TestExistingMobileApp)
 
             $templates = @(
                 @{
@@ -287,15 +353,33 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Skipped'
-                $result[0].Status | Should -Be 'Already exists'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Skipped'
+            $result[0].Status | Should -Be 'Already exists'
+        }
+
+        It 'Should skip legacy prefixed apps that already exist with hydration kit tag' {
+            Set-TestExistingMobileAppsMock -Apps @(
+                New-TestExistingMobileApp -Id 'legacy-prefixed-id' -DisplayName '[IHD] Existing App'
+            )
+
+            $templates = @(
+                @{
+                    '@odata.type' = '#microsoft.graph.winGetApp'
+                    displayName   = 'Existing App'
+                    publisher     = 'Test Publisher'
+                }
+            )
+            $tempDir = New-TestTemplateDirectory -Templates $templates
+
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
+
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Skipped'
+            $result[0].Name | Should -Be 'Existing App - [IHD]'
+            $result[0].Id | Should -Be 'legacy-prefixed-id'
         }
 
         It 'Should create app when existing app lacks hydration kit tag' {
@@ -329,16 +413,12 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Created'
-                $result[0].Name | Should -Be '[IHD] PowerShell'
-                $script:capturedBatchBody.requests[0].body.notes | Should -BeLike '*Imported by Intune Hydration Kit*'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Created'
+            $result[0].Name | Should -Be 'PowerShell - [IHD]'
+            $script:capturedBatchBody.requests[0].body.notes | Should -BeLike '*Imported by Intune Hydration Kit*'
         }
 
         It 'Should create app when existing app has null notes' {
@@ -372,15 +452,11 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Created'
-                $result[0].Name | Should -Be '[IHD] Slack'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Created'
+            $result[0].Name | Should -Be 'Slack - [IHD]'
         }
 
         It 'Should fail templates missing displayName' {
@@ -393,15 +469,11 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Failed'
-                $result[0].Status | Should -Be 'Missing displayName'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Failed'
+            $result[0].Status | Should -Be 'Missing displayName'
         }
 
         It 'Should add hydration kit marker to notes field' {
@@ -430,14 +502,10 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result[0].Action | Should -Be 'Created'
-                $script:capturedBatchBody.requests[0].body.notes | Should -BeLike '*Imported by Intune Hydration Kit*'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result[0].Action | Should -Be 'Created'
+            $script:capturedBatchBody.requests[0].body.notes | Should -BeLike '*Imported by Intune Hydration Kit*'
         }
 
         It 'Should preserve existing notes and append marker' {
@@ -467,15 +535,11 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result[0].Action | Should -Be 'Created'
-                $script:capturedBatchBody.requests[0].body.notes | Should -BeLike 'Existing notes here*'
-                $script:capturedBatchBody.requests[0].body.notes | Should -BeLike '*Imported by Intune Hydration Kit*'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result[0].Action | Should -Be 'Created'
+            $script:capturedBatchBody.requests[0].body.notes | Should -BeLike 'Existing notes here*'
+            $script:capturedBatchBody.requests[0].body.notes | Should -BeLike '*Imported by Intune Hydration Kit*'
         }
     }
 
@@ -518,35 +582,18 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
-                # Filter out null entries
-                $result = @($result | Where-Object { $_ -ne $null })
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
+            $result = @($result | Where-Object { $_ -ne $null })
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Deleted'
-                $result[0].Name | Should -Be 'Hydration Kit App'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Deleted'
+            $result[0].Name | Should -Be 'Hydration Kit App'
         }
 
         It 'Should skip apps without hydration kit marker' {
-            Mock Invoke-MgGraphRequest {
-                param($Method)
-                if ($Method -eq 'GET') {
-                    return @{
-                        value             = @(
-                            @{
-                                id          = 'manual-app'
-                                displayName = 'Manually Created App'
-                                notes       = 'Created manually by admin'
-                            }
-                        )
-                        '@odata.nextLink' = $null
-                    }
-                }
-            } -ModuleName IntuneHydrationKit
+            Set-TestExistingMobileAppsMock -Apps @(
+                New-TestExistingMobileApp -Id 'manual-app' -DisplayName 'Manually Created App' -Notes 'Created manually by admin'
+            )
 
             # Create a template file so the function doesn't exit early
             $templates = @(
@@ -558,31 +605,15 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
 
-                $result | Should -BeNullOrEmpty
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -BeNullOrEmpty
         }
 
         It 'Should skip apps with null notes' {
-            Mock Invoke-MgGraphRequest {
-                param($Method)
-                if ($Method -eq 'GET') {
-                    return @{
-                        value             = @(
-                            @{
-                                id          = 'app-no-notes'
-                                displayName = 'App Without Notes'
-                                notes       = $null
-                            }
-                        )
-                        '@odata.nextLink' = $null
-                    }
-                }
-            } -ModuleName IntuneHydrationKit
+            Set-TestExistingMobileAppsMock -Apps @(
+                New-TestExistingMobileApp -Id 'app-no-notes' -DisplayName 'App Without Notes' -Notes $null
+            )
 
             # Create a template file so the function doesn't exit early
             $templates = @(
@@ -594,13 +625,9 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
 
-                $result | Should -BeNullOrEmpty
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -BeNullOrEmpty
         }
     }
 
@@ -625,33 +652,17 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -WhatIf
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -WhatIf
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'WouldCreate'
-                $result[0].Status | Should -Be 'DryRun'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'WouldCreate'
+            $result[0].Status | Should -Be 'DryRun'
         }
 
         It 'Should return WouldDelete action in WhatIf mode for deletion' {
-            Mock Invoke-MgGraphRequest {
-                param($Method)
-                if ($Method -eq 'GET') {
-                    return @{
-                        value             = @(
-                            @{
-                                id          = 'app-id'
-                                displayName = 'App To Delete'
-                                notes       = 'Imported by Intune Hydration Kit'
-                            }
-                        )
-                        '@odata.nextLink' = $null
-                    }
-                }
-            } -ModuleName IntuneHydrationKit
+            Set-TestExistingMobileAppsMock -Apps @(
+                New-TestExistingMobileApp -Id 'app-id' -DisplayName 'App To Delete'
+            )
 
             # Create a template file so the function doesn't exit early
             $templates = @(
@@ -663,15 +674,11 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting -WhatIf
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting -WhatIf
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'WouldDelete'
-                $result[0].Status | Should -Be 'DryRun'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'WouldDelete'
+            $result[0].Status | Should -Be 'DryRun'
         }
     }
 
@@ -705,14 +712,10 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Failed'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Failed'
         }
 
         It 'Should handle Graph API errors during deletion' {
@@ -749,15 +752,11 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir -RemoveExisting
 
-                $result | Should -HaveCount 1
-                $result[0].Action | Should -Be 'Failed'
-                $result[0].Status | Should -BeLike '*Delete failed*'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Failed'
+            $result[0].Status | Should -BeLike '*Delete failed*'
         }
     }
 
@@ -775,14 +774,14 @@ Describe 'Import-IntuneMobileApp' {
                     if ($script:pageCount -eq 1) {
                         return @{
                             value             = @(
-                                @{ id = 'app1'; displayName = '[IHD] App 1'; notes = 'Imported by Intune Hydration Kit' }
+                                @{ id = 'app1'; displayName = 'App 1 - [IHD]'; notes = 'Imported by Intune Hydration Kit' }
                             )
                             '@odata.nextLink' = 'https://graph.microsoft.com/beta/next-page'
                         }
                     } else {
                         return @{
                             value             = @(
-                                @{ id = 'app2'; displayName = '[IHD] App 2'; notes = 'Imported by Intune Hydration Kit' }
+                                @{ id = 'app2'; displayName = 'App 2 - [IHD]'; notes = 'Imported by Intune Hydration Kit' }
                             )
                             '@odata.nextLink' = $null
                         }
@@ -804,14 +803,9 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                # Both apps should be skipped since they exist
-                $result | Where-Object { $_.Action -eq 'Skipped' } | Should -HaveCount 2
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Where-Object { $_.Action -eq 'Skipped' } | Should -HaveCount 2
         }
     }
 
@@ -843,18 +837,14 @@ Describe 'Import-IntuneMobileApp' {
             )
             $tempDir = New-TestTemplateDirectory -Templates $templates
 
-            try {
-                $result = Import-IntuneMobileApp -TemplatePath $tempDir
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
 
-                $result | Should -HaveCount 1
-                $result[0].PSObject.Properties.Name | Should -Contain 'Name'
-                $result[0].PSObject.Properties.Name | Should -Contain 'Action'
-                $result[0].PSObject.Properties.Name | Should -Contain 'Status'
-                $result[0].PSObject.Properties.Name | Should -Contain 'Type'
-                $result[0].Type | Should -Be 'MobileApp'
-            } finally {
-                Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result | Should -HaveCount 1
+            $result[0].PSObject.Properties.Name | Should -Contain 'Name'
+            $result[0].PSObject.Properties.Name | Should -Contain 'Action'
+            $result[0].PSObject.Properties.Name | Should -Contain 'Status'
+            $result[0].PSObject.Properties.Name | Should -Contain 'Type'
+            $result[0].Type | Should -Be 'MobileApp'
         }
     }
 }

--- a/Tests/Public/Import-IntuneMobileApp.Tests.ps1
+++ b/Tests/Public/Import-IntuneMobileApp.Tests.ps1
@@ -102,8 +102,10 @@ BeforeAll {
 
 AfterAll {
     # Cleanup any temp directories
-    Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Directory -Filter "MobileAppsTest-*" |
-        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    foreach ($directoryFilter in @('MobileAppsTest-*', 'EmptyMobileAppsTest-*')) {
+        Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Directory -Filter $directoryFilter |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 
 Describe 'Import-IntuneMobileApp' {
@@ -240,6 +242,39 @@ Describe 'Import-IntuneMobileApp' {
             $result | Should -HaveCount 1
             $result[0].Action | Should -Be 'Created'
             $result[0].Name | Should -Be 'Test WinGet App - [IHD]'
+        }
+
+        It 'Should create legacy-prefixed template names with the suffix after the app name' {
+            $script:capturedBatchBody = $null
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body)
+                if ($Method -eq 'GET') {
+                    return @{ value = @(); '@odata.nextLink' = $null }
+                }
+                if ($Method -eq 'POST' -and $Uri -like '*$batch*') {
+                    $script:capturedBatchBody = $Body | ConvertFrom-Json
+                    return @{
+                        responses = @(
+                            @{ id = '1'; status = 201; body = @{ id = 'legacy-prefixed-app-id' } }
+                        )
+                    }
+                }
+            } -ModuleName IntuneHydrationKit
+
+            $tempDir = New-TestTemplateDirectory -Templates @(
+                [PSCustomObject]@{
+                    '@odata.type' = '#microsoft.graph.winGetApp'
+                    displayName   = '[IHD] Company Portal'
+                    publisher     = 'Microsoft'
+                }
+            )
+
+            $result = Import-IntuneMobileApp -TemplatePath $tempDir
+
+            $result | Should -HaveCount 1
+            $result[0].Action | Should -Be 'Created'
+            $result[0].Name | Should -Be 'Company Portal - [IHD]'
+            $script:capturedBatchBody.requests[0].body.displayName | Should -Be 'Company Portal - [IHD]'
         }
 
         It 'Should ignore WinGet catalog JSON files in the generic mobile app importer' {

--- a/Tests/Public/Import-IntuneWinGetApp.Tests.ps1
+++ b/Tests/Public/Import-IntuneWinGetApp.Tests.ps1
@@ -44,6 +44,44 @@ BeforeAll {
             }
         }
     }
+
+    function New-TestExistingWinGetApp {
+        param(
+            [Parameter()]
+            [string]$Id = 'existing-id',
+
+            [Parameter()]
+            [string]$DisplayName = 'Contoso App - [IHD]',
+
+            [Parameter()]
+            [string]$PackageIdentifier = 'Contoso.App'
+        )
+
+        @{
+            id          = $Id
+            displayName = $DisplayName
+            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
+            notes       = "Imported from WinGet`nWinGetPackageIdentifier: $PackageIdentifier"
+        }
+    }
+
+    function Set-TestExistingWinGetAppsMock {
+        param(
+            [Parameter(Mandatory)]
+            [object[]]$Apps
+        )
+
+        $script:testExistingWinGetApps = @($Apps)
+        Mock Invoke-HydrationGraphRequest {
+            param($Method)
+            if ($Method -eq 'GET') {
+                return @{
+                    value             = @($script:testExistingWinGetApps)
+                    '@odata.nextLink' = $null
+                }
+            }
+        } -ModuleName IntuneHydrationKit
+    }
 }
 
 Describe 'Import-IntuneWinGetApp' {
@@ -161,6 +199,7 @@ Describe 'Import-IntuneWinGetApp' {
         $script:deletedGraphUris = @()
         $script:batchOperationItems = @()
         $script:invokeTemplateCallCount = 0
+        $script:testExistingWinGetApps = @()
     }
 
     It 'Should create a WinGet-backed Win32 app with ownership metadata' {
@@ -394,22 +433,7 @@ Describe 'Import-IntuneWinGetApp' {
     }
 
     It 'Should skip apps already owned by the WinGet hydration importer' {
-        Mock Invoke-HydrationGraphRequest {
-            param($Method)
-            if ($Method -eq 'GET') {
-                return @{
-                    value             = @(
-                        @{
-                            id          = 'existing-id'
-                            displayName = 'Contoso App - [IHD]'
-                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
-                        }
-                    )
-                    '@odata.nextLink' = $null
-                }
-            }
-        } -ModuleName IntuneHydrationKit
+        Set-TestExistingWinGetAppsMock -Apps @(New-TestExistingWinGetApp)
 
         $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
 
@@ -419,50 +443,20 @@ Describe 'Import-IntuneWinGetApp' {
         Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
     }
 
-    It 'Should skip WinGet-owned apps with the mobile app suffix' {
-        Mock Invoke-HydrationGraphRequest {
-            param($Method)
-            if ($Method -eq 'GET') {
-                return @{
-                    value             = @(
-                        @{
-                            id          = 'existing-id'
-                            displayName = 'Contoso App - [IHD]'
-                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
-                        }
-                    )
-                    '@odata.nextLink' = $null
-                }
-            }
-        } -ModuleName IntuneHydrationKit
+    It 'Should skip WinGet-owned apps with a legacy prefixed name' {
+        Set-TestExistingWinGetAppsMock -Apps @(New-TestExistingWinGetApp -DisplayName '[IHD] Contoso App')
 
         $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot
 
         $result | Should -HaveCount 1
         $result[0].Action | Should -Be 'Skipped'
         $result[0].Name | Should -Be 'Contoso App - [IHD]'
+        $result[0].Id | Should -Be 'existing-id'
         Should -Not -Invoke Publish-IntuneWin32AppContent -ModuleName IntuneHydrationKit
     }
 
     It 'Should delete proactive remediations with app deletes when enabled' {
-        Mock Invoke-HydrationGraphRequest {
-            param($Method, $Uri)
-            $null = $Uri
-            if ($Method -eq 'GET') {
-                return @{
-                    value             = @(
-                        @{
-                            id          = 'existing-id'
-                            displayName = 'Contoso App - [IHD]'
-                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
-                        }
-                    )
-                    '@odata.nextLink' = $null
-                }
-            }
-        } -ModuleName IntuneHydrationKit
+        Set-TestExistingWinGetAppsMock -Apps @(New-TestExistingWinGetApp)
 
         $null = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemoveExisting -RemediationEnabled
 
@@ -473,28 +467,10 @@ Describe 'Import-IntuneWinGetApp' {
     }
 
     It 'Should only delete template-scoped WinGet-owned apps' {
-        Mock Invoke-HydrationGraphRequest {
-            param($Method)
-            if ($Method -eq 'GET') {
-                return @{
-                    value             = @(
-                        @{
-                            id          = 'delete-me'
-                            displayName = 'Contoso App - [IHD]'
-                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
-                        },
-                        @{
-                            id          = 'leave-me'
-                            displayName = 'Other App - [IHD]'
-                            description = 'Other app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Other.App"
-                        }
-                    )
-                    '@odata.nextLink' = $null
-                }
-            }
-        } -ModuleName IntuneHydrationKit
+        Set-TestExistingWinGetAppsMock -Apps @(
+            New-TestExistingWinGetApp -Id 'delete-me'
+            New-TestExistingWinGetApp -Id 'leave-me' -DisplayName 'Other App - [IHD]' -PackageIdentifier 'Other.App'
+        )
         Mock Invoke-GraphBatchOperation {
             $script:batchOperationItems = @($Items)
             @(
@@ -516,28 +492,13 @@ Describe 'Import-IntuneWinGetApp' {
         $script:batchOperationItems[0].Id | Should -Be 'delete-me'
     }
 
-    It 'Should delete WinGet-owned apps with the mobile app suffix' {
-        Mock Invoke-HydrationGraphRequest {
-            param($Method)
-            if ($Method -eq 'GET') {
-                return @{
-                    value             = @(
-                        @{
-                            id          = 'delete-me'
-                            displayName = 'Contoso App - [IHD]'
-                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
-                        }
-                    )
-                    '@odata.nextLink' = $null
-                }
-            }
-        } -ModuleName IntuneHydrationKit
+    It 'Should delete WinGet-owned apps with a legacy prefixed name' {
+        Set-TestExistingWinGetAppsMock -Apps @(New-TestExistingWinGetApp -Id 'delete-me' -DisplayName '[IHD] Contoso App')
         Mock Invoke-GraphBatchOperation {
             $script:batchOperationItems = @($Items)
             @(
                 [pscustomobject]@{
-                    Name   = 'Contoso App - [IHD]'
+                    Name   = '[IHD] Contoso App'
                     Type   = 'WinGetWin32App'
                     Action = 'Deleted'
                     Status = 'Success'
@@ -550,28 +511,13 @@ Describe 'Import-IntuneWinGetApp' {
 
         $result | Should -HaveCount 1
         $result[0].Action | Should -Be 'Deleted'
-        $result[0].Name | Should -Be 'Contoso App - [IHD]'
+        $result[0].Name | Should -Be '[IHD] Contoso App'
         $script:batchOperationItems | Should -HaveCount 1
         $script:batchOperationItems[0].Id | Should -Be 'delete-me'
     }
 
     It 'Should return dry-run delete results without calling the batch deleter' {
-        Mock Invoke-HydrationGraphRequest {
-            param($Method)
-            if ($Method -eq 'GET') {
-                return @{
-                    value             = @(
-                        @{
-                            id          = 'delete-me'
-                            displayName = 'Contoso App - [IHD]'
-                            description = 'WinGet packaged Contoso app - Imported by Intune Hydration Kit'
-                            notes       = "Imported from WinGet`nWinGetPackageIdentifier: Contoso.App"
-                        }
-                    )
-                    '@odata.nextLink' = $null
-                }
-            }
-        } -ModuleName IntuneHydrationKit
+        Set-TestExistingWinGetAppsMock -Apps @(New-TestExistingWinGetApp -Id 'delete-me')
 
         $result = Import-IntuneWinGetApp -WorkingDirectory $script:workingRoot -RemoveExisting -WhatIf
 

--- a/Tests/Public/Test-IntunePrerequisites.Tests.ps1
+++ b/Tests/Public/Test-IntunePrerequisites.Tests.ps1
@@ -228,7 +228,7 @@ Describe 'Test-IntunePrerequisites' {
         It 'Should skip WinGet remediation access probe when remediation is disabled' {
             Set-PrerequisiteGraphRequestMock -MobileAppsResponse { @{ value = @() } }
 
-            Test-IntunePrerequisites -Imports @{ mobileApps = $true } -MobileAppsRemediationEnabled $false | Should -Be $true
+            Test-IntunePrerequisites -Imports @{ mobileApps = $true } -MobileAppConfiguration @{ remediationEnabled = $false } | Should -Be $true
 
             Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Method -eq 'GET' -and $Uri -like '*deviceAppManagement/mobileApps*'
@@ -241,7 +241,24 @@ Describe 'Test-IntunePrerequisites' {
         It 'Should skip WinGet remediation access probe when Windows mobile apps are not selected' {
             Set-PrerequisiteGraphRequestMock -MobileAppsResponse { @{ value = @() } }
 
-            Test-IntunePrerequisites -Imports @{ mobileApps = $true } -MobileAppsIncludeWinGet $false | Should -Be $true
+            Test-IntunePrerequisites -Imports @{ mobileApps = $true } -MobileAppPlatforms @('macOS') | Should -Be $true
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like '*deviceAppManagement/mobileApps*'
+            }
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -Times 0 -ParameterFilter {
+                $Uri -like '*deviceManagement/deviceHealthScripts*'
+            }
+        }
+
+        It 'Should skip WinGet remediation access probe when selected template IDs are legacy mobile apps only' {
+            Set-PrerequisiteGraphRequestMock -MobileAppsResponse { @{ value = @() } }
+
+            Test-IntunePrerequisites `
+                -Imports @{ mobileApps = $true } `
+                -MobileAppConfiguration @{ remediationEnabled = $true; templateIds = @('CompanyPortal', 'M365Apps') } `
+                -MobileAppPlatforms @('Windows') |
+                Should -Be $true
 
             Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Method -eq 'GET' -and $Uri -like '*deviceAppManagement/mobileApps*'

--- a/Tests/Public/Test-IntunePrerequisites.Tests.ps1
+++ b/Tests/Public/Test-IntunePrerequisites.Tests.ps1
@@ -4,6 +4,68 @@ BeforeAll {
     # Import the module
     $modulePath = Join-Path $PSScriptRoot '..\..\'
     Import-Module (Join-Path $modulePath 'IntuneHydrationKit.psd1') -Force
+
+    function Set-RequiredGraphContextMock {
+        Mock Get-MgContext {
+            return @{
+                Scopes = @(
+                    'DeviceManagementConfiguration.ReadWrite.All',
+                    'DeviceManagementServiceConfig.ReadWrite.All',
+                    'DeviceManagementManagedDevices.ReadWrite.All',
+                    'DeviceManagementScripts.ReadWrite.All',
+                    'DeviceManagementApps.ReadWrite.All',
+                    'Group.ReadWrite.All',
+                    'Policy.Read.All',
+                    'Policy.ReadWrite.ConditionalAccess',
+                    'Application.Read.All',
+                    'Directory.ReadWrite.All',
+                    'LicenseAssignment.Read.All',
+                    'Organization.Read.All'
+                )
+            }
+        } -ModuleName IntuneHydrationKit
+    }
+
+    function Set-PrerequisiteGraphRequestMock {
+        param(
+            [scriptblock]$AssignmentFilterResponse,
+
+            [scriptblock]$MobileAppsResponse,
+
+            [scriptblock]$DeviceHealthScriptsResponse
+        )
+
+        $script:AssignmentFilterResponse = $AssignmentFilterResponse
+        $script:MobileAppsResponse = $MobileAppsResponse
+        $script:DeviceHealthScriptsResponse = $DeviceHealthScriptsResponse
+        Mock Invoke-MgGraphRequest {
+            param($Uri)
+
+            if ($Uri -like '*organization*') {
+                return @{ value = @(@{ displayName = 'Test Organization' }) }
+            }
+            if ($Uri -like '*subscribedSkus*') {
+                return @{
+                    value = @(@{
+                            capabilityStatus = 'Enabled'
+                            servicePlans     = @(@{
+                                    servicePlanName    = 'INTUNE_A'
+                                    provisioningStatus = 'Success'
+                                })
+                        })
+                }
+            }
+            if ($Uri -like '*assignmentFilters*' -and $script:AssignmentFilterResponse) {
+                return & $script:AssignmentFilterResponse
+            }
+            if ($Uri -like '*deviceAppManagement/mobileApps*' -and $script:MobileAppsResponse) {
+                return & $script:MobileAppsResponse
+            }
+            if ($Uri -like '*deviceManagement/deviceHealthScripts*' -and $script:DeviceHealthScriptsResponse) {
+                return & $script:DeviceHealthScriptsResponse
+            }
+        } -ModuleName IntuneHydrationKit
+    }
 }
 
 Describe 'Test-IntunePrerequisites' {
@@ -100,6 +162,102 @@ Describe 'Test-IntunePrerequisites' {
             Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
                 $Uri -like '*subscribedSkus*'
             }
+        }
+    }
+
+    Context 'Workload Access Validation' {
+        BeforeEach {
+            Set-RequiredGraphContextMock
+        }
+
+        It 'Should probe device filter access when DeviceFilters is selected' {
+            Set-PrerequisiteGraphRequestMock -AssignmentFilterResponse { @{ value = @() } }
+
+            Test-IntunePrerequisites -Imports @{ deviceFilters = $true } | Should -Be $true
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like '*deviceManagement/assignmentFilters*'
+            }
+        }
+
+        It 'Should fail pre-flight with a concise device filter access issue on Intune backend 401 Forbidden' {
+            Set-PrerequisiteGraphRequestMock -AssignmentFilterResponse {
+                throw 'HTTP/2.0 401 Unauthorized {"error":{"code":"UnknownError","message":"{\"ErrorCode\":\"Forbidden\"}"}}'
+            }
+
+            { Test-IntunePrerequisites -Imports @{ deviceFilters = $true } } |
+                Should -Throw '*Device Filters access check failed*HTTP 401*DeviceManagementConfiguration.ReadWrite.All*Global Administrator*'
+        }
+
+        It 'Should not probe device filter access when DeviceFilters is not selected' {
+            Set-PrerequisiteGraphRequestMock
+
+            Test-IntunePrerequisites -Imports @{ deviceFilters = $false } | Should -Be $true
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -Times 0 -ParameterFilter {
+                $Uri -like '*deviceManagement/assignmentFilters*'
+            }
+        }
+
+        It 'Should not emit Conditional Access notes when only DeviceFilters is selected' {
+            Set-PrerequisiteGraphRequestMock -AssignmentFilterResponse { @{ value = @() } }
+
+            $messages = @()
+            Test-IntunePrerequisites -Imports @{ deviceFilters = $true; conditionalAccess = $false } -InformationVariable messages -InformationAction Continue | Out-Null
+
+            $messageData = $messages | ForEach-Object { $_.MessageData }
+            $messageData | Should -Not -Contain '  • Azure AD Premium P2 not detected. Risk-based Conditional Access templates will be skipped:'
+            $messageData | Should -Not -Contain '  • Some Conditional Access templates use private preview features and will be skipped unless the tenant is explicitly authorized.'
+        }
+
+        It 'Should probe mobile app and WinGet remediation access when MobileApps is selected' {
+            Set-PrerequisiteGraphRequestMock `
+                -MobileAppsResponse { @{ value = @() } } `
+                -DeviceHealthScriptsResponse { @{ value = @() } }
+
+            Test-IntunePrerequisites -Imports @{ mobileApps = $true } | Should -Be $true
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like '*deviceAppManagement/mobileApps*'
+            }
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like '*deviceManagement/deviceHealthScripts*'
+            }
+        }
+
+        It 'Should skip WinGet remediation access probe when remediation is disabled' {
+            Set-PrerequisiteGraphRequestMock -MobileAppsResponse { @{ value = @() } }
+
+            Test-IntunePrerequisites -Imports @{ mobileApps = $true } -MobileAppsRemediationEnabled $false | Should -Be $true
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like '*deviceAppManagement/mobileApps*'
+            }
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -Times 0 -ParameterFilter {
+                $Uri -like '*deviceManagement/deviceHealthScripts*'
+            }
+        }
+
+        It 'Should skip WinGet remediation access probe when Windows mobile apps are not selected' {
+            Set-PrerequisiteGraphRequestMock -MobileAppsResponse { @{ value = @() } }
+
+            Test-IntunePrerequisites -Imports @{ mobileApps = $true } -MobileAppsIncludeWinGet $false | Should -Be $true
+
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -ParameterFilter {
+                $Method -eq 'GET' -and $Uri -like '*deviceAppManagement/mobileApps*'
+            }
+            Should -Invoke Invoke-MgGraphRequest -ModuleName IntuneHydrationKit -Times 0 -ParameterFilter {
+                $Uri -like '*deviceManagement/deviceHealthScripts*'
+            }
+        }
+
+        It 'Should fail pre-flight with a concise mobile app access issue on Intune backend 403' {
+            Set-PrerequisiteGraphRequestMock -MobileAppsResponse {
+                throw 'HTTP/2.0 403 Forbidden {"error":{"code":"UnknownError","message":"User is not authorized to perform this operation"}}'
+            }
+
+            { Test-IntunePrerequisites -Imports @{ mobileApps = $true } } |
+                Should -Throw '*Mobile Apps access check failed*HTTP 403*DeviceManagementApps.ReadWrite.All*Global Administrator*'
         }
     }
 
@@ -522,4 +680,3 @@ Describe 'Test-IntunePrerequisites' {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- replace interactive Graph auth with themed browser PKCE flow using the IHT logo
- add selected workload pre-flight probes for Intune authorization issues
- fix mobile app naming/idempotency compatibility and WinGet remediation delete handling
- rev module metadata and release notes to 0.8.1

## Validation
- ./build.ps1 -Task Test: 905 passed, 0 failed
- ./build.ps1 -Task Analyze: 0 errors, 176 existing warnings
- ./build.ps1 -Task Build: passed
- git diff --check: passed