### PR TITLE
Restore README GIF demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Intune Hydration Kit is a PowerShell module that bootstraps Microsoft Intune
 ### Demo
 
 <p align="center">
-  <video src="media/IHDEdit.mp4" controls width="900" aria-label="Demo"></video>
+  <img src="media/demo.gif" alt="Demo" width="900">
 </p>
 
 ### What Gets Created


### PR DESCRIPTION
## Summary

- Restore the README demo to the inline `media/demo.gif` embed that GitHub renders correctly.
- Leave the VHS tape and docs aligned with `media/demo.gif`.

## Validation

- GitHub Markdown API renders the GIF embed correctly.
- `vhs validate vhs/intune-hydration-tui.tape`
- `git diff --check`
