### PR TITLE
Add architecture assignment filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-26
+
+### Added
+
+- **Device Filters**: Added Windows architecture assignment filters for x64, ARM64, and x86 devices using Intune's native `device.cpuArchitecture` property.
+- **Device Filters**: Added macOS architecture assignment filters for Apple Silicon and Intel devices using Intune's native `device.cpuArchitecture` property.
+- **Template contracts**: Added coverage for bundled dynamic group and device filter templates, including architecture filter rule validation.
+
 ## [1.0.1] - 2026-06-20
 
 ### Fixed

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion     = '1.0.1'
+    ModuleVersion     = '1.1.0'
 
     # ID used to uniquely identify this module
     GUID              = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -104,20 +104,11 @@ To update to the latest version:
 Update-Module -Name IntuneHydrationKit
 ```
 
-## v1.0.1
+## v1.1.0
 
-- **Mobile Apps:** Fixed user-scope WinGet app installs for standard users by preferring the signed-in user's WinGet executable and avoiding SYSTEM bootstrap attempts in user context.
-- **WinGet logging:** Generated WinGet install, uninstall, and remediation scripts now fall back to user-writable log folders when the Intune Management Extension log directory is not writable.
-- **Template contracts:** Added coverage to keep user-scope WinGet templates aligned with `install.experience = user`, `--scope user`, and Graph `runAsAccount = user`.
-
-## v1.0.0
-
-- **Interactive TUI:** Calling `Invoke-IntuneHydration` with no arguments now launches a guided console flow for Azure cloud, operation mode, workload targets, platform filtering, optional Graph consent prompting, verbose logging, and final confirmation. The tenant ID is discovered after browser sign-in.
-- **Dry-run first workflow:** The TUI includes a dry-run create mode and review screen before Graph write calls, making manual previews the default path.
-- **Unified execution path:** TUI selections resolve into the same settings shape as parameter and settings-file runs, preserving logging, reports, pre-flight checks, platform filtering, and deletion protections.
-- **Common parameter handling:** `-WhatIf` and `-Verbose` are reflected in TUI execution settings and review output.
-- **Wrapper parity:** The repository wrapper now matches the module command surface, including `-StaticGroups`, `-MobileApps`, `-CISBaselines`, `-Platform`, and zero-argument TUI invocation.
-- **Documentation:** Updated README, help content, TUI screenshot, demo capture, and VHS source files for the new guided experience.
+- **Device Filters:** Added Windows architecture assignment filters for x64, ARM64, and x86 devices using Intune's native `device.cpuArchitecture` property.
+- **Device Filters:** Added macOS architecture assignment filters for Apple Silicon and Intel devices using Intune's native `device.cpuArchitecture` property.
+- **Template contracts:** Added coverage for bundled dynamic group and device filter templates, including architecture filter rule validation.
 
 '@
         }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These counts reflect the bundled template set at the time of the latest validate
 | ---------- | ------- | ------------- |
 | Dynamic Groups | 50 | Device and user targeting groups (OS, manufacturer, Autopilot, ownership, VMs, license-based) |
 | Static Groups | 5 | Update ring groups (Pilot, UAT) and Autopilot device preparation group |
-| Device Filters | 24 | Platform, manufacturer, and VM-based filters (Windows, macOS, iOS, Android) |
+| Device Filters | 29 | Platform, architecture, manufacturer, and VM-based filters (Windows, macOS, iOS, Android) |
 | OpenIntuneBaseline | 99 | [OpenIntuneBaseline](https://github.com/jorgeasaurus/OpenIntuneBaseline) policies (Windows, macOS, iOS, Android) - bundled, no download required |
 | CIS Baselines | 728 | Bundled [IntuneBaselines](https://github.com/jorgeasaurus/IntuneBaselines) CIS benchmark-derived policies across Windows, macOS, iOS, Android, Edge, Chrome, and related administrative template workloads |
 | Compliance Policies | 10 | Multi-platform compliance (Windows, macOS, iOS, Android, Linux) |
@@ -103,6 +103,7 @@ When using delete mode (`-Delete` parameter or `"delete": true` in settings), th
 - **Safe Deletion** - Only removes objects created by this kit (identified by the hydration marker, with prefixes used where applicable)
 - **Multi-Platform** - Supports Windows, macOS, iOS, Android, and Linux
 - **Platform Filtering** - Import resources for specific platforms only (e.g., `-Platform Windows,macOS`)
+- **Architecture Filters** - Windows and macOS assignment filters use Intune's native `device.cpuArchitecture` property for policy and app targeting
 - **Detailed Logging** - Full audit trail of all operations
 - **Elapsed Time Tracking** - Final summary output and reports include total hydration time
 - **Summary Reports** - Markdown and JSON reports of all changes

--- a/Templates/Filters/Windows-Architecture-Filters.json
+++ b/Templates/Filters/Windows-Architecture-Filters.json
@@ -1,0 +1,22 @@
+{
+    "filters": [
+        {
+            "displayName": "Windows - x64 Devices",
+            "description": "Filter for Windows devices reporting amd64 CPU architecture",
+            "platform": "windows10AndLater",
+            "rule": "(device.cpuArchitecture -eq \"amd64\")"
+        },
+        {
+            "displayName": "Windows - ARM64 Devices",
+            "description": "Filter for Windows devices reporting ARM64 CPU architecture",
+            "platform": "windows10AndLater",
+            "rule": "(device.cpuArchitecture -eq \"arm64\")"
+        },
+        {
+            "displayName": "Windows - x86 Devices",
+            "description": "Filter for Windows devices reporting x86 CPU architecture",
+            "platform": "windows10AndLater",
+            "rule": "(device.cpuArchitecture -eq \"x86\")"
+        }
+    ]
+}

--- a/Templates/Filters/macOS-Architecture-Filters.json
+++ b/Templates/Filters/macOS-Architecture-Filters.json
@@ -1,0 +1,16 @@
+{
+    "filters": [
+        {
+            "displayName": "macOS - Apple Silicon Devices",
+            "description": "Filter for macOS devices reporting ARM64 CPU architecture",
+            "platform": "macOS",
+            "rule": "(device.cpuArchitecture -eq \"arm64\")"
+        },
+        {
+            "displayName": "macOS - Intel Devices",
+            "description": "Filter for macOS devices reporting x64 CPU architecture",
+            "platform": "macOS",
+            "rule": "(device.cpuArchitecture -eq \"x64\")"
+        }
+    ]
+}

--- a/Tests/Private/TemplateContracts.Tests.ps1
+++ b/Tests/Private/TemplateContracts.Tests.ps1
@@ -7,6 +7,10 @@ BeforeAll {
 
     $script:OpenIntuneTemplates = Get-ChildItem -Path (Join-Path $modulePath 'Templates/OpenIntuneBaseline') -Filter '*.json' -File -Recurse
     $script:CisTemplates = Get-ChildItem -Path (Join-Path $modulePath 'Templates/CISBaselines') -Filter '*.json' -File -Recurse
+    $script:DynamicGroupTemplatePath = Join-Path $modulePath 'Templates/DynamicGroups'
+    $script:DynamicGroupTemplates = Get-ChildItem -Path $script:DynamicGroupTemplatePath -Filter '*.json' -File
+    $script:DeviceFilterTemplatePath = Join-Path $modulePath 'Templates/Filters'
+    $script:DeviceFilterTemplates = Get-ChildItem -Path $script:DeviceFilterTemplatePath -Filter '*.json' -File
     $script:WinGetRoot = Join-Path $modulePath 'Templates/MobileApps/Windows/WinGet'
     $script:WinGetAppTemplates = Get-ChildItem -Path (Join-Path $script:WinGetRoot 'Apps') -Filter '*.json' -File
     $script:WinGetPresetTemplates = Get-ChildItem -Path (Join-Path $script:WinGetRoot 'Presets') -Filter '*.json' -File
@@ -26,6 +30,77 @@ Describe 'Bundled template contracts' {
             {
                 $null = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 100
             } | Should -Not -Throw
+        }
+    }
+
+    It 'Should load bundled dynamic group templates as valid JSON with unique names' {
+        $script:DynamicGroupTemplates.Count | Should -BeGreaterThan 0
+        $displayNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+        foreach ($templateFile in $script:DynamicGroupTemplates) {
+            $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 20
+            $groups = @($template.groups)
+            $groups.Count | Should -BeGreaterThan 0 -Because $templateFile.FullName
+
+            foreach ($group in $groups) {
+                [string]::IsNullOrWhiteSpace([string]$group.displayName) | Should -BeFalse -Because $templateFile.FullName
+                [string]::IsNullOrWhiteSpace([string]$group.description) | Should -BeFalse -Because $templateFile.FullName
+                [string]::IsNullOrWhiteSpace([string]$group.membershipRule) | Should -BeFalse -Because $templateFile.FullName
+
+                if ($group.PSObject.Properties['platform']) {
+                    [string]$group.platform | Should -BeIn @('All', 'Windows', 'macOS', 'iOS', 'Android') -Because $group.displayName
+                }
+
+                $displayNames.Add([string]$group.displayName) | Should -BeTrue -Because "Duplicate dynamic group name: $($group.displayName)"
+            }
+        }
+    }
+
+    It 'Should load bundled device filter templates as valid JSON with unique names' {
+        $script:DeviceFilterTemplates.Count | Should -BeGreaterThan 0
+        $displayNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+        foreach ($templateFile in $script:DeviceFilterTemplates) {
+            $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 20
+            $filters = @($template.filters)
+            $filters.Count | Should -BeGreaterThan 0 -Because $templateFile.FullName
+
+            foreach ($filter in $filters) {
+                [string]::IsNullOrWhiteSpace([string]$filter.displayName) | Should -BeFalse -Because $templateFile.FullName
+                [string]::IsNullOrWhiteSpace([string]$filter.description) | Should -BeFalse -Because $templateFile.FullName
+                [string]::IsNullOrWhiteSpace([string]$filter.platform) | Should -BeFalse -Because $templateFile.FullName
+                [string]::IsNullOrWhiteSpace([string]$filter.rule) | Should -BeFalse -Because $templateFile.FullName
+                [string]$filter.platform | Should -BeIn @('androidForWork', 'iOS', 'macOS', 'windows10AndLater') -Because $filter.displayName
+
+                $displayNames.Add([string]$filter.displayName) | Should -BeTrue -Because "Duplicate device filter name: $($filter.displayName)"
+            }
+        }
+    }
+
+    It 'Should keep architecture device filters on documented cpu architecture rules' {
+        $architectureTemplateFiles = @(
+            Join-Path $script:DeviceFilterTemplatePath 'Windows-Architecture-Filters.json'
+            Join-Path $script:DeviceFilterTemplatePath 'macOS-Architecture-Filters.json'
+        )
+        $filters = foreach ($templateFile in $architectureTemplateFiles) {
+            $template = Get-Content -Path $templateFile -Raw | ConvertFrom-Json -Depth 20
+            @($template.filters)
+        }
+        $expectedFilters = @{
+            'Windows - x64 Devices'           = @{ Platform = 'windows10AndLater'; Rule = '(device.cpuArchitecture -eq "amd64")' }
+            'Windows - ARM64 Devices'         = @{ Platform = 'windows10AndLater'; Rule = '(device.cpuArchitecture -eq "arm64")' }
+            'Windows - x86 Devices'           = @{ Platform = 'windows10AndLater'; Rule = '(device.cpuArchitecture -eq "x86")' }
+            'macOS - Apple Silicon Devices'   = @{ Platform = 'macOS'; Rule = '(device.cpuArchitecture -eq "arm64")' }
+            'macOS - Intel Devices'           = @{ Platform = 'macOS'; Rule = '(device.cpuArchitecture -eq "x64")' }
+        }
+
+        $filters | Should -HaveCount $expectedFilters.Count
+        foreach ($filter in $filters) {
+            $expectedFilters.ContainsKey([string]$filter.displayName) | Should -BeTrue -Because $filter.displayName
+            $expected = $expectedFilters[[string]$filter.displayName]
+
+            $filter.platform | Should -Be $expected.Platform
+            $filter.rule | Should -Be $expected.Rule
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds Windows architecture assignment filters for amd64, arm64, and x86 devices.
- Adds macOS architecture assignment filters for Apple Silicon and Intel devices.
- Updates README device filter count from 24 to 29.
- Adds template contract coverage for device filter JSON and cpuArchitecture rules.

## Rationale
Entra dynamic device membership rules do not expose CPU architecture as a supported device property. Microsoft lists the supported dynamic device attributes, including properties like `deviceManufacturer`, `deviceModel`, `deviceOSType`, `deviceTrustType`, and `extensionAttribute1-15`, but not CPU architecture.

For Intune app and policy targeting, Microsoft recommends assignment filters when they meet the targeting need. Intune assignment filters support `device.cpuArchitecture` for Windows and macOS, so this uses the native Intune targeting path instead of requiring extension attribute stamping or another scheduled membership bridge.

Sources:
- https://learn.microsoft.com/en-us/entra/identity/users/groups-dynamic-membership#rules-for-devices
- https://learn.microsoft.com/en-us/intune/fundamentals/filters/ref-device-properties
- https://learn.microsoft.com/en-us/intune/fundamentals/filters/ref-supported-workloads
- https://learn.microsoft.com/en-us/graph/api/intune-policyset-deviceandappmanagementassignmentfilter-create?view=graph-rest-beta

## Validation
- Focused Pester: 35 passed
- Analyzer: 0 errors
- Full test task: 991 passed, 2 skipped
- Build succeeded
- Built templates present
- JSON/rule checks passed
- Filter count check: 29
- `git diff --check` passed

Addresses #32.
