### PR TITLE
Avoid duplicate install commands in release notes

### DIFF
--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -92,18 +92,6 @@
             # Release notes for this module
             ReleaseNotes = @'
 
-Install directly from the PowerShell Gallery:
-
-```powershell
-Install-Module -Name IntuneHydrationKit -Scope CurrentUser
-```
-
-To update to the latest version:
-
-```powershell
-Update-Module -Name IntuneHydrationKit
-```
-
 ## v1.1.0
 
 - **Device Filters:** Added Windows architecture assignment filters for x64, ARM64, and x86 devices using Intune's native `device.cpuArchitecture` property.

--- a/Tests/Private/TemplateContracts.Tests.ps1
+++ b/Tests/Private/TemplateContracts.Tests.ps1
@@ -33,6 +33,16 @@ Describe 'Bundled template contracts' {
         }
     }
 
+    It 'Should keep manifest release notes scoped to release notes only' {
+        $manifest = Import-PowerShellDataFile -Path (Join-Path $modulePath 'IntuneHydrationKit.psd1')
+        $releaseNotes = [string]$manifest.PrivateData.PSData.ReleaseNotes
+
+        $releaseNotes | Should -Match '## v\d+\.\d+\.\d+'
+        $releaseNotes | Should -Not -Match 'Install-Module'
+        $releaseNotes | Should -Not -Match 'Update-Module'
+        $releaseNotes | Should -Not -Match 'Install directly from the PowerShell Gallery'
+    }
+
     It 'Should load bundled dynamic group templates as valid JSON with unique names' {
         $script:DynamicGroupTemplates.Count | Should -BeGreaterThan 0
         $displayNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- Removes install/update command text from manifest `ReleaseNotes` so the GitHub release body does not duplicate the workflow-owned Installation section.
- Adds a template contract test to keep manifest release notes scoped to release notes only.

## Rationale
The release workflow already renders an `Installation` section before appending manifest release notes. Keeping install/update commands inside `PrivateData.PSData.ReleaseNotes` causes duplicate install instructions in GitHub Releases and PowerShell Gallery release notes.

Going forward:
- `.github/workflows/ci.yml` owns the GitHub Release installation instructions.
- `IntuneHydrationKit.psd1` `ReleaseNotes` owns only version-specific release notes.

## Validation
- `Invoke-Pester -Path ./Tests/Private/TemplateContracts.Tests.ps1 -Output Detailed`: 12 passed
- `Test-ModuleManifest`: version 1.1.0, current release heading present, no `Install-Module`/`Update-Module` in release notes
- `git diff --check`
