### PR TITLE
Add web app template parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-07-22
+
+### Added
+
+- **Dynamic Groups**: Added OS-version groups for Windows 11 24H2/25H2/26H1, macOS 14-27, and iOS/iPadOS 18/26.
+- **Device Filters**: Added matching Windows, macOS, and iOS OS-version assignment filters.
+
 ## [1.1.2] - 2026-07-12
 
 ### Fixed

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion     = '1.1.2'
+    ModuleVersion     = '1.2.0'
 
     # ID used to uniquely identify this module
     GUID              = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -85,10 +85,10 @@
             # Release notes for this module
             ReleaseNotes = @'
 
-## v1.1.2
+## v1.2.0
 
-- **Conditional Access:** Fixed policy imports failing when templates contain prefixed OData annotations (e.g. `authenticationStrength@odata.context`); annotations are now stripped recursively while `@odata.type` is preserved.
-- **License detection:** Removed Defender for Cloud Apps (`ADALLOM_S_STANDALONE`) and Defender for Identity (`ATA`) service plans from Entra ID Premium P2 detection, so risk-based Conditional Access templates are correctly skipped on tenants without P2.
+- **Dynamic Groups:** Added Windows 11 24H2/25H2/26H1, macOS 14-27, and iOS/iPadOS 18/26 OS-version groups.
+- **Device Filters:** Added matching Windows, macOS, and iOS OS-version assignment filters.
 
 '@
         }

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ These counts reflect the bundled template set at the time of the latest validate
 
 | Category | Count | Description |
 | ---------- | ------- | ------------- |
-| Dynamic Groups | 50 | Device and user targeting groups (OS, manufacturer, Autopilot, ownership, VMs, license-based) |
+| Dynamic Groups | 59 | Device and user targeting groups (OS, manufacturer, Autopilot, ownership, VMs, license-based) |
 | Static Groups | 5 | Update ring groups (Pilot, UAT) and Autopilot device preparation group |
