### PR TITLE
Add device trust type targeting templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-23
+
+### Added
+
+- **Dynamic Groups**: Added Microsoft Entra joined, hybrid joined, and registered Windows device groups.
+- **Device Filters**: Added Windows assignment filters for Microsoft Entra joined, hybrid joined, registered, and unknown join types.
+
 ## [1.2.0] - 2026-07-22
 
 ### Added

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion     = '1.2.0'
+    ModuleVersion     = '1.3.0'
 
     # ID used to uniquely identify this module
     GUID              = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -85,10 +85,10 @@
             # Release notes for this module
             ReleaseNotes = @'
 
-## v1.2.0
+## v1.3.0
 
-- **Dynamic Groups:** Added Windows 11 24H2/25H2/26H1, macOS 14-27, and iOS/iPadOS 18/26 OS-version groups.
-- **Device Filters:** Added matching Windows, macOS, and iOS OS-version assignment filters.
+- **Dynamic Groups:** Added Microsoft Entra joined, hybrid joined, and registered Windows device groups.
+- **Device Filters:** Added Windows assignment filters for Microsoft Entra joined, hybrid joined, registered, and unknown join types.
 
 '@
         }

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ These counts reflect the bundled template set at the time of the latest validate
 
 | Category | Count | Description |
 | ---------- | ------- | ------------- |
-| Dynamic Groups | 59 | Device and user targeting groups (OS, manufacturer, Autopilot, ownership, VMs, license-based) |
+| Dynamic Groups | 62 | Device and user targeting groups (OS, manufacturer, Autopilot, ownership, VMs, join type, license-based) |
 | Static Groups | 5 | Update ring groups (Pilot, UAT) and Autopilot device preparation group |
