### PR TITLE
Fix OIB assignment safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-07-26
+
+### Fixed
+
+- **WinGet detection**: Prevented bootstrap log messages from corrupting the resolved WinGet executable path.
+- **OIB Settings Catalog**: Added a guarded assignment script that targets managed policies by default, preserves direct assignments, and fails closed on filtered or policy-set-owned targets.
+
 ## [1.3.0] - 2026-07-23
 
 ### Added

--- a/IntuneHydrationKit.psd1
+++ b/IntuneHydrationKit.psd1
@@ -2,7 +2,7 @@
     # Module manifest for IntuneHydrationKit
 
     # Version number of this module
-    ModuleVersion     = '1.3.0'
+    ModuleVersion     = '1.3.1'
 
     # ID used to uniquely identify this module
     GUID              = 'f755f41b-d5fc-48db-8b11-62b7ed71b1cd'
@@ -85,10 +85,10 @@
             # Release notes for this module
             ReleaseNotes = @'
 
-## v1.3.0
+## v1.3.1
 
-- **Dynamic Groups:** Added Microsoft Entra joined, hybrid joined, and registered Windows device groups.
-- **Device Filters:** Added Windows assignment filters for Microsoft Entra joined, hybrid joined, registered, and unknown join types.
+- **WinGet detection:** Prevented bootstrap log messages from corrupting the WinGet executable path.
+- **OIB Settings Catalog:** Added a guarded assignment script that targets managed policies, preserves direct assignments, and fails closed on filtered or policy-set-owned targets.
 
 '@
         }