-| Device Filters | 29 | Platform, architecture, manufacturer, and VM-based filters (Windows, macOS, iOS, Android) |
+| Device Filters | 38 | Platform, OS-version, architecture, manufacturer, and VM-based filters (Windows, macOS, iOS, Android) |
 | OpenIntuneBaseline | 99 | [OpenIntuneBaseline](https://github.com/jorgeasaurus/OpenIntuneBaseline) policies (Windows, macOS, iOS, Android) - bundled, no download required |
 | CIS Baselines | 728 | Bundled [IntuneBaselines](https://github.com/jorgeasaurus/IntuneBaselines) CIS benchmark-derived policies across Windows, macOS, iOS, Android, Edge, Chrome, and related administrative template workloads |
 | Compliance Policies | 10 | Multi-platform compliance (Windows, macOS, iOS, Android, Linux) |

--- a/Templates/DynamicGroups/OS-Groups.json
+++ b/Templates/DynamicGroups/OS-Groups.json
@@ -19,6 +19,24 @@
             "platform": "Windows"
         },
         {
+            "displayName": "Intune - Windows 11 24H2 Devices",
+            "description": "All Windows 11 24H2 devices (build 26100) managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"Windows\") and (device.deviceOSVersion -startsWith \"10.0.26100\") and (device.managementType -eq \"MDM\")",
+            "platform": "Windows"
+        },
+        {
+            "displayName": "Intune - Windows 11 25H2 Devices",
+            "description": "All Windows 11 25H2 devices (build 26200) managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"Windows\") and (device.deviceOSVersion -startsWith \"10.0.26200\") and (device.managementType -eq \"MDM\")",
+            "platform": "Windows"
+        },
+        {
+            "displayName": "Intune - Windows 11 26H1 Devices",
+            "description": "All Windows 11 26H1 devices (build 28000) managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"Windows\") and (device.deviceOSVersion -startsWith \"10.0.28000\") and (device.managementType -eq \"MDM\")",
+            "platform": "Windows"
+        },
+        {
             "displayName": "Intune - Windows ConfigMgr Managed Devices",
             "description": "All Windows devices managed by ConfigMgr (co-managed)",
             "membershipRule": "(device.deviceManagementAppId -eq \"54b943f8-d761-4f8d-951e-9cea1846db5a\")",
@@ -28,6 +46,30 @@
             "displayName": "Intune - macOS Devices",
             "description": "All macOS devices managed by Intune",
             "membershipRule": "(device.deviceOSType -eq \"MacMDM\")",
+            "platform": "macOS"
+        },
+        {
+            "displayName": "Intune - macOS 27 Golden Gate Devices",
+            "description": "All macOS 27 (Golden Gate) devices managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"MacMDM\") and (device.deviceOSVersion -startsWith \"27.\")",
+            "platform": "macOS"
+        },
+        {
+            "displayName": "Intune - macOS 26 Tahoe Devices",
+            "description": "All macOS 26 (Tahoe) devices managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"MacMDM\") and (device.deviceOSVersion -startsWith \"26.\")",
+            "platform": "macOS"
+        },
+        {
+            "displayName": "Intune - macOS 15 Sequoia Devices",
+            "description": "All macOS 15 (Sequoia) devices managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"MacMDM\") and (device.deviceOSVersion -startsWith \"15.\")",
+            "platform": "macOS"
+        },
+        {
+            "displayName": "Intune - macOS 14 Sonoma Devices",
+            "description": "All macOS 14 (Sonoma) devices managed by Intune",
+            "membershipRule": "(device.deviceOSType -eq \"MacMDM\") and (device.deviceOSVersion -startsWith \"14.\")",
             "platform": "macOS"
         },
         {
@@ -46,6 +88,18 @@
             "displayName": "Intune - iOS iPadOS Devices",
             "description": "All iOS and iPadOS devices managed by Intune",
             "membershipRule": "(device.deviceOSType -eq \"iOS\") or (device.deviceOSType -eq \"iPad\")",
+            "platform": "iOS"
+        },
+        {
+            "displayName": "Intune - iOS iPadOS 26 Devices",
+            "description": "All iOS and iPadOS 26 devices managed by Intune",
+            "membershipRule": "((device.deviceOSType -eq \"iOS\") or (device.deviceOSType -eq \"iPad\")) and (device.deviceOSVersion -startsWith \"26.\")",
+            "platform": "iOS"
+        },
+        {
+            "displayName": "Intune - iOS iPadOS 18 Devices",
+            "description": "All iOS and iPadOS 18 devices managed by Intune",
+            "membershipRule": "((device.deviceOSType -eq \"iOS\") or (device.deviceOSType -eq \"iPad\")) and (device.deviceOSVersion -startsWith \"18.\")",
             "platform": "iOS"
         },
         {

--- a/Templates/Filters/Windows-OSVersion-Filters.json
+++ b/Templates/Filters/Windows-OSVersion-Filters.json
@@ -1,0 +1,22 @@
+{
+    "filters": [
+        {
+            "displayName": "Windows - Windows 11 24H2 Devices",
+            "description": "Filter for Windows 11 24H2 devices (build 26100)",
+            "platform": "windows10AndLater",
+            "rule": "(device.osVersion -startsWith \"10.0.26100\")"
+        },
+        {
+            "displayName": "Windows - Windows 11 25H2 Devices",
+            "description": "Filter for Windows 11 25H2 devices (build 26200)",
+            "platform": "windows10AndLater",
+            "rule": "(device.osVersion -startsWith \"10.0.26200\")"
+        },
+        {
+            "displayName": "Windows - Windows 11 26H1 Devices",
+            "description": "Filter for Windows 11 26H1 devices (build 28000)",
+            "platform": "windows10AndLater",
+            "rule": "(device.osVersion -startsWith \"10.0.28000\")"
+        }
+    ]
+}

--- a/Templates/Filters/iOS-OSVersion-Filters.json
+++ b/Templates/Filters/iOS-OSVersion-Filters.json
@@ -1,0 +1,16 @@
+{
+    "filters": [
+        {
+            "displayName": "iOS - iOS 26 Devices",
+            "description": "Filter for iOS/iPadOS 26 devices",
+            "platform": "iOS",
+            "rule": "(device.osVersion -startsWith \"26.\")"
+        },
+        {
+            "displayName": "iOS - iOS 18 Devices",
+            "description": "Filter for iOS/iPadOS 18 devices",
+            "platform": "iOS",
+            "rule": "(device.osVersion -startsWith \"18.\")"
+        }
+    ]
+}

--- a/Templates/Filters/macOS-OSVersion-Filters.json
+++ b/Templates/Filters/macOS-OSVersion-Filters.json
@@ -1,0 +1,28 @@
+{
+    "filters": [
+        {
+            "displayName": "macOS - macOS 27 Golden Gate Devices",
+            "description": "Filter for macOS 27 (Golden Gate) devices",
+            "platform": "macOS",
+            "rule": "(device.osVersion -startsWith \"27.\")"
+        },
+        {
+            "displayName": "macOS - macOS 26 Tahoe Devices",
+            "description": "Filter for macOS 26 (Tahoe) devices",
+            "platform": "macOS",
+            "rule": "(device.osVersion -startsWith \"26.\")"
+        },
+        {
+            "displayName": "macOS - macOS 15 Sequoia Devices",
+            "description": "Filter for macOS 15 (Sequoia) devices",
+            "platform": "macOS",
+            "rule": "(device.osVersion -startsWith \"15.\")"
+        },
+        {
+            "displayName": "macOS - macOS 14 Sonoma Devices",
+            "description": "Filter for macOS 14 (Sonoma) devices",
+            "platform": "macOS",
+            "rule": "(device.osVersion -startsWith \"14.\")"
+        }
+    ]
+}

--- a/Tests/Private/TemplateContracts.Tests.ps1
+++ b/Tests/Private/TemplateContracts.Tests.ps1
@@ -87,6 +87,58 @@ Describe 'Bundled template contracts' {
         }
     }
 
+    It 'Should include the web-app OS-version dynamic group templates' {
+        $groups = foreach ($templateFile in $script:DynamicGroupTemplates) {
+            $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 20
+            @($template.groups)
+        }
+        $expectedGroups = @{
+            'Intune - Windows 11 24H2 Devices'   = @{ Platform = 'Windows'; Rule = '(device.deviceOSType -eq "Windows") and (device.deviceOSVersion -startsWith "10.0.26100") and (device.managementType -eq "MDM")' }
+            'Intune - Windows 11 25H2 Devices'   = @{ Platform = 'Windows'; Rule = '(device.deviceOSType -eq "Windows") and (device.deviceOSVersion -startsWith "10.0.26200") and (device.managementType -eq "MDM")' }
+            'Intune - Windows 11 26H1 Devices'   = @{ Platform = 'Windows'; Rule = '(device.deviceOSType -eq "Windows") and (device.deviceOSVersion -startsWith "10.0.28000") and (device.managementType -eq "MDM")' }
+            'Intune - macOS 27 Golden Gate Devices' = @{ Platform = 'macOS'; Rule = '(device.deviceOSType -eq "MacMDM") and (device.deviceOSVersion -startsWith "27.")' }
+            'Intune - macOS 26 Tahoe Devices'    = @{ Platform = 'macOS'; Rule = '(device.deviceOSType -eq "MacMDM") and (device.deviceOSVersion -startsWith "26.")' }
+            'Intune - macOS 15 Sequoia Devices'  = @{ Platform = 'macOS'; Rule = '(device.deviceOSType -eq "MacMDM") and (device.deviceOSVersion -startsWith "15.")' }
+            'Intune - macOS 14 Sonoma Devices'   = @{ Platform = 'macOS'; Rule = '(device.deviceOSType -eq "MacMDM") and (device.deviceOSVersion -startsWith "14.")' }
+            'Intune - iOS iPadOS 26 Devices'     = @{ Platform = 'iOS'; Rule = '((device.deviceOSType -eq "iOS") or (device.deviceOSType -eq "iPad")) and (device.deviceOSVersion -startsWith "26.")' }
+            'Intune - iOS iPadOS 18 Devices'     = @{ Platform = 'iOS'; Rule = '((device.deviceOSType -eq "iOS") or (device.deviceOSType -eq "iPad")) and (device.deviceOSVersion -startsWith "18.")' }
+        }
+
+        $groups | Should -HaveCount 59
+        foreach ($name in $expectedGroups.Keys) {
+            $group = $groups | Where-Object { $_.displayName -eq $name }
+            $group | Should -HaveCount 1
+            $group.platform | Should -Be $expectedGroups[$name].Platform
+            $group.membershipRule | Should -Be $expectedGroups[$name].Rule
+        }
+    }
+
+    It 'Should include the web-app OS-version device filter templates' {
+        $filters = foreach ($templateFile in $script:DeviceFilterTemplates) {
+            $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 20
+            @($template.filters)
+        }
+        $expectedFilters = @{
+            'Windows - Windows 11 24H2 Devices'    = @{ Platform = 'windows10AndLater'; Rule = '(device.osVersion -startsWith "10.0.26100")' }
+            'Windows - Windows 11 25H2 Devices'    = @{ Platform = 'windows10AndLater'; Rule = '(device.osVersion -startsWith "10.0.26200")' }
+            'Windows - Windows 11 26H1 Devices'    = @{ Platform = 'windows10AndLater'; Rule = '(device.osVersion -startsWith "10.0.28000")' }
+            'iOS - iOS 26 Devices'                 = @{ Platform = 'iOS'; Rule = '(device.osVersion -startsWith "26.")' }
+            'iOS - iOS 18 Devices'                 = @{ Platform = 'iOS'; Rule = '(device.osVersion -startsWith "18.")' }
+            'macOS - macOS 27 Golden Gate Devices' = @{ Platform = 'macOS'; Rule = '(device.osVersion -startsWith "27.")' }
+            'macOS - macOS 26 Tahoe Devices'       = @{ Platform = 'macOS'; Rule = '(device.osVersion -startsWith "26.")' }
+            'macOS - macOS 15 Sequoia Devices'     = @{ Platform = 'macOS'; Rule = '(device.osVersion -startsWith "15.")' }
+            'macOS - macOS 14 Sonoma Devices'      = @{ Platform = 'macOS'; Rule = '(device.osVersion -startsWith "14.")' }
+        }
+
+        $filters | Should -HaveCount 38
+        foreach ($name in $expectedFilters.Keys) {
+            $filter = $filters | Where-Object { $_.displayName -eq $name }
+            $filter | Should -HaveCount 1
+            $filter.platform | Should -Be $expectedFilters[$name].Platform
+            $filter.rule | Should -Be $expectedFilters[$name].Rule
+        }
+    }
+
     It 'Should keep architecture device filters on documented cpu architecture rules' {
         $architectureTemplateFiles = @(
             Join-Path $script:DeviceFilterTemplatePath 'Windows-Architecture-Filters.json'


### PR DESCRIPTION
## Summary

- Add nine OS-version dynamic groups and nine matching device filters from the web app template inventory.
- Cover the bundled inventory and rules with template contract tests.
- Update README template counts to 59 dynamic groups and 38 device filters.

## Why

The PowerShell module lagged behind the web app template inventory.

## Validation

- `Invoke-Pester -Path ./Tests/Private/TemplateContracts.Tests.ps1 -Output Detailed` (14 passed)
- `./build.ps1 -Task Analyze`
- `./build.ps1 -Task Build`
- `git diff --check`