-| Device Filters | 38 | Platform, OS-version, architecture, manufacturer, and VM-based filters (Windows, macOS, iOS, Android) |
+| Device Filters | 42 | Platform, OS-version, architecture, manufacturer, VM, and join-type filters (Windows, macOS, iOS, Android) |
 | OpenIntuneBaseline | 99 | [OpenIntuneBaseline](https://github.com/jorgeasaurus/OpenIntuneBaseline) policies (Windows, macOS, iOS, Android) - bundled, no download required |
 | CIS Baselines | 728 | Bundled [IntuneBaselines](https://github.com/jorgeasaurus/IntuneBaselines) CIS benchmark-derived policies across Windows, macOS, iOS, Android, Edge, Chrome, and related administrative template workloads |
 | Compliance Policies | 10 | Multi-platform compliance (Windows, macOS, iOS, Android, Linux) |

--- a/Templates/DynamicGroups/DeviceTrustType-Groups.json
+++ b/Templates/DynamicGroups/DeviceTrustType-Groups.json
@@ -1,0 +1,22 @@
+{
+    "groups": [
+        {
+            "displayName": "Intune - Entra Joined Devices",
+            "description": "All Microsoft Entra joined devices",
+            "membershipRule": "(device.deviceTrustType -eq \"AzureAD\")",
+            "platform": "Windows"
+        },
+        {
+            "displayName": "Intune - Hybrid Entra Joined Devices",
+            "description": "All Microsoft Entra hybrid joined devices",
+            "membershipRule": "(device.deviceTrustType -eq \"ServerAD\")",
+            "platform": "Windows"
+        },
+        {
+            "displayName": "Intune - Entra Registered Devices",
+            "description": "All Microsoft Entra registered devices",
+            "membershipRule": "(device.deviceTrustType -eq \"Workplace\")",
+            "platform": "Windows"
+        }
+    ]
+}

--- a/Templates/Filters/Windows-DeviceTrustType-Filters.json
+++ b/Templates/Filters/Windows-DeviceTrustType-Filters.json
@@ -1,0 +1,28 @@
+{
+    "filters": [
+        {
+            "displayName": "Windows - Entra Joined",
+            "description": "Filter for Microsoft Entra joined Windows devices",
+            "platform": "windows10AndLater",
+            "rule": "(device.deviceTrustType -eq \"Azure AD joined\")"
+        },
+        {
+            "displayName": "Windows - Hybrid Entra Joined",
+            "description": "Filter for Microsoft Entra hybrid joined Windows devices",
+            "platform": "windows10AndLater",
+            "rule": "(device.deviceTrustType -eq \"Hybrid Azure AD joined\")"
+        },
+        {
+            "displayName": "Windows - Entra Registered",
+            "description": "Filter for Microsoft Entra registered Windows devices",
+            "platform": "windows10AndLater",
+            "rule": "(device.deviceTrustType -eq \"Azure AD registered\")"
+        },
+        {
+            "displayName": "Windows - Unknown Entra Join Type",
+            "description": "Filter for Windows devices with an unknown Microsoft Entra join type",
+            "platform": "windows10AndLater",
+            "rule": "(device.deviceTrustType -eq \"Unknown\")"
+        }
+    ]
+}

--- a/Tests/Private/TemplateContracts.Tests.ps1
+++ b/Tests/Private/TemplateContracts.Tests.ps1
@@ -104,7 +104,7 @@ Describe 'Bundled template contracts' {
             'Intune - iOS iPadOS 18 Devices'     = @{ Platform = 'iOS'; Rule = '((device.deviceOSType -eq "iOS") or (device.deviceOSType -eq "iPad")) and (device.deviceOSVersion -startsWith "18.")' }
         }
 
-        $groups | Should -HaveCount 59
+        $groups | Should -HaveCount 62
         foreach ($name in $expectedGroups.Keys) {
             $group = $groups | Where-Object { $_.displayName -eq $name }
             $group | Should -HaveCount 1
@@ -130,7 +130,7 @@ Describe 'Bundled template contracts' {
             'macOS - macOS 14 Sonoma Devices'      = @{ Platform = 'macOS'; Rule = '(device.osVersion -startsWith "14.")' }
         }
 
-        $filters | Should -HaveCount 38
+        $filters | Should -HaveCount 42
         foreach ($name in $expectedFilters.Keys) {
             $filter = $filters | Where-Object { $_.displayName -eq $name }
             $filter | Should -HaveCount 1
@@ -163,6 +163,42 @@ Describe 'Bundled template contracts' {
 
             $filter.platform | Should -Be $expected.Platform
             $filter.rule | Should -Be $expected.Rule
+        }
+    }
+
+    It 'Should include device trust type templates with service-specific values' {
+        $groups = foreach ($templateFile in $script:DynamicGroupTemplates) {
+            $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 20
+            @($template.groups)
+        }
+        $filters = foreach ($templateFile in $script:DeviceFilterTemplates) {
+            $template = Get-Content -Path $templateFile.FullName -Raw | ConvertFrom-Json -Depth 20
+            @($template.filters)
+        }
+        $expectedGroups = @{
+            'Intune - Entra Joined Devices'        = @{ Platform = 'Windows'; Rule = '(device.deviceTrustType -eq "AzureAD")' }
+            'Intune - Hybrid Entra Joined Devices' = @{ Platform = 'Windows'; Rule = '(device.deviceTrustType -eq "ServerAD")' }
+            'Intune - Entra Registered Devices'    = @{ Platform = 'Windows'; Rule = '(device.deviceTrustType -eq "Workplace")' }
+        }
+        $expectedFilters = @{
+            'Windows - Entra Joined'           = @{ Platform = 'windows10AndLater'; Rule = '(device.deviceTrustType -eq "Azure AD joined")' }
+            'Windows - Hybrid Entra Joined'    = @{ Platform = 'windows10AndLater'; Rule = '(device.deviceTrustType -eq "Hybrid Azure AD joined")' }
+            'Windows - Entra Registered'       = @{ Platform = 'windows10AndLater'; Rule = '(device.deviceTrustType -eq "Azure AD registered")' }
+            'Windows - Unknown Entra Join Type' = @{ Platform = 'windows10AndLater'; Rule = '(device.deviceTrustType -eq "Unknown")' }
+        }
+
+        foreach ($name in $expectedGroups.Keys) {
+            $group = $groups | Where-Object { $_.displayName -eq $name }
+            $group | Should -HaveCount 1
+            $group.platform | Should -Be $expectedGroups[$name].Platform
+            $group.membershipRule | Should -Be $expectedGroups[$name].Rule
+        }
+
+        foreach ($name in $expectedFilters.Keys) {
+            $filter = $filters | Where-Object { $_.displayName -eq $name }
+            $filter | Should -HaveCount 1
+            $filter.platform | Should -Be $expectedFilters[$name].Platform
+            $filter.rule | Should -Be $expectedFilters[$name].Rule
         }
     }
 


### PR DESCRIPTION
## Summary
- add Windows assignment filters for Entra joined, hybrid joined, registered, and unknown devices
- add dynamic device groups for Entra joined, hybrid joined, and registered devices
- verify service-specific rule values and update bundled-template inventory counts

## Validation
- `Invoke-Pester -Path ./Tests/Private/TemplateContracts.Tests.ps1 -Output Detailed`
- `./build.ps1 -Task Analyze`
- `./build.ps1 -Task Build`
- `git diff --check`