--- a/Private/WinGet/Get-WinGetDetectionScriptContent.ps1
+++ b/Private/WinGet/Get-WinGetDetectionScriptContent.ps1
@@ -35,7 +35,7 @@ function Write-WinGetDetectionLog {
         [string]`$Level = 'INFO'
     )
 
-    Write-Output "[`$Level] `$Message"
+    Write-Verbose "[`$Level] `$Message"
 }
 
 $bootstrapFragment

--- a/Templates/MobileApps/Windows/WinGet/Apps/pstools.json
+++ b/Templates/MobileApps/Windows/WinGet/Apps/pstools.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "../Schemas/winGetAppTemplate.schema.json",
+    "schemaVersion": "1.0.0",
+    "templateId": "pstools",
+    "packageIdentifier": "Microsoft.Sysinternals.PsTools",
+    "displayName": "PsTools Suite",
+    "publisher": "Sysinternals",
+    "description": "WinGet template for the Sysinternals PsTools command-line suite.",
+    "package": {
+        "source": "WinGet",
+        "match": {
+            "packageIdentifier": "Microsoft.Sysinternals.PsTools",
+            "architectures": [
+                "x64",
+                "x86"
+            ],
+            "installerTypes": [
+                "zip",
+                "portable"
+            ],
+            "scope": "machine",
+            "locale": "en-US",
+            "channel": null
+        }
+    },
+    "install": {
+        "command": "winget install --id Microsoft.Sysinternals.PsTools --exact --silent --scope machine --accept-package-agreements --accept-source-agreements",
+        "experience": "system",
+        "restartBehavior": "suppress"
+    },
+    "uninstall": {
+        "command": "winget uninstall --id Microsoft.Sysinternals.PsTools --exact --scope machine --silent",
+        "behavior": "allow"
+    },
+    "detection": {
+        "strategy": "generated"
+    },
+    "requirements": {
+        "minimumSupportedWindowsRelease": "W10_22H2",
+        "architectures": [
+            "x64",
+            "x86"
+        ],
+        "minimumFreeDiskSpaceInMB": null,
+        "minimumMemoryInMB": null
+    },
+    "icon": {
+        "sourceType": "file",
+        "fileName": "../../../../../media/IHTLogoClearLight.png",
+        "notes": "Uses the bundled Intune Hydration Kit icon."
+    },
+    "metadata": {
+        "categories": [
+            "StarterPack",
+            "Utilities",
+            "Administration"
+        ],
+        "tags": [
+            "starter-pack",
+            "sysinternals",
+            "pstools",
+            "administration",
+            "command-line"
+        ],
+        "notes": [],
+        "placeholders": {
+            "customNotes": [],
+            "owner": "",
+            "scopeTagIds": []
+        },
+        "markers": {
+            "hydration": "Imported by Intune Hydration Kit",
+            "source": "Imported from WinGet"
+        }
+    },
+    "resolvedPackage": {
+        "packageVersion": "latest",
+        "manifestSource": {
+            "repository": "microsoft/winget-pkgs",
+            "ref": "master",
+            "packagePath": "manifests/m/Microsoft/Sysinternals/PsTools",
+            "versionPath": "manifests/m/Microsoft/Sysinternals/PsTools",
+            "installerFile": null,
+            "localeFile": null
+        },
+        "selectedInstaller": {
+            "Architecture": "x64",
+            "Scope": "machine",
+            "InstallerLocale": "en-US",
+            "InstallerType": "portable",
+            "InstallerUrl": null,
+            "InstallerSha256": null,
+            "ProductCode": null,
+            "PackageFamilyName": null,
+            "NestedInstallerType": "portable",
+            "AppsAndFeaturesEntry": []
+        }
+    }
+}

--- a/Tests/Private/Get-WinGetDetectionScriptContent.Tests.ps1
+++ b/Tests/Private/Get-WinGetDetectionScriptContent.Tests.ps1
@@ -17,7 +17,6 @@ Describe 'Get-WinGetDetectionScriptContent' {
         $scriptContent | Should -Match 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\*'
         $scriptContent | Should -Match 'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\*'
         $scriptContent | Should -Match 'Test-InstalledApplicationRegistry'
-        $scriptContent | Should -Match ([regex]::Escape('Write-Output "[$Level] $Message"'))
         $scriptContent | Should -Match ([regex]::Escape('Write-Output "$PackageIdentifier is installed"'))
         $scriptContent | Should -Match ([regex]::Escape('Write-Output "$PackageIdentifier is not installed"'))
         $scriptContent | Should -Not -Match 'Write-Host'
@@ -25,5 +24,17 @@ Describe 'Get-WinGetDetectionScriptContent' {
         $parseErrors = $null
         $null = [System.Management.Automation.Language.Parser]::ParseInput($scriptContent, [ref]$null, [ref]$parseErrors)
         $parseErrors | Should -BeNullOrEmpty
+    }
+
+    It 'Should keep bootstrap log messages out of the success stream' {
+        $scriptContent = Get-WinGetDetectionScriptContent -PackageIdentifier 'Contoso.App'
+        $loggerDefinition = [regex]::Match($scriptContent, '(?ms)^function Write-WinGetDetectionLog \{.*?^\}')
+
+        $loggerDefinition.Success | Should -BeTrue
+        . ([scriptblock]::Create($loggerDefinition.Value))
+
+        $successOutput = @(Write-WinGetDetectionLog -Message 'Bootstrapping WinGet for detection.')
+
+        $successOutput | Should -BeNullOrEmpty
     }
 }

--- a/Tests/Private/TemplateContracts.Tests.ps1
+++ b/Tests/Private/TemplateContracts.Tests.ps1
@@ -339,7 +339,7 @@ Describe 'Bundled template contracts' {
     }
 
     It 'Should keep bundled WinGet app templates internally consistent' {
-        $script:WinGetAppTemplates.Count | Should -Be 28
+        $script:WinGetAppTemplates.Count | Should -Be 29
 
         $templateIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         foreach ($templateFile in $script:WinGetAppTemplates) {

--- a/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
+++ b/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
@@ -72,6 +72,11 @@ Describe 'Set-WindowsOIBSettingsCatalogAssignments' {
     }
 
     Context 'Set-OIBSettingsCatalogAssignment' {
+        It 'Should distinguish WhatIf from an interactive cancellation' {
+            Get-OIBAssignmentSkipStatus -WasWhatIf $true | Should -Be 'WhatIf'
+            Get-OIBAssignmentSkipStatus -WasWhatIf $false | Should -Be 'Cancelled'
+        }
+
         It 'Should skip an existing unfiltered intended target' {
             Mock Invoke-MgGraphRequest {
                 param($Method, $Uri, $Body, $ContentType)

--- a/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
+++ b/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
@@ -1,0 +1,168 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    . $PSScriptRoot/../../scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
+}
+
+Describe 'Set-WindowsOIBSettingsCatalogAssignments' {
+    Context 'Get-WindowsOIBSettingsCatalogPolicy' {
+        BeforeEach {
+            Mock Invoke-MgGraphRequest {
+                @{
+                    value = @(
+                        [PSCustomObject]@{ id = 'managed'; platforms = 'windows10'; name = '[IHD] Win - OIB - SC - Managed - D - Policy' }
+                        [PSCustomObject]@{ id = 'unmanaged'; platforms = 'windows10'; name = 'Win - OIB - SC - Unmanaged - U - Policy' }
+                        [PSCustomObject]@{ id = 'non-oib'; platforms = 'windows10'; name = '[IHD] Other Windows Policy' }
+                    )
+                }
+            }
+        }
+
+        It 'Should select only managed OIB policies by default' {
+            $result = Get-WindowsOIBSettingsCatalogPolicy
+
+            $result.id | Should -Be 'managed'
+        }
+
+        It 'Should allow an explicitly selected unmanaged OIB policy' {
+            $result = Get-WindowsOIBSettingsCatalogPolicy -PolicyId 'unmanaged'
+
+            $result.id | Should -Be 'unmanaged'
+        }
+
+        It 'Should allow all unmanaged OIB policies only with explicit opt-in' {
+            $result = Get-WindowsOIBSettingsCatalogPolicy -IncludeUnmanaged
+
+            $result.id | Should -Be @('managed', 'unmanaged')
+        }
+
+        It 'Should resolve one anchored scope marker for managed and unmanaged OIB names' {
+            Get-OIBPolicyScope -PolicyName '[IHD] Win - OIB - SC - Test - U - Policy' | Should -Be 'U'
+            Get-OIBPolicyScope -PolicyName 'Win - OIB - SC - Test - D - Policy' | Should -Be 'D'
+            Get-OIBPolicyScope -PolicyName '[IHD] Other Windows Policy' | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Set-OIBSettingsCatalogAssignment' {
+        It 'Should skip an existing unfiltered intended target' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body, $ContentType)
+                $null = $Method, $Uri, $Body, $ContentType
+            }
+            Mock Get-ConfigurationPolicyAssignment {
+                @([PSCustomObject]@{
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        }
+                    })
+            }
+
+            $result = Set-OIBSettingsCatalogAssignment -PolicyId 'policy-id' -PolicyName '[IHD] Win - OIB - SC - Test - U - Policy' -Confirm:$false
+
+            $result.Status | Should -Be 'Skipped'
+            Should -Invoke Invoke-MgGraphRequest -Exactly 0
+        }
+
+        It 'Should fail rather than treat a filtered target as an unfiltered target' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body, $ContentType)
+                $null = $Method, $Uri, $Body, $ContentType
+            }
+            Mock Get-ConfigurationPolicyAssignment {
+                @([PSCustomObject]@{
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget'
+                            deviceAndAppManagementAssignmentFilterType = 'include'
+                            deviceAndAppManagementAssignmentFilterId = 'filter-id'
+                        }
+                    })
+            }
+
+            {
+                Set-OIBSettingsCatalogAssignment -PolicyId 'policy-id' -PolicyName '[IHD] Win - OIB - SC - Test - U - Policy' -Confirm:$false
+            } | Should -Throw '*filtered All Users assignment*'
+            Should -Invoke Invoke-MgGraphRequest -Exactly 0
+        }
+
+        It 'Should fail rather than replay a policy-set-owned assignment as direct' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body, $ContentType)
+                $null = $Method, $Uri, $Body, $ContentType
+            }
+            Mock Get-ConfigurationPolicyAssignment {
+                @([PSCustomObject]@{
+                        source = 'policySets'
+                        sourceId = 'policy-set-id'
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                            groupId = 'existing-group'
+                        }
+                    })
+            }
+
+            {
+                Set-OIBSettingsCatalogAssignment -PolicyId 'policy-id' -PolicyName '[IHD] Win - OIB - SC - Test - D - Policy' -Confirm:$false
+            } | Should -Throw '*owned by a policy set*'
+            Should -Invoke Invoke-MgGraphRequest -Exactly 0
+        }
+
+        It 'Should not write assignments in WhatIf mode' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body, $ContentType)
+                $null = $Method, $Uri, $Body, $ContentType
+            }
+            Mock Get-ConfigurationPolicyAssignment { @() }
+
+            $result = Set-OIBSettingsCatalogAssignment -PolicyId 'policy-id' -PolicyName '[IHD] Win - OIB - SC - Test - D - Policy' -WhatIf
+
+            $result.Status | Should -Be 'WhatIf'
+            Should -Invoke Invoke-MgGraphRequest -Exactly 0
+        }
+
+        It 'Should preserve assignments, add the target, and verify the result' {
+            $script:assignmentReadCount = 0
+            Mock Get-ConfigurationPolicyAssignment {
+                $script:assignmentReadCount++
+                if ($script:assignmentReadCount -eq 1) {
+                    return @([PSCustomObject]@{
+                            target = [PSCustomObject]@{
+                                '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                                groupId = 'existing-group'
+                            }
+                        })
+                }
+
+                return @(
+                    [PSCustomObject]@{
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                            groupId = 'existing-group'
+                        }
+                    }
+                    [PSCustomObject]@{
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        }
+                    }
+                )
+            }
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body, $ContentType)
+                $null = $Method, $Uri, $Body, $ContentType
+            }
+
+            $result = Set-OIBSettingsCatalogAssignment -PolicyId 'policy-id' -PolicyName '[IHD] Win - OIB - SC - Test - D - Policy' -Confirm:$false
+
+            $result.Status | Should -Be 'Assigned'
+            Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+                $Method -eq 'POST' -and
+                $Uri -eq 'beta/deviceManagement/configurationPolicies/policy-id/assign' -and
+                $Body -match 'existing-group' -and
+                $Body -match 'allDevicesAssignmentTarget' -and
+                $Body -match '"source"\s*:\s*"direct"'
+            }
+        }
+    }
+}

--- a/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
+++ b/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
@@ -5,6 +5,34 @@ BeforeAll {
 }
 
 Describe 'Set-WindowsOIBSettingsCatalogAssignments' {
+    Context 'Connect-AssignmentGraph' {
+        It 'Should connect using the requested configuration policy scope' {
+            Mock Get-MgContext { $null }
+            Mock Connect-MgGraph {}
+
+            Connect-AssignmentGraph -RequiredScope 'DeviceManagementConfiguration.ReadWrite.All'
+
+            Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+                $Scopes -eq 'DeviceManagementConfiguration.ReadWrite.All' -and $NoWelcome
+            }
+        }
+
+        It 'Should reconnect when the requested scope is missing' {
+            Mock Get-MgContext {
+                [PSCustomObject]@{ Scopes = @('DeviceManagementApps.ReadWrite.All') }
+            }
+            Mock Disconnect-MgGraph {}
+            Mock Connect-MgGraph {}
+
+            Connect-AssignmentGraph -RequiredScope 'DeviceManagementConfiguration.ReadWrite.All'
+
+            Should -Invoke Disconnect-MgGraph -Exactly 1
+            Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+                $Scopes -eq 'DeviceManagementConfiguration.ReadWrite.All' -and $NoWelcome
+            }
+        }
+    }
+
     Context 'Get-WindowsOIBSettingsCatalogPolicy' {
         BeforeEach {
             Mock Invoke-MgGraphRequest {

--- a/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
+++ b/Tests/Scripts/Set-WindowsOIBSettingsCatalogAssignments.Tests.ps1
@@ -135,6 +135,28 @@ Describe 'Set-WindowsOIBSettingsCatalogAssignments' {
             Should -Invoke Invoke-MgGraphRequest -Exactly 0
         }
 
+        It 'Should fail when an existing intended target is owned by a policy set' {
+            Mock Invoke-MgGraphRequest {
+                param($Method, $Uri, $Body, $ContentType)
+                $null = $Method, $Uri, $Body, $ContentType
+            }
+            Mock Get-ConfigurationPolicyAssignment {
+                @([PSCustomObject]@{
+                        source = 'policySets'
+                        sourceId = 'policy-set-id'
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        }
+                    })
+            }
+
+            {
+                Set-OIBSettingsCatalogAssignment -PolicyId 'policy-id' -PolicyName '[IHD] Win - OIB - SC - Test - U - Policy' -Confirm:$false
+            } | Should -Throw '*owned by a policy set*'
+            Should -Invoke Invoke-MgGraphRequest -Exactly 0
+        }
+
         It 'Should not write assignments in WhatIf mode' {
             Mock Invoke-MgGraphRequest {
                 param($Method, $Uri, $Body, $ContentType)

--- a/scripts/AssignmentHelpers.ps1
+++ b/scripts/AssignmentHelpers.ps1
@@ -19,13 +19,13 @@ function Connect-AssignmentGraph {
 
     $context = Get-MgContext
     if (-not $context) {
-        Connect-MgGraph -Scopes $requiredScope -NoWelcome | Out-Null
+        Connect-MgGraph -Scopes $RequiredScope -NoWelcome | Out-Null
         return
     }
 
-    if ($context.Scopes -notcontains $requiredScope) {
+    if ($context.Scopes -notcontains $RequiredScope) {
         Disconnect-MgGraph | Out-Null
-        Connect-MgGraph -Scopes $requiredScope -NoWelcome | Out-Null
+        Connect-MgGraph -Scopes $RequiredScope -NoWelcome | Out-Null
     }
 }
 

--- a/scripts/AssignmentHelpers.ps1
+++ b/scripts/AssignmentHelpers.ps1
@@ -11,9 +11,12 @@
 
 function Connect-AssignmentGraph {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$RequiredScope = 'DeviceManagementApps.ReadWrite.All'
+    )
 
-    $requiredScope = 'DeviceManagementApps.ReadWrite.All'
     $context = Get-MgContext
     if (-not $context) {
         Connect-MgGraph -Scopes $requiredScope -NoWelcome | Out-Null

--- a/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
+++ b/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
@@ -176,6 +176,20 @@ function Test-UnfilteredConfigurationPolicyAssignmentTarget {
     return ([string]::IsNullOrWhiteSpace($filterType) -or $filterType -eq 'none') -and [string]::IsNullOrWhiteSpace($filterId)
 }
 
+function Get-OIBAssignmentSkipStatus {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [bool]$WasWhatIf = $WhatIfPreference
+    )
+
+    if ($WasWhatIf) {
+        return 'WhatIf'
+    }
+
+    return 'Cancelled'
+}
+
 function Set-OIBSettingsCatalogAssignment {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -217,11 +231,10 @@ function Set-OIBSettingsCatalogAssignment {
     }
 
     if (-not $PSCmdlet.ShouldProcess($PolicyName, "Assign to $targetName")) {
-        $status = if ($WhatIfPreference) { 'WhatIf' } else { 'Cancelled' }
         return [PSCustomObject]@{
             Name   = $PolicyName
             Target = $targetName
-            Status = $status
+            Status = Get-OIBAssignmentSkipStatus
             Reason = $null
         }
     }

--- a/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
+++ b/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
@@ -1,0 +1,295 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Assigns managed Windows OIB Settings Catalog policies to their intended built-in target.
+
+.DESCRIPTION
+    Finds Intune Hydration Kit-managed Windows Settings Catalog policies whose OIB names include a scope marker.
+    Policies named `- U -` are assigned to All Users and policies named `- D -` are
+    assigned to All Devices. Existing assignments are preserved in the assign action.
+    A filtered target is treated as a conflict instead of an equivalent built-in target.
+
+.EXAMPLE
+    ./scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1 -WhatIf
+
+.EXAMPLE
+    ./scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
+
+.EXAMPLE
+    ./scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1 -PolicyId 'policy-id'
+
+.EXAMPLE
+    ./scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1 -IncludeUnmanaged
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string[]]$PolicyId,
+
+    [Parameter()]
+    [switch]$IncludeUnmanaged
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'AssignmentHelpers.ps1')
+
+function Get-WindowsOIBSettingsCatalogPolicy {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]$PolicyId,
+
+        [Parameter()]
+        [switch]$IncludeUnmanaged
+    )
+
+    $policies = [System.Collections.Generic.List[object]]::new()
+    $uri = 'beta/deviceManagement/configurationPolicies?$select=id,name,platforms'
+
+    do {
+        $response = Invoke-MgGraphRequest -Method GET -Uri $uri -ErrorAction Stop
+        foreach ($policy in @($response.value)) {
+            $name = [string]$policy.name
+            $isExplicitPolicy = $policy.id -in $PolicyId
+            $isRequestedPolicy = $PolicyId.Count -eq 0 -or $isExplicitPolicy
+            $scope = Get-OIBPolicyScope -PolicyName $name
+            $isManagedPolicy = $name -match '^\[IHD\]\s*'
+            if ($policy.platforms -eq 'windows10' -and $isRequestedPolicy -and $scope -and ($isManagedPolicy -or $IncludeUnmanaged -or $isExplicitPolicy)) {
+                $policies.Add($policy)
+            }
+        }
+
+        $uri = $response.'@odata.nextLink'
+    } while ($uri)
+
+    return @($policies)
+}
+
+function Get-ConfigurationPolicyAssignment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PolicyId
+    )
+
+    $assignments = [System.Collections.Generic.List[object]]::new()
+    $uri = "beta/deviceManagement/configurationPolicies/$PolicyId/assignments"
+
+    do {
+        $response = Invoke-MgGraphRequest -Method GET -Uri $uri -ErrorAction Stop
+        foreach ($assignment in @($response.value)) {
+            $assignments.Add($assignment)
+        }
+
+        $uri = $response.'@odata.nextLink'
+    } while ($uri)
+
+    return @($assignments)
+}
+
+function Get-OIBPolicyScope {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PolicyName
+    )
+
+    $match = [regex]::Match($PolicyName, '^(?:\[IHD\]\s*)?Win - OIB - .+ - (?<Scope>[UD]) - ')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return $match.Groups['Scope'].Value
+}
+
+function Get-OIBAssignmentTargetType {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PolicyName
+    )
+
+    switch (Get-OIBPolicyScope -PolicyName $PolicyName) {
+        'U' {
+            return '#microsoft.graph.allLicensedUsersAssignmentTarget'
+        }
+        'D' {
+            return '#microsoft.graph.allDevicesAssignmentTarget'
+        }
+        default {
+            throw "Policy '$PolicyName' does not contain an OIB user or device scope marker."
+        }
+    }
+}
+
+function Test-DirectConfigurationPolicyAssignment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Assignment
+    )
+
+    $source = [string]$Assignment.source
+    $sourceId = [string]$Assignment.sourceId
+    return ([string]::IsNullOrWhiteSpace($source) -or $source -eq 'direct') -and [string]::IsNullOrWhiteSpace($sourceId)
+}
+
+function ConvertTo-ConfigurationPolicyAssignmentPayload {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [object]$Assignment
+    )
+
+    process {
+        return @{
+            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationPolicyAssignment'
+            source        = 'direct'
+            target        = ConvertTo-PlainValue -InputObject $Assignment.target
+        }
+    }
+}
+
+function Test-UnfilteredConfigurationPolicyAssignmentTarget {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Assignment,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TargetType
+    )
+
+    $target = $Assignment.target
+    if ($target.'@odata.type' -ne $TargetType) {
+        return $false
+    }
+
+    $filterType = [string]$target.deviceAndAppManagementAssignmentFilterType
+    $filterId = [string]$target.deviceAndAppManagementAssignmentFilterId
+    return ([string]::IsNullOrWhiteSpace($filterType) -or $filterType -eq 'none') -and [string]::IsNullOrWhiteSpace($filterId)
+}
+
+function Set-OIBSettingsCatalogAssignment {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PolicyId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PolicyName
+    )
+
+    $targetType = Get-OIBAssignmentTargetType -PolicyName $PolicyName
+    $targetName = if ($targetType -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
+        'All Users'
+    } else {
+        'All Devices'
+    }
+
+    $existingAssignments = Get-ConfigurationPolicyAssignment -PolicyId $PolicyId
+    $matchingTargets = @($existingAssignments | Where-Object { $_.target.'@odata.type' -eq $targetType })
+    $unfilteredTarget = @($matchingTargets | Where-Object { Test-UnfilteredConfigurationPolicyAssignmentTarget -Assignment $_ -TargetType $targetType })
+    if ($unfilteredTarget.Count -gt 0) {
+        return [PSCustomObject]@{
+            Name   = $PolicyName
+            Target = $targetName
+            Status = 'Skipped'
+            Reason = "Already assigned to $targetName"
+        }
+    }
+
+    if ($matchingTargets.Count -gt 0) {
+        throw "Policy '$PolicyName' has a filtered $targetName assignment. Refusing to add an unfiltered target."
+    }
+
+    $indirectAssignments = @($existingAssignments | Where-Object { -not (Test-DirectConfigurationPolicyAssignment -Assignment $_) })
+    if ($indirectAssignments.Count -gt 0) {
+        throw "Policy '$PolicyName' has an assignment owned by a policy set. Refusing to replay it as a direct assignment."
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($PolicyName, "Assign to $targetName")) {
+        return [PSCustomObject]@{
+            Name   = $PolicyName
+            Target = $targetName
+            Status = 'WhatIf'
+            Reason = $null
+        }
+    }
+
+    $assignmentPayload = [System.Collections.Generic.List[object]]::new()
+    foreach ($assignment in $existingAssignments) {
+        $assignmentPayload.Add((ConvertTo-ConfigurationPolicyAssignmentPayload -Assignment $assignment))
+    }
+
+    $assignmentPayload.Add(@{
+            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationPolicyAssignment'
+            source        = 'direct'
+            target        = @{
+                '@odata.type' = $targetType
+            }
+        })
+
+    $bodyJson = @{
+        assignments = @($assignmentPayload)
+    } | ConvertTo-Json -Depth 10
+
+    Invoke-MgGraphRequest -Method POST -Uri "beta/deviceManagement/configurationPolicies/$PolicyId/assign" -Body $bodyJson -ContentType 'application/json' -ErrorAction Stop | Out-Null
+
+    $verifiedAssignments = Get-ConfigurationPolicyAssignment -PolicyId $PolicyId
+    $verifiedTarget = @($verifiedAssignments | Where-Object { Test-UnfilteredConfigurationPolicyAssignmentTarget -Assignment $_ -TargetType $targetType })
+    if ($verifiedTarget.Count -eq 0) {
+        throw "Policy '$PolicyName' did not retain the requested unfiltered $targetName assignment."
+    }
+
+    return [PSCustomObject]@{
+        Name   = $PolicyName
+        Target = $targetName
+        Status = 'Assigned'
+        Reason = $null
+    }
+}
+
+function Invoke-OIBSettingsCatalogAssignment {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter()]
+        [string[]]$PolicyId,
+
+        [Parameter()]
+        [switch]$IncludeUnmanaged
+    )
+
+    Connect-AssignmentGraph -RequiredScope 'DeviceManagementConfiguration.ReadWrite.All'
+
+    $policies = Get-WindowsOIBSettingsCatalogPolicy -PolicyId $PolicyId -IncludeUnmanaged:$IncludeUnmanaged
+    if ($policies.Count -eq 0) {
+        Write-Warning 'No matching Windows OIB Settings Catalog policies were found.'
+        return
+    }
+
+    foreach ($policy in $policies) {
+        try {
+            Set-OIBSettingsCatalogAssignment -PolicyId $policy.id -PolicyName $policy.name -WhatIf:$WhatIfPreference
+        } catch {
+            [PSCustomObject]@{
+                Name   = [string]$policy.name
+                Target = $null
+                Status = 'Failed'
+                Reason = $_.Exception.Message
+            }
+        }
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-OIBSettingsCatalogAssignment -PolicyId $PolicyId -IncludeUnmanaged:$IncludeUnmanaged -WhatIf:$WhatIfPreference
+}

--- a/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
+++ b/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
@@ -196,6 +196,11 @@ function Set-OIBSettingsCatalogAssignment {
     }
 
     $existingAssignments = Get-ConfigurationPolicyAssignment -PolicyId $PolicyId
+    $indirectAssignments = @($existingAssignments | Where-Object { -not (Test-DirectConfigurationPolicyAssignment -Assignment $_) })
+    if ($indirectAssignments.Count -gt 0) {
+        throw "Policy '$PolicyName' has an assignment owned by a policy set. Refusing to replay it as a direct assignment."
+    }
+
     $matchingTargets = @($existingAssignments | Where-Object { $_.target.'@odata.type' -eq $targetType })
     $unfilteredTarget = @($matchingTargets | Where-Object { Test-UnfilteredConfigurationPolicyAssignmentTarget -Assignment $_ -TargetType $targetType })
     if ($unfilteredTarget.Count -gt 0) {
@@ -209,11 +214,6 @@ function Set-OIBSettingsCatalogAssignment {
 
     if ($matchingTargets.Count -gt 0) {
         throw "Policy '$PolicyName' has a filtered $targetName assignment. Refusing to add an unfiltered target."
-    }
-
-    $indirectAssignments = @($existingAssignments | Where-Object { -not (Test-DirectConfigurationPolicyAssignment -Assignment $_) })
-    if ($indirectAssignments.Count -gt 0) {
-        throw "Policy '$PolicyName' has an assignment owned by a policy set. Refusing to replay it as a direct assignment."
     }
 
     if (-not $PSCmdlet.ShouldProcess($PolicyName, "Assign to $targetName")) {

--- a/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
+++ b/scripts/Set-WindowsOIBSettingsCatalogAssignments.ps1
@@ -217,10 +217,11 @@ function Set-OIBSettingsCatalogAssignment {
     }
 
     if (-not $PSCmdlet.ShouldProcess($PolicyName, "Assign to $targetName")) {
+        $status = if ($WhatIfPreference) { 'WhatIf' } else { 'Cancelled' }
         return [PSCustomObject]@{
             Name   = $PolicyName
             Target = $targetName
-            Status = 'WhatIf'
+            Status = $status
             Reason = $null
         }
     }


### PR DESCRIPTION
## Summary

- add guarded OIB Settings Catalog assignment automation for managed policies
- fail closed on filtered and policy-set-owned targets
- keep WinGet bootstrap logs out of executable-path output
- rev the module to v1.3.1

## Root cause

WinGet detection emitted bootstrap logs through the success stream, and Settings Catalog assignment automation needed explicit ownership and target-scope boundaries before replaying assignments.

## Validation

- `./build.ps1 -Task CI`
- 1,096 Pester tests passed; 0 failed
- PSScriptAnalyzer: 0 errors (existing repository warnings remain)
- built module validated at v1.3